### PR TITLE
🔥 Fastify関連の記載を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ## 技術スタック
 
 - **フロントエンド**: Next.js, React
-- **バックエンド**: Hono, Fastify
+- **バックエンド**: Hono
 - **データベース**: PostgreSQL, Prisma
 - **認証**: Firebase Authentication
 - **モノレポ**: Turborepo

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,13 +18,11 @@
     "hono": "catalog:",
     "@hono/node-server": "catalog:",
     "@hono/zod-validator": "catalog:",
-    "@fastify/cors": "catalog:",
     "@packages/database": "workspace:*",
     "@packages/shared-types": "workspace:*",
     "@packages/shared-utils": "workspace:*",
     "@packages/firebase-auth-server": "workspace:*",
     "dotenv": "catalog:",
-    "fastify": "catalog:",
     "firebase": "catalog:",
     "firebase-admin": "catalog:",
     "zod": "catalog:"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,8 +12,6 @@ catalog:
 
   hono: 4.10.3
   '@hono/node-server': 1.19.5
-  fastify: 5.6.2
-  '@fastify/cors': 11.1.0
   firebase: 12.6.0
   'firebase-admin': 13.6.0
   next: 16.0.1


### PR DESCRIPTION
## 概要

現在の実装ではHonoを使用しているため、未使用のFastify依存関係を削除しました。

## 変更内容

- `pnpm-workspace.yaml` からFastifyカタログ定義を削除
  - `fastify: 5.6.2`
  - `'@fastify/cors': 11.1.0`
- `apps/api/package.json` からFastify依存関係を削除
  - `"@fastify/cors": "catalog:"`
  - `"fastify": "catalog:"`
- `README.md` の技術スタックからFastifyを削除
  - バックエンド: `Hono, Fastify` → `Hono`

## 背景

プロジェクトではバックエンドフレームワークとしてHonoを採用していますが、依存関係にはFastifyが残っていました。実際には使用されていないため、混乱を避けるために削除しました。

## テスト計画

- [x] `pnpm install` が正常に実行できることを確認
- [x] 既存のテストが通ることを確認
- [x] APIサーバーが正常に起動することを確認
