### PR TITLE
Implement GET /api/v1/user-bike/bikes

### DIFF
--- a/apps/api/src/lib/interfaces/IMyUserBikeRepository.ts
+++ b/apps/api/src/lib/interfaces/IMyUserBikeRepository.ts
@@ -1,5 +1,27 @@
+import {
+  BikeId,
+  MyUserBikeId,
+  UserBikeId,
+  UserId,
+} from '@shared-types/index'
 import { MyUserBikeEntity } from '../classes/entities/MyUserBikeEntity'
+
+export type MyUserBikeDetail = {
+  userBikeId: UserBikeId
+  myUserBikeId: MyUserBikeId
+  bikeId: BikeId
+  manufacturerName: string
+  modelName: string
+  nickname: string | null
+  purchaseDate: Date | null
+  totalMileage: number
+  displacement: number
+  modelYear: number
+  createdAt: Date
+  updatedAt: Date
+}
 
 export interface IMyUserBikeRepository {
   createMyUserBike(myUserBike: MyUserBikeEntity): Promise<MyUserBikeEntity>
+  findMyUserBikes(userId: UserId): Promise<MyUserBikeDetail[]>
 }

--- a/packages/shared-types/src/common/ApiIO.ts
+++ b/packages/shared-types/src/common/ApiIO.ts
@@ -69,3 +69,20 @@ export type ApiResponseUserBikeRegister = {
   userBikeId: string
   myUserBikeId: string
 }
+
+export type ApiResponseUserBikeList = {
+  bikes: {
+    userBikeId: string
+    myUserBikeId: string
+    manufacturerName: string
+    bikeId: string
+    modelName: string
+    nickname: string | null
+    purchaseDate: string | null
+    totalMileage: number
+    displacement: number
+    modelYear: number
+    createdAt: string
+    updatedAt: string
+  }[]
+}


### PR DESCRIPTION
## Summary
- add response typing and repository support for user bike listings
- implement GET /api/v1/user-bike/bikes endpoint with formatted payload
- extend user bike API tests to cover listing flow

## Testing
- pnpm --filter @apps/api test *(fails: prisma client generation requires ESM-compatible environment; see logs for ERR_REQUIRE_ESM during prisma generate)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933b663ff688330a59af5c16ddf781d)