### PR TITLE
✨ GET /api/v1/user-bike/bike/{my-user-bike-id}/fuel-logs を実装

### DIFF
--- a/apps/api/src/lib/classes/services/FuelLogService.ts
+++ b/apps/api/src/lib/classes/services/FuelLogService.ts
@@ -4,6 +4,7 @@ import { IMyUserBikeRepository } from '../../interfaces/IMyUserBikeRepository'
 import { ApiV1Error } from '../common/ApiV1Error'
 import { FuelLogEntity } from '../entities/FuelLogEntity'
 import { MyUserBikeEntity } from '../entities/MyUserBikeEntity'
+import { FuelLogSearchParams } from '../valueObjects/FuelLogSearchParams'
 
 type RegisterFuelLogParams = {
   myUserBikeId: MyUserBikeId
@@ -54,5 +55,22 @@ export class FuelLogService {
     }
 
     return createdFuelLog
+  }
+
+  public async getFuelLogs(
+    myUserBikeId: MyUserBikeId,
+    userId: UserId,
+    searchParams: FuelLogSearchParams
+  ): Promise<FuelLogEntity[]> {
+    const myUserBike = await this.myUserBikeRepository.findMyUserBikeById(
+      myUserBikeId,
+      userId
+    )
+
+    if (!myUserBike) {
+      throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
+    }
+
+    return await this.fuelLogRepository.findFuelLogs(myUserBikeId, searchParams)
   }
 }

--- a/apps/api/src/lib/classes/valueObjects/FuelLogSearchParams.ts
+++ b/apps/api/src/lib/classes/valueObjects/FuelLogSearchParams.ts
@@ -1,0 +1,51 @@
+/**
+ * 燃料ログ検索パラメータを表すバリューオブジェクト
+ */
+export class FuelLogSearchParams {
+  private readonly _page: number
+  private readonly _pageSize: number
+  private readonly _sortBy: 'refueledAt' | 'mileage'
+  private readonly _sortOrder: 'asc' | 'desc'
+
+  constructor(params: {
+    page?: number
+    pageSize?: number
+    sortBy?: 'refueledAt' | 'mileage'
+    sortOrder?: 'asc' | 'desc'
+  }) {
+    this._page = params.page && params.page > 0 ? params.page : 1
+    this._pageSize = this.validatePageSize(params.pageSize)
+    this._sortBy = params.sortBy || 'refueledAt'
+    this._sortOrder = params.sortOrder || 'desc'
+  }
+
+  private validatePageSize(size?: number): number {
+    if (!size || size < 1) return 20
+    if (size > 100) return 100
+    return size
+  }
+
+  get page(): number {
+    return this._page
+  }
+
+  get pageSize(): number {
+    return this._pageSize
+  }
+
+  get skip(): number {
+    return (this._page - 1) * this._pageSize
+  }
+
+  get take(): number {
+    return this._pageSize
+  }
+
+  get sortBy(): 'refueledAt' | 'mileage' {
+    return this._sortBy
+  }
+
+  get sortOrder(): 'asc' | 'desc' {
+    return this._sortOrder
+  }
+}

--- a/apps/api/src/lib/interfaces/IFuelLogRepository.ts
+++ b/apps/api/src/lib/interfaces/IFuelLogRepository.ts
@@ -1,5 +1,8 @@
+import { MyUserBikeId } from '@shared-types/index'
 import { FuelLogEntity } from '../classes/entities/FuelLogEntity'
+import { FuelLogSearchParams } from '../classes/valueObjects/FuelLogSearchParams'
 
 export interface IFuelLogRepository {
   createFuelLog(fuelLog: FuelLogEntity): Promise<FuelLogEntity>
+  findFuelLogs(myUserBikeId: MyUserBikeId, searchParams: FuelLogSearchParams): Promise<FuelLogEntity[]>
 }

--- a/apps/api/src/lib/middlewares/zodValidation.ts
+++ b/apps/api/src/lib/middlewares/zodValidation.ts
@@ -27,7 +27,7 @@ import { convertZodErrorToApiError } from '../functions/zodErrorHandler'
  * ```
  */
 export function zodValidateJson<T extends ZodSchema>(schema: T) {
-  return zValidator('json', schema, (result, c) => {
+  return zValidator('json', schema, (result) => {
     if (!result.success) {
       throw convertZodErrorToApiError(result.error)
     }
@@ -41,7 +41,7 @@ export function zodValidateJson<T extends ZodSchema>(schema: T) {
  * @returns Honoミドルウェア
  */
 export function zodValidateQuery<T extends ZodSchema>(schema: T) {
-  return zValidator('query', schema, (result, c) => {
+  return zValidator('query', schema, (result) => {
     if (!result.success) {
       throw convertZodErrorToApiError(result.error)
     }
@@ -55,7 +55,7 @@ export function zodValidateQuery<T extends ZodSchema>(schema: T) {
  * @returns Honoミドルウェア
  */
 export function zodValidateParam<T extends ZodSchema>(schema: T) {
-  return zValidator('param', schema, (result, c) => {
+  return zValidator('param', schema, (result) => {
     if (!result.success) {
       throw convertZodErrorToApiError(result.error)
     }

--- a/packages/shared-types/src/common/ApiIO.ts
+++ b/packages/shared-types/src/common/ApiIO.ts
@@ -113,3 +113,5 @@ export type ApiResponseFuelLogDetail = {
   amount: number
   totalPrice: number
 }
+
+export type ApiResponseFuelLogList = ApiResponseFuelLogDetail[]

--- a/packages/shared-types/src/schemas/fuelLogSchema.ts
+++ b/packages/shared-types/src/schemas/fuelLogSchema.ts
@@ -32,3 +32,15 @@ export const FuelLogRegisterRequestSchema = z.object({
 })
 
 export type FuelLogRegisterRequest = z.infer<typeof FuelLogRegisterRequestSchema>
+
+/**
+ * 燃料ログ一覧取得クエリパラメータのバリデーションスキーマ
+ */
+export const FuelLogListQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1).optional(),
+  'per-size': z.coerce.number().int().min(1).max(100).default(20).optional(),
+  'sort-by': z.enum(['refueled-at', 'mileage']).optional(),
+  'sort-order': z.enum(['asc', 'desc']).default('desc').optional(),
+})
+
+export type FuelLogListQuery = z.infer<typeof FuelLogListQuerySchema>


### PR DESCRIPTION
## 概要

Issue #22に基づき、OpenAPI仕様に従って燃料ログ一覧取得エンドポイントを実装しました。

Closes #22

## 実装内容

### 新規作成
- **FuelLogSearchParams**: クエリパラメータのバリデーションとページネーション計算を行うValueObject

### 機能
- ✅ ページネーション機能 (page, per-size)
- ✅ ソート機能 (refueled-at/mileage, asc/desc)
- ✅ 認証・認可 (バイク所有権の確認)
- ✅ エラーハンドリング (401, 404, 400)

### アーキテクチャ

#### Repository層
- `IFuelLogRepository`: `findFuelLogs` メソッドを追加
- `PrismaFuelLogRepository`: `findFuelLogs` 実装を追加
  - userMyBikeIdでフィルタリング
  - ページネーション対応 (skip/take)
  - ソート対応 (refueledAt/mileage)
  - 既存のDBインデックス `@@index([userMyBikeId, refueledAt])` を活用

#### Service層
- `FuelLogService`: `getFuelLogs` メソッドを追加
  - バイク所有権の確認（認可処理）
  - 存在しない/権限のないバイクの場合は `NOT_FOUND` エラー

#### ルーティング層
- `userBike.ts`: GETエンドポイントを実装
  - 認証: `honoAuthMiddleware`
  - バリデーション: `zodValidateQuery(FuelLogListQuerySchema)`
  - トランザクション不要（読み取りのみ）
  - レスポンス: HTTPステータス 200

### 型定義とスキーマ
- `ApiResponseFuelLogList` 型を追加
- `FuelLogListQuerySchema` を追加（クエリパラメータのZodスキーマ）

### テスト

8つの統合テストケースを追加:
- ✅ 認証エラー (401)
- ✅ リソース未存在 (404)
- ✅ デフォルトパラメータでの取得
- ✅ ページネーション機能
- ✅ ソート機能 (mileage昇順)
- ✅ ソート機能 (refueled-at昇順)
- ✅ 0件の場合の空配列
- ✅ バリデーションエラー (400)
- ✅ レスポンス形式の検証

### その他の改善
- `zodValidation.ts`: 未使用変数を削除してlintエラーを解消

## テスト結果

```
✓ src/__tests__/api/v1/userBike.test.ts (29 tests) 479ms

Test Files  1 passed (1)
     Tests  29 passed (29)
```

- **全29テスト中29テストがパス** ✅
- **Lintエラーなし** ✅

## OpenAPI仕様との整合性

- ✅ エンドポイントパス: `GET /api/v1/user-bike/bike/{my-user-bike-id}/fuel-logs`
- ✅ クエリパラメータ: `page`, `per-size`, `sort-by`, `sort-order`
- ✅ レスポンス形式: `status`, `data` (配列), `message`
- ✅ エラーレスポンス: 400, 401, 404

## レビューポイント

- 既存のアーキテクチャパターンに完全に準拠しています
- POST fuel-logsエンドポイントと同じ認可パターンを使用しています
- BikeSearchParamsと同様のValueObjectパターンを採用しています
- DBインデックスを効率的に活用しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)