### PR TITLE
Add user bike detail and update endpoints

### DIFF
--- a/apps/api/src/__tests__/api/v1/userBike.test.ts
+++ b/apps/api/src/__tests__/api/v1/userBike.test.ts
@@ -12,6 +12,7 @@ describe('UserBike API Endpoints', () => {
   let createdSerialNumber: string
   let createdUserBikeId: string
   let createdMyUserBikeId: string
+  const updatedNickname = 'アップデート後のバイク'
 
   beforeAll(async () => {
     const email = createRandomEmail()
@@ -246,6 +247,143 @@ describe('UserBike API Endpoints', () => {
           expect(typeof bike.updatedAt).toBe('string')
         }
       )
+    })
+  })
+
+  describe('GET /api/v1/user-bike/bike/:myUserBikeId', () => {
+    test('Authorizationヘッダーが未指定の場合にエラーとなる', async () => {
+      const res = await app.request(`/api/v1/user-bike/bike/${createdMyUserBikeId}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const json = await res.json()
+      expect(res.status).toBe(401)
+      expect(json).toEqual({
+        status: 'error',
+        errorCode: 'AUTH_FAILED',
+        message: expect.any(String),
+      })
+    })
+
+    test('ユーザー所有バイクの詳細を取得できる', async () => {
+      const res = await app.request(`/api/v1/user-bike/bike/${createdMyUserBikeId}`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const json = await res.json()
+      expect(res.status).toBe(200)
+      expect(json.status).toBe('success')
+      expect(json.message).toBe('ユーザー所有バイク詳細取得成功')
+      expect(json.data.userBikeId).toBe(createdUserBikeId)
+      expect(json.data.myUserBikeId).toBe(createdMyUserBikeId)
+      expect(json.data.nickname).toBe('メインバイク')
+      expect(json.data.purchaseDate).toBe('2024-01-01T00:00:00.000Z')
+      expect(json.data.totalMileage).toBe(1500)
+      expect(json.data.purchasePrice).toBe(500000)
+      expect(json.data.purchaseMileage).toBe(1200)
+    })
+  })
+
+  describe('PATCH /api/v1/user-bike/bike/:myUserBikeId', () => {
+    test('Authorizationヘッダーが未指定の場合にエラーとなる', async () => {
+      const res = await app.request(`/api/v1/user-bike/bike/${createdMyUserBikeId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          nickname: updatedNickname,
+        }),
+      })
+
+      const json = await res.json()
+      expect(res.status).toBe(401)
+      expect(json).toEqual({
+        status: 'error',
+        errorCode: 'AUTH_FAILED',
+        message: expect.any(String),
+      })
+    })
+
+    test('不正な入力の場合はバリデーションエラーとなる', async () => {
+      const res = await app.request(`/api/v1/user-bike/bike/${createdMyUserBikeId}`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          totalMileage: -100,
+        }),
+      })
+
+      const json = await res.json()
+      expect(res.status).toBe(400)
+      expect(json.status).toBe('error')
+      expect(json.errorCode).toBe('VALIDATION_ERROR')
+      expect(Array.isArray(json.details)).toBe(true)
+    })
+
+    test('存在しないバイクIDの場合は404となる', async () => {
+      const res = await app.request(`/api/v1/user-bike/bike/${randomUUID()}`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          nickname: updatedNickname,
+        }),
+      })
+
+      const json = await res.json()
+      expect(res.status).toBe(404)
+      expect(json.status).toBe('error')
+      expect(json.errorCode).toBe('NOT_FOUND')
+    })
+
+    test('ユーザー所有バイクの情報を更新できる', async () => {
+      const purchaseDate = '2024-02-02T00:00:00.000Z'
+      const res = await app.request(`/api/v1/user-bike/bike/${createdMyUserBikeId}`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          nickname: updatedNickname,
+          purchaseDate,
+          purchasePrice: 450000,
+          purchaseMileage: 1300,
+          totalMileage: 2100,
+        }),
+      })
+
+      const json = await res.json()
+      expect(res.status).toBe(200)
+      expect(json.status).toBe('success')
+      expect(json.data.nickname).toBe(updatedNickname)
+      expect(json.data.purchaseDate).toBe(purchaseDate)
+      expect(json.data.purchasePrice).toBe(450000)
+      expect(json.data.purchaseMileage).toBe(1300)
+      expect(json.data.totalMileage).toBe(2100)
+
+      const myUserBikeRecord = await prisma.tUserMyBike.findUnique({
+        where: { id: createdMyUserBikeId },
+      })
+
+      expect(myUserBikeRecord?.nickname).toBe(updatedNickname)
+      expect(myUserBikeRecord?.purchaseDate?.toISOString()).toBe(purchaseDate)
+      expect(myUserBikeRecord?.purchasePrice).toBe(450000)
+      expect(myUserBikeRecord?.purchaseMileage).toBe(1300)
+      expect(myUserBikeRecord?.totalMileage).toBe(2100)
     })
   })
 })

--- a/apps/api/src/api/v1/userBike.ts
+++ b/apps/api/src/api/v1/userBike.ts
@@ -3,10 +3,13 @@ import { prisma } from '@packages/database'
 import {
   ApiResponseUserBikeRegister,
   ApiResponseUserBikeList,
+  ApiResponseUserBikeDetail,
   createBikeId,
+  createMyUserBikeId,
   createUserId,
   SuccessResponse,
   UserBikeRegisterRequestSchema,
+  UserBikeUpdateRequestSchema,
 } from '@shared-types/index'
 import { PrismaBikeRepository } from '../../lib/classes/repositories/PrismaBikeRepository'
 import { PrismaMyUserBikeRepository } from '../../lib/classes/repositories/PrismaMyUserBikeRepository'
@@ -74,6 +77,8 @@ userBike.get('/bikes', honoAuthMiddleware, async (c) => {
         modelName: bike.modelName,
         nickname: bike.nickname,
         purchaseDate: bike.purchaseDate?.toISOString() ?? null,
+        purchasePrice: bike.purchasePrice,
+        purchaseMileage: bike.purchaseMileage,
         totalMileage: bike.totalMileage,
         displacement: bike.displacement,
         modelYear: bike.modelYear,
@@ -85,8 +90,86 @@ userBike.get('/bikes', honoAuthMiddleware, async (c) => {
   })
 })
 
-userBike.get('/bike/:userBikeId', honoAuthMiddleware, async (c) => {
-  return c.json({})
+userBike.get('/bike/:myUserBikeId', honoAuthMiddleware, async (c) => {
+  const { userId } = c.var.user!
+
+  const detail = await prisma.$transaction((t) => {
+    const userBikeRepo = new PrismaUserBikeRepository(t)
+    const myUserBikeRepo = new PrismaMyUserBikeRepository(t)
+    const bikeRepo = new PrismaBikeRepository(t)
+    const service = new UserBikeService(userBikeRepo, myUserBikeRepo, bikeRepo)
+
+    return service.getMyUserBikeDetail(c.req.param('myUserBikeId'), createUserId(userId))
+  })
+
+  return c.json<SuccessResponse<ApiResponseUserBikeDetail>>({
+    status: 'success',
+    data: {
+      userBikeId: detail.userBikeId,
+      myUserBikeId: detail.myUserBikeId,
+      manufacturerName: detail.manufacturerName,
+      bikeId: detail.bikeId,
+      modelName: detail.modelName,
+      nickname: detail.nickname,
+      purchaseDate: detail.purchaseDate?.toISOString() ?? null,
+      purchasePrice: detail.purchasePrice,
+      purchaseMileage: detail.purchaseMileage,
+      totalMileage: detail.totalMileage,
+      displacement: detail.displacement,
+      modelYear: detail.modelYear,
+      createdAt: detail.createdAt.toISOString(),
+      updatedAt: detail.updatedAt.toISOString(),
+    },
+    message: 'ユーザー所有バイク詳細取得成功',
+  })
 })
+
+userBike.patch(
+  '/bike/:myUserBikeId',
+  honoAuthMiddleware,
+  zodValidateJson(UserBikeUpdateRequestSchema),
+  async (c) => {
+    const { userId } = c.var.user!
+    const body = c.req.valid('json')
+
+    const detail = await prisma.$transaction((t) => {
+      const userBikeRepo = new PrismaUserBikeRepository(t)
+      const myUserBikeRepo = new PrismaMyUserBikeRepository(t)
+      const bikeRepo = new PrismaBikeRepository(t)
+      const service = new UserBikeService(userBikeRepo, myUserBikeRepo, bikeRepo)
+
+      return service.updateMyUserBike({
+        myUserBikeId: createMyUserBikeId(c.req.param('myUserBikeId')),
+        userId: createUserId(userId),
+        nickname: body.nickname,
+        purchaseDate: body.purchaseDate,
+        purchasePrice: body.purchasePrice,
+        purchaseMileage: body.purchaseMileage,
+        totalMileage: body.totalMileage,
+      })
+    })
+
+    return c.json<SuccessResponse<ApiResponseUserBikeDetail>>({
+      status: 'success',
+      data: {
+        userBikeId: detail.userBikeId,
+        myUserBikeId: detail.myUserBikeId,
+        manufacturerName: detail.manufacturerName,
+        bikeId: detail.bikeId,
+        modelName: detail.modelName,
+        nickname: detail.nickname,
+        purchaseDate: detail.purchaseDate?.toISOString() ?? null,
+        purchasePrice: detail.purchasePrice,
+        purchaseMileage: detail.purchaseMileage,
+        totalMileage: detail.totalMileage,
+        displacement: detail.displacement,
+        modelYear: detail.modelYear,
+        createdAt: detail.createdAt.toISOString(),
+        updatedAt: detail.updatedAt.toISOString(),
+      },
+      message: 'ユーザー所有バイク情報更新成功',
+    })
+  }
+)
 
 export default userBike

--- a/apps/api/src/lib/classes/entities/MyUserBikeEntity.ts
+++ b/apps/api/src/lib/classes/entities/MyUserBikeEntity.ts
@@ -14,6 +14,14 @@ export class MyUserBikeEntity {
       throw new Error('総走行距離は0以上である必要があります')
     }
 
+    if (myUserBike.purchaseMileage !== null && myUserBike.purchaseMileage < 0) {
+      throw new Error('購入時走行距離は0以上である必要があります')
+    }
+
+    if (myUserBike.purchasePrice !== null && myUserBike.purchasePrice < 0) {
+      throw new Error('購入価格は0以上である必要があります')
+    }
+
     this._value = myUserBike
   }
 

--- a/apps/api/src/lib/classes/repositories/PrismaMyUserBikeRepository.ts
+++ b/apps/api/src/lib/classes/repositories/PrismaMyUserBikeRepository.ts
@@ -93,11 +93,151 @@ export class PrismaMyUserBikeRepository
       modelName: myUserBike.userBike.bike.modelName,
       nickname: myUserBike.nickname,
       purchaseDate: myUserBike.purchaseDate,
+      purchasePrice: myUserBike.purchasePrice,
+      purchaseMileage: myUserBike.purchaseMileage,
       totalMileage: myUserBike.totalMileage,
       displacement: myUserBike.userBike.bike.displacement,
       modelYear: myUserBike.userBike.bike.modelYear,
       createdAt: myUserBike.createdAt,
       updatedAt: myUserBike.updatedAt,
     }))
+  }
+
+  async findMyUserBikeById(
+    myUserBikeId: MyUserBikeId,
+    userId: UserId
+  ): Promise<MyUserBikeEntity | null> {
+    const myUserBike = await this.connection.tUserMyBike.findFirst({
+      where: { id: myUserBikeId, userId, ownStatus: 'OWN' },
+      select: {
+        id: true,
+        userBikeId: true,
+        userId: true,
+        nickname: true,
+        purchaseDate: true,
+        purchasePrice: true,
+        purchaseMileage: true,
+        totalMileage: true,
+        ownedAt: true,
+        soldAt: true,
+        ownStatus: true,
+        userBike: {
+          select: {
+            bikeId: true,
+          },
+        },
+      },
+    })
+
+    if (!myUserBike) {
+      return null
+    }
+
+    return new MyUserBikeEntity({
+      bikeId: createBikeId(myUserBike.userBike.bikeId),
+      userBikeId: createUserBikeId(myUserBike.userBikeId),
+      myUserBikeId: createMyUserBikeId(myUserBike.id),
+      userId: createUserId(myUserBike.userId),
+      nickname: myUserBike.nickname,
+      purchaseDate: myUserBike.purchaseDate,
+      purchasePrice: myUserBike.purchasePrice,
+      purchaseMileage: myUserBike.purchaseMileage,
+      totalMileage: myUserBike.totalMileage,
+      ownedAt: myUserBike.ownedAt,
+      soldAt: myUserBike.soldAt,
+      ownStatus: myUserBike.ownStatus,
+    })
+  }
+
+  async updateMyUserBike(myUserBike: MyUserBikeEntity): Promise<MyUserBikeEntity> {
+    const updated = await this.connection.tUserMyBike.update({
+      where: {
+        id: myUserBike.id,
+      },
+      data: {
+        nickname: myUserBike.nickname,
+        purchaseDate: myUserBike.purchaseDate,
+        purchasePrice: myUserBike.purchasePrice,
+        purchaseMileage: myUserBike.purchaseMileage,
+        totalMileage: myUserBike.totalMileage,
+        ownedAt: myUserBike.ownedAt,
+        soldAt: myUserBike.soldAt,
+        ownStatus: myUserBike.ownStatus,
+      },
+      select: {
+        id: true,
+        userId: true,
+        userBikeId: true,
+        nickname: true,
+        purchaseDate: true,
+        purchasePrice: true,
+        purchaseMileage: true,
+        totalMileage: true,
+        ownedAt: true,
+        soldAt: true,
+        ownStatus: true,
+        userBike: {
+          select: {
+            bikeId: true,
+          },
+        },
+      },
+    })
+
+    return new MyUserBikeEntity({
+      bikeId: createBikeId(updated.userBike.bikeId),
+      userBikeId: createUserBikeId(updated.userBikeId),
+      myUserBikeId: createMyUserBikeId(updated.id),
+      userId: createUserId(updated.userId),
+      nickname: updated.nickname,
+      purchaseDate: updated.purchaseDate,
+      purchasePrice: updated.purchasePrice,
+      purchaseMileage: updated.purchaseMileage,
+      totalMileage: updated.totalMileage,
+      ownedAt: updated.ownedAt,
+      soldAt: updated.soldAt,
+      ownStatus: updated.ownStatus,
+    })
+  }
+
+  async findMyUserBikeDetail(
+    myUserBikeId: MyUserBikeId,
+    userId: UserId
+  ): Promise<MyUserBikeDetail | null> {
+    const myUserBike = await this.connection.tUserMyBike.findFirst({
+      where: { id: myUserBikeId, userId, ownStatus: 'OWN' },
+      include: {
+        userBike: {
+          include: {
+            bike: {
+              include: {
+                manufacturer: true,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    if (!myUserBike) {
+      return null
+    }
+
+    return {
+      myUserBikeId: createMyUserBikeId(myUserBike.id),
+      userBikeId: createUserBikeId(myUserBike.userBikeId),
+      bikeId: createBikeId(myUserBike.userBike.bikeId),
+      manufacturerName: myUserBike.userBike.bike.manufacturer.name,
+      modelName: myUserBike.userBike.bike.modelName,
+      nickname: myUserBike.nickname,
+      purchaseDate: myUserBike.purchaseDate,
+      purchasePrice: myUserBike.purchasePrice,
+      purchaseMileage: myUserBike.purchaseMileage,
+      totalMileage: myUserBike.totalMileage,
+      displacement: myUserBike.userBike.bike.displacement,
+      modelYear: myUserBike.userBike.bike.modelYear,
+      createdAt: myUserBike.createdAt,
+      updatedAt: myUserBike.updatedAt,
+    }
   }
 }

--- a/apps/api/src/lib/classes/services/UserBikeService.ts
+++ b/apps/api/src/lib/classes/services/UserBikeService.ts
@@ -17,6 +17,16 @@ type RegisterUserBikeParams = {
   totalMileage?: number
 }
 
+type UpdateMyUserBikeParams = {
+  myUserBikeId: ReturnType<typeof createMyUserBikeId>
+  userId: UserId
+  nickname?: string | null
+  purchaseDate?: Date | null
+  purchasePrice?: number | null
+  purchaseMileage?: number | null
+  totalMileage?: number | null
+}
+
 export class UserBikeService {
   constructor(
     private userBikeRepository: IUserBikeRepository,
@@ -58,5 +68,50 @@ export class UserBikeService {
     )
 
     return { userBike, myUserBike }
+  }
+
+  public async getMyUserBikeDetail(myUserBikeId: string, userId: UserId) {
+    const detail = await this.myUserBikeRepository.findMyUserBikeDetail(
+      createMyUserBikeId(myUserBikeId),
+      userId
+    )
+
+    if (!detail) {
+      throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
+    }
+
+    return detail
+  }
+
+  public async updateMyUserBike(params: UpdateMyUserBikeParams) {
+    const myUserBike = await this.myUserBikeRepository.findMyUserBikeById(
+      params.myUserBikeId,
+      params.userId
+    )
+
+    if (!myUserBike) {
+      throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
+    }
+
+    const current = myUserBike.toJson()
+
+    const updatedEntity = new MyUserBikeEntity({
+      ...current,
+      nickname: params.nickname !== undefined ? params.nickname : current.nickname,
+      purchaseDate:
+        params.purchaseDate !== undefined ? params.purchaseDate : current.purchaseDate,
+      purchasePrice:
+        params.purchasePrice !== undefined ? params.purchasePrice : current.purchasePrice,
+      purchaseMileage:
+        params.purchaseMileage !== undefined
+          ? params.purchaseMileage
+          : current.purchaseMileage,
+      totalMileage:
+        params.totalMileage !== undefined ? params.totalMileage : current.totalMileage,
+    })
+
+    await this.myUserBikeRepository.updateMyUserBike(updatedEntity)
+
+    return this.getMyUserBikeDetail(params.myUserBikeId, params.userId)
   }
 }

--- a/apps/api/src/lib/interfaces/IMyUserBikeRepository.ts
+++ b/apps/api/src/lib/interfaces/IMyUserBikeRepository.ts
@@ -14,6 +14,8 @@ export type MyUserBikeDetail = {
   modelName: string
   nickname: string | null
   purchaseDate: Date | null
+  purchasePrice: number | null
+  purchaseMileage: number | null
   totalMileage: number
   displacement: number
   modelYear: number
@@ -24,4 +26,13 @@ export type MyUserBikeDetail = {
 export interface IMyUserBikeRepository {
   createMyUserBike(myUserBike: MyUserBikeEntity): Promise<MyUserBikeEntity>
   findMyUserBikes(userId: UserId): Promise<MyUserBikeDetail[]>
+  findMyUserBikeById(
+    myUserBikeId: MyUserBikeId,
+    userId: UserId
+  ): Promise<MyUserBikeEntity | null>
+  updateMyUserBike(myUserBike: MyUserBikeEntity): Promise<MyUserBikeEntity>
+  findMyUserBikeDetail(
+    myUserBikeId: MyUserBikeId,
+    userId: UserId
+  ): Promise<MyUserBikeDetail | null>
 }

--- a/packages/shared-types/src/common/ApiIO.ts
+++ b/packages/shared-types/src/common/ApiIO.ts
@@ -79,10 +79,29 @@ export type ApiResponseUserBikeList = {
     modelName: string
     nickname: string | null
     purchaseDate: string | null
+    purchasePrice: number | null
+    purchaseMileage: number | null
     totalMileage: number
     displacement: number
     modelYear: number
     createdAt: string
     updatedAt: string
   }[]
+}
+
+export type ApiResponseUserBikeDetail = {
+  userBikeId: string
+  myUserBikeId: string
+  manufacturerName: string
+  bikeId: string
+  modelName: string
+  nickname: string | null
+  purchaseDate: string | null
+  purchasePrice: number | null
+  purchaseMileage: number | null
+  totalMileage: number
+  displacement: number
+  modelYear: number
+  createdAt: string
+  updatedAt: string
 }

--- a/packages/shared-types/src/schemas/userBikeSchema.ts
+++ b/packages/shared-types/src/schemas/userBikeSchema.ts
@@ -45,3 +45,54 @@ export const UserBikeRegisterRequestSchema = z.object({
 })
 
 export type UserBikeRegisterRequest = z.infer<typeof UserBikeRegisterRequestSchema>
+
+/**
+ * ユーザーバイク更新リクエストのバリデーションスキーマ
+ */
+export const UserBikeUpdateRequestSchema = z
+  .object({
+    nickname: z
+      .string({ invalid_type_error: 'ニックネームは文字列で指定してください' })
+      .trim()
+      .min(1, 'ニックネームは1文字以上で指定してください')
+      .max(50, 'ニックネームは50文字以内で指定してください')
+      .nullable()
+      .optional(),
+    purchaseDate: z
+      .coerce.date({
+        invalid_type_error: '購入日は日付形式で指定してください',
+      })
+      .nullable()
+      .optional(),
+    purchasePrice: z
+      .number({ invalid_type_error: '購入価格は数値で指定してください' })
+      .int('購入価格は整数で指定してください')
+      .nonnegative('購入価格は0以上で指定してください')
+      .nullable()
+      .optional(),
+    purchaseMileage: z
+      .number({ invalid_type_error: '購入時走行距離は数値で指定してください' })
+      .int('購入時走行距離は整数で指定してください')
+      .nonnegative('購入時走行距離は0以上で指定してください')
+      .nullable()
+      .optional(),
+    totalMileage: z
+      .number({ invalid_type_error: '総走行距離は数値で指定してください' })
+      .int('総走行距離は整数で指定してください')
+      .nonnegative('総走行距離は0以上で指定してください')
+      .nullable()
+      .optional(),
+  })
+  .refine(
+    (data) =>
+      data.nickname !== undefined ||
+      data.purchaseDate !== undefined ||
+      data.purchasePrice !== undefined ||
+      data.purchaseMileage !== undefined ||
+      data.totalMileage !== undefined,
+    {
+      message: 'いずれかの更新項目を指定してください',
+    }
+  )
+
+export type UserBikeUpdateRequest = z.infer<typeof UserBikeUpdateRequestSchema>


### PR DESCRIPTION
## Summary
- implement GET and PATCH `/api/v1/user-bike/bike/:myUserBikeId` with validation and detailed responses
- extend user bike domain types, repository methods, and service logic to support updating mileage and purchase info
- add tests covering authentication, validation, not found cases, and successful updates

## Testing
- pnpm --filter @apps/api test:setup *(fails: database server at 127.0.0.1:5432 is unreachable in the container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693403c8188883309a022b157fd6b024)