### PR TITLE
ユーザーバイク登録でbikeIdを任意化し排気量入力に対応

### DIFF
--- a/apps/docs/public/openapi.yaml
+++ b/apps/docs/public/openapi.yaml
@@ -691,7 +691,8 @@ components:
         modelName:
           type: string
         displacement:
-          type: integer
+          type: number
+          format: float
           description: 排気量（cc）
         modelYear:
           type: integer
@@ -705,10 +706,13 @@ components:
           type: string
         manufacturerName:
           type: string
+          nullable: true
         bikeId:
           type: string
+          nullable: true
         modelName:
           type: string
+          nullable: true
         nickname:
           type: string
           nullable: true
@@ -718,17 +722,27 @@ components:
           type: string
           description: 購入日（ISO 8601形式）
           nullable: true
+        purchasePrice:
+          type: integer
+          description: 購入価格（円）
+          nullable: true
+        purchaseMileage:
+          type: integer
+          description: 購入時走行距離（km）
+          nullable: true
         totalMileage:
           type: integer
           description: 総走行距離（km）
           nullable: true
           default: 0
         displacement:
-          type: integer
+          type: number
+          format: float
           description: 排気量（cc）
         modelYear:
           type: integer
           description: モデル公開年
+          nullable: true
           example: 2025
         createdAt:
           type: string
@@ -738,11 +752,23 @@ components:
           description: 最終更新日時（ISO 8601形式）
     UserBikeRegisterDetail:
       type: object
-      required:
-        - bikeId
+      anyOf:
+        - required:
+            - bikeId
+        - required:
+            - displacement
       properties:
         bikeId:
           type: string
+          nullable: true
+        displacement:
+          type: number
+          format: float
+          description: 排気量（cc）。bikeId未指定の場合は必須。
+        serialNumber:
+          type: string
+          nullable: true
+          maxLength: 100
         nickname:
           type: string
           nullable: true
@@ -750,11 +776,20 @@ components:
           maxLength: 50
         purchaseDate:
           type: string
+          format: date-time
           description: 購入日（ISO 8601形式）
           nullable: true
-        mileage:
+        purchasePrice:
+          type: integer
+          description: 購入価格（円）
+          nullable: true
+        purchaseMileage:
           type: integer
           description: 購入時走行距離（km）
+          nullable: true
+        totalMileage:
+          type: integer
+          description: 総走行距離（km）
           nullable: true
           default: 0
     UserBikeUpdateDetail:
@@ -769,9 +804,17 @@ components:
           type: string
           description: 購入日（ISO 8601形式）
           nullable: true
-        mileage:
+        purchaseMileage:
           type: integer
           description: 購入時走行距離（km）
+          nullable: true
+        purchasePrice:
+          type: integer
+          description: 購入価格（円）
+          nullable: true
+        totalMileage:
+          type: integer
+          description: 総走行距離（km）
           nullable: true
           default: 0
     MyUserBikeFuelLogDetail:

--- a/apps/web/__tests__/api/v1/userBike.test.ts
+++ b/apps/web/__tests__/api/v1/userBike.test.ts
@@ -190,6 +190,37 @@ describe('UserBike API Endpoints', () => {
     expect(userBikeRecord?.bikeId).toBe(bikeId)
   })
 
+  test('bikeIdを指定せず排気量のみで登録できる', async () => {
+    const displacement = 400
+    const res = await app.request('/api/v1/user-bike/register', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        displacement,
+        nickname: '排気量のみ登録',
+      }),
+    })
+
+    const json = await res.json()
+    expect(res.status).toBe(201)
+    expect(json.status).toBe('success')
+    expect(json.data.bikeId).toBeNull()
+    expect(json.data.manufacturerName).toBeNull()
+    expect(json.data.modelName).toBeNull()
+    expect(json.data.modelYear).toBeNull()
+    expect(json.data.displacement).toBe(displacement)
+
+    const userBikeRecord = await prisma.tUserBike.findUnique({
+      where: { id: json.data.userBikeId },
+    })
+
+    expect(userBikeRecord?.bikeId).toBeNull()
+    expect(userBikeRecord?.displacement).toBe(displacement)
+  })
+
   test('同じ車台番号でも登録できる', async () => {
     const res = await app.request('/api/v1/user-bike/register', {
       method: 'POST',

--- a/apps/web/lib/api/server/entities/MyUserBikeEntity.ts
+++ b/apps/web/lib/api/server/entities/MyUserBikeEntity.ts
@@ -22,14 +22,17 @@ export class MyUserBikeEntity {
       throw new Error('購入価格は0以上である必要があります')
     }
 
-    this._value = myUserBike
+    this._value = {
+      ...myUserBike,
+      bikeId: myUserBike.bikeId ?? null,
+    }
   }
 
   public get id(): MyUserBikeId {
     return this._value.myUserBikeId
   }
 
-  public get bikeId(): BikeId {
+  public get bikeId(): BikeId | null {
     return this._value.bikeId
   }
 

--- a/apps/web/lib/api/server/entities/UserBikeEntity.ts
+++ b/apps/web/lib/api/server/entities/UserBikeEntity.ts
@@ -4,8 +4,14 @@ export class UserBikeEntity {
   private _value: UserBike
 
   constructor(userBike: UserBike) {
+    if (userBike.displacement <= 0) {
+      throw new Error('排気量は0より大きい必要があります')
+    }
+
     this._value = {
       ...userBike,
+      bikeId: userBike.bikeId ?? null,
+      displacement: userBike.displacement,
       serialNumber: userBike.serialNumber?.trim() ?? null,
     }
   }
@@ -14,8 +20,12 @@ export class UserBikeEntity {
     return this._value.userBikeId
   }
 
-  public get bikeId(): BikeId {
+  public get bikeId(): BikeId | null {
     return this._value.bikeId
+  }
+
+  public get displacement(): number {
+    return this._value.displacement
   }
 
   public get serialNumber(): string | null {

--- a/apps/web/lib/api/server/interfaces/IMyUserBikeRepository.ts
+++ b/apps/web/lib/api/server/interfaces/IMyUserBikeRepository.ts
@@ -9,16 +9,16 @@ import { MyUserBikeEntity } from '../entities/MyUserBikeEntity'
 export type MyUserBikeDetail = {
   userBikeId: UserBikeId
   myUserBikeId: MyUserBikeId
-  bikeId: BikeId
-  manufacturerName: string
-  modelName: string
+  bikeId: BikeId | null
+  manufacturerName: string | null
+  modelName: string | null
   nickname: string | null
   purchaseDate: Date | null
   purchasePrice: number | null
   purchaseMileage: number | null
   totalMileage: number
   displacement: number
-  modelYear: number
+  modelYear: number | null
   createdAt: Date
   updatedAt: Date
 }

--- a/apps/web/lib/api/server/repositories/PrismaMyUserBikeRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaMyUserBikeRepository.ts
@@ -48,13 +48,16 @@ export class PrismaMyUserBikeRepository
         userBike: {
           select: {
             bikeId: true,
+            displacement: true,
           },
         },
       },
     })
 
     return new MyUserBikeEntity({
-      bikeId: createBikeId(created.userBike.bikeId),
+      bikeId: created.userBike.bikeId
+        ? createBikeId(created.userBike.bikeId)
+        : null,
       userBikeId: createUserBikeId(created.userBikeId),
       myUserBikeId: createMyUserBikeId(created.id),
       userId: createUserId(created.userId),
@@ -74,7 +77,9 @@ export class PrismaMyUserBikeRepository
       where: { userId, ownStatus: 'OWN' },
       include: {
         userBike: {
-          include: {
+          select: {
+            bikeId: true,
+            displacement: true,
             bike: {
               include: {
                 manufacturer: true,
@@ -91,16 +96,20 @@ export class PrismaMyUserBikeRepository
     return myUserBikes.map((myUserBike) => ({
       myUserBikeId: createMyUserBikeId(myUserBike.id),
       userBikeId: createUserBikeId(myUserBike.userBikeId),
-      bikeId: createBikeId(myUserBike.userBike.bikeId),
-      manufacturerName: myUserBike.userBike.bike.manufacturer.name,
-      modelName: myUserBike.userBike.bike.modelName,
+      bikeId: myUserBike.userBike.bikeId
+        ? createBikeId(myUserBike.userBike.bikeId)
+        : null,
+      manufacturerName: myUserBike.userBike.bike?.manufacturer.name ?? null,
+      modelName: myUserBike.userBike.bike?.modelName ?? null,
       nickname: myUserBike.nickname,
       purchaseDate: myUserBike.purchaseDate,
       purchasePrice: myUserBike.purchasePrice,
       purchaseMileage: myUserBike.purchaseMileage,
       totalMileage: myUserBike.totalMileage,
-      displacement: myUserBike.userBike.bike.displacement,
-      modelYear: myUserBike.userBike.bike.modelYear,
+      displacement:
+        myUserBike.userBike.bike?.displacement ??
+        myUserBike.userBike.displacement,
+      modelYear: myUserBike.userBike.bike?.modelYear ?? null,
       createdAt: myUserBike.createdAt,
       updatedAt: myUserBike.updatedAt,
     }))
@@ -127,6 +136,7 @@ export class PrismaMyUserBikeRepository
         userBike: {
           select: {
             bikeId: true,
+            displacement: true,
           },
         },
       },
@@ -137,7 +147,9 @@ export class PrismaMyUserBikeRepository
     }
 
     return new MyUserBikeEntity({
-      bikeId: createBikeId(myUserBike.userBike.bikeId),
+      bikeId: myUserBike.userBike.bikeId
+        ? createBikeId(myUserBike.userBike.bikeId)
+        : null,
       userBikeId: createUserBikeId(myUserBike.userBikeId),
       myUserBikeId: createMyUserBikeId(myUserBike.id),
       userId: createUserId(myUserBike.userId),
@@ -184,13 +196,16 @@ export class PrismaMyUserBikeRepository
         userBike: {
           select: {
             bikeId: true,
+            displacement: true,
           },
         },
       },
     })
 
     return new MyUserBikeEntity({
-      bikeId: createBikeId(updated.userBike.bikeId),
+      bikeId: updated.userBike.bikeId
+        ? createBikeId(updated.userBike.bikeId)
+        : null,
       userBikeId: createUserBikeId(updated.userBikeId),
       myUserBikeId: createMyUserBikeId(updated.id),
       userId: createUserId(updated.userId),
@@ -213,7 +228,9 @@ export class PrismaMyUserBikeRepository
       where: { id: myUserBikeId, userId, ownStatus: 'OWN' },
       include: {
         userBike: {
-          include: {
+          select: {
+            bikeId: true,
+            displacement: true,
             bike: {
               include: {
                 manufacturer: true,
@@ -231,16 +248,20 @@ export class PrismaMyUserBikeRepository
     return {
       myUserBikeId: createMyUserBikeId(myUserBike.id),
       userBikeId: createUserBikeId(myUserBike.userBikeId),
-      bikeId: createBikeId(myUserBike.userBike.bikeId),
-      manufacturerName: myUserBike.userBike.bike.manufacturer.name,
-      modelName: myUserBike.userBike.bike.modelName,
+      bikeId: myUserBike.userBike.bikeId
+        ? createBikeId(myUserBike.userBike.bikeId)
+        : null,
+      manufacturerName: myUserBike.userBike.bike?.manufacturer.name ?? null,
+      modelName: myUserBike.userBike.bike?.modelName ?? null,
       nickname: myUserBike.nickname,
       purchaseDate: myUserBike.purchaseDate,
       purchasePrice: myUserBike.purchasePrice,
       purchaseMileage: myUserBike.purchaseMileage,
       totalMileage: myUserBike.totalMileage,
-      displacement: myUserBike.userBike.bike.displacement,
-      modelYear: myUserBike.userBike.bike.modelYear,
+      displacement:
+        myUserBike.userBike.bike?.displacement ??
+        myUserBike.userBike.displacement,
+      modelYear: myUserBike.userBike.bike?.modelYear ?? null,
       createdAt: myUserBike.createdAt,
       updatedAt: myUserBike.updatedAt,
     }

--- a/apps/web/lib/api/server/repositories/PrismaUserBikeRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaUserBikeRepository.ts
@@ -11,18 +11,21 @@ export class PrismaUserBikeRepository
     const created = await this.connection.tUserBike.create({
       data: {
         bikeId: userBike.bikeId,
+        displacement: userBike.displacement,
         serialNumber: userBike.serialNumber,
       },
       select: {
         id: true,
         bikeId: true,
+        displacement: true,
         serialNumber: true,
       },
     })
 
     return new UserBikeEntity({
-      bikeId: createBikeId(created.bikeId),
+      bikeId: created.bikeId ? createBikeId(created.bikeId) : null,
       userBikeId: createUserBikeId(created.id),
+      displacement: created.displacement,
       serialNumber: created.serialNumber,
     })
   }

--- a/apps/web/lib/api/server/services/UserBikeService.ts
+++ b/apps/web/lib/api/server/services/UserBikeService.ts
@@ -4,6 +4,7 @@ import {
   createUserBikeId,
   UserId,
 } from '@packages/shared-types'
+import { BikeEntity } from '../entities/BikeEntity'
 import { MyUserBikeEntity } from '../entities/MyUserBikeEntity'
 import { UserBikeEntity } from '../entities/UserBikeEntity'
 import { ApiV1Error } from '../errors/ApiV1Error'
@@ -12,7 +13,8 @@ import { IMyUserBikeRepository } from '../interfaces/IMyUserBikeRepository'
 import { IUserBikeRepository } from '../interfaces/IUserBikeRepository'
 
 type RegisterUserBikeParams = {
-  bikeId: BikeId
+  bikeId?: BikeId | null
+  displacement?: number
   serialNumber?: string
   userId: UserId
   nickname?: string
@@ -40,15 +42,24 @@ export class UserBikeService {
   ) {}
 
   public async registerUserBike(params: RegisterUserBikeParams) {
-    const bike = await this.bikeRepository.findById(params.bikeId)
-    if (!bike) {
-      throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
+    let bike: BikeEntity | null = null
+    if (params.bikeId) {
+      bike = await this.bikeRepository.findById(params.bikeId)
+      if (!bike) {
+        throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
+      }
+    }
+
+    const displacement = bike?.displacement ?? params.displacement
+    if (displacement === undefined) {
+      throw new ApiV1Error('INVALID_REQUEST', '排気量を指定してください')
     }
 
     const userBike = await this.userBikeRepository.createUserBike(
       new UserBikeEntity({
-        bikeId: bike.id,
+        bikeId: bike?.id ?? null,
         userBikeId: createUserBikeId(''),
+        displacement,
         serialNumber: params.serialNumber ?? null,
       })
     )

--- a/apps/web/lib/api/server/v1/userBike.ts
+++ b/apps/web/lib/api/server/v1/userBike.ts
@@ -35,7 +35,7 @@ const toApiResponseUserBikeDetail = (
   userBikeId: detail.userBikeId,
   myUserBikeId: detail.myUserBikeId,
   manufacturerName: detail.manufacturerName,
-  bikeId: detail.bikeId,
+  bikeId: detail.bikeId ?? null,
   modelName: detail.modelName,
   nickname: detail.nickname,
   purchaseDate: detail.purchaseDate?.toISOString() ?? null,
@@ -67,7 +67,8 @@ userBike.post(
       )
 
       const { myUserBike } = await service.registerUserBike({
-        bikeId: createBikeId(body.bikeId),
+        bikeId: body.bikeId ? createBikeId(body.bikeId) : null,
+        displacement: body.displacement,
         serialNumber: body.serialNumber,
         userId,
         nickname: body.nickname,

--- a/development/docs/02_design/api.md
+++ b/development/docs/02_design/api.md
@@ -176,6 +176,28 @@ Authorization: Bearer <token>
 }
 ```
 
+#### `POST /api/v1/user-bike/register`
+
+ユーザーバイクを登録する。`bikeId`を指定してカタログに登録されているバイクと紐づけるか、`bikeId`を省略して排気量（`displacement`）のみを指定することもできる。
+
+**リクエスト例（排気量のみを指定する場合）**
+
+```json
+{
+  "displacement": 400,
+  "nickname": "排気量のみ登録バイク"
+}
+```
+
+**リクエスト例（bikeIdを指定する場合）**
+
+```json
+{
+  "bikeId": "string",
+  "totalMileage": 0
+}
+```
+
 ### ロール`ADMIN`
 
 - `GET /api/v1/admin/users` - 全ユーザーの一覧取得

--- a/development/docs/02_design/db_schema.md
+++ b/development/docs/02_design/db_schema.md
@@ -85,8 +85,9 @@ erDiagram
 
     TUserBike {
         string id PK
-        string bikeId FK
-        string serialNumber UK
+        string? bikeId FK
+        float displacement
+        string? serialNumber
     }
 
     TMyBike {

--- a/packages/database/prisma/migrations/20251221000000_optional_user_bike_displacement/migration.sql
+++ b/packages/database/prisma/migrations/20251221000000_optional_user_bike_displacement/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE "TUserBike" DROP CONSTRAINT "TUserBike_bike_id_fkey";
+ALTER TABLE "TUserBike" ALTER COLUMN "bike_id" DROP NOT NULL;
+ALTER TABLE "TUserBike" ADD COLUMN     "displacement" DOUBLE PRECISION;
+
+UPDATE "TUserBike" ub
+SET "displacement" = b."displacement"
+FROM "MBike" b
+WHERE ub."bike_id" = b."id";
+
+UPDATE "TUserBike"
+SET "displacement" = 0
+WHERE "displacement" IS NULL;
+
+ALTER TABLE "TUserBike" ALTER COLUMN "displacement" SET NOT NULL;
+
+ALTER TABLE "TUserBike" ADD CONSTRAINT "TUserBike_bike_id_fkey" FOREIGN KEY ("bike_id") REFERENCES "MBike"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -96,13 +96,14 @@ model MMaintenanceType {
 
 model TUserBike {
   id           String @id @default(cuid(2))
-  bikeId       String @map("bike_id")
+  bikeId       String? @map("bike_id")
   serialNumber String? @map("serial_number")
+  displacement Float   @map("displacement")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  bike    MBike         @relation(fields: [bikeId], references: [id], onDelete: Restrict)
+  bike    MBike?        @relation(fields: [bikeId], references: [id], onDelete: Restrict)
   myBikes TUserMyBike[]
 }
 

--- a/packages/shared-types/src/common/ApiIO.ts
+++ b/packages/shared-types/src/common/ApiIO.ts
@@ -74,16 +74,16 @@ export type ApiResponseUserBikeList = {
   bikes: {
     userBikeId: string
     myUserBikeId: string
-    manufacturerName: string
-    bikeId: string
-    modelName: string
+    manufacturerName: string | null
+    bikeId: string | null
+    modelName: string | null
     nickname: string | null
     purchaseDate: string | null
     purchasePrice: number | null
     purchaseMileage: number | null
     totalMileage: number
     displacement: number
-    modelYear: number
+    modelYear: number | null
     createdAt: string
     updatedAt: string
   }[]
@@ -92,16 +92,16 @@ export type ApiResponseUserBikeList = {
 export type ApiResponseUserBikeDetail = {
   userBikeId: string
   myUserBikeId: string
-  manufacturerName: string
-  bikeId: string
-  modelName: string
+  manufacturerName: string | null
+  bikeId: string | null
+  modelName: string | null
   nickname: string | null
   purchaseDate: string | null
   purchasePrice: number | null
   purchaseMileage: number | null
   totalMileage: number
   displacement: number
-  modelYear: number
+  modelYear: number | null
   createdAt: string
   updatedAt: string
 }

--- a/packages/shared-types/src/domain/bike.ts
+++ b/packages/shared-types/src/domain/bike.ts
@@ -14,8 +14,9 @@ export type UserBikeId = string & { readonly __brand: unique symbol }
 export const createUserBikeId = (id: string): UserBikeId => id as UserBikeId
 
 export type UserBike = {
-  bikeId: BikeId
+  bikeId: BikeId | null
   userBikeId: UserBikeId
+  displacement: number
 
   serialNumber: string | null
 }
@@ -27,7 +28,7 @@ export const createMyUserBikeId = (id: string): MyUserBikeId =>
 import { UserId } from './user'
 
 export type MyUserBike = {
-  bikeId: BikeId
+  bikeId: BikeId | null
   userBikeId: UserBikeId
   myUserBikeId: MyUserBikeId
   userId: UserId

--- a/packages/shared-types/src/schemas/userBikeSchema.ts
+++ b/packages/shared-types/src/schemas/userBikeSchema.ts
@@ -3,46 +3,59 @@ import { z } from 'zod'
 /**
  * ユーザーバイク登録リクエストのバリデーションスキーマ
  */
-export const UserBikeRegisterRequestSchema = z.object({
-  bikeId: z
-    .string({
-      required_error: 'bikeIdは必須です',
-      invalid_type_error: 'bikeIdは文字列で指定してください',
-    })
-    .min(1, 'bikeIdは1文字以上で指定してください'),
-  serialNumber: z
-    .string({ invalid_type_error: '車台番号は文字列で指定してください' })
-    .trim()
-    .min(1, '車台番号は1文字以上で指定してください')
-    .max(100, '車台番号は100文字以内で指定してください')
-    .optional(),
-  nickname: z
-    .string({ invalid_type_error: 'ニックネームは文字列で指定してください' })
-    .trim()
-    .min(1, 'ニックネームは1文字以上で指定してください')
-    .max(50, 'ニックネームは50文字以内で指定してください')
-    .optional(),
-  purchaseDate: z.coerce
-    .date({
-      invalid_type_error: '購入日は日付形式で指定してください',
-    })
-    .optional(),
-  purchasePrice: z
-    .number({ invalid_type_error: '購入価格は数値で指定してください' })
-    .int('購入価格は整数で指定してください')
-    .nonnegative('購入価格は0以上で指定してください')
-    .optional(),
-  purchaseMileage: z
-    .number({ invalid_type_error: '購入時走行距離は数値で指定してください' })
-    .int('購入時走行距離は整数で指定してください')
-    .nonnegative('購入時走行距離は0以上で指定してください')
-    .optional(),
-  totalMileage: z
-    .number({ invalid_type_error: '総走行距離は数値で指定してください' })
-    .int('総走行距離は整数で指定してください')
-    .nonnegative('総走行距離は0以上で指定してください')
-    .optional(),
-})
+export const UserBikeRegisterRequestSchema = z
+  .object({
+    bikeId: z
+      .string({
+        invalid_type_error: 'bikeIdは文字列で指定してください',
+      })
+      .min(1, 'bikeIdは1文字以上で指定してください')
+      .optional(),
+    displacement: z
+      .number({
+        invalid_type_error: '排気量は数値で指定してください',
+      })
+      .positive('排気量は0より大きい値で指定してください')
+      .optional(),
+    serialNumber: z
+      .string({ invalid_type_error: '車台番号は文字列で指定してください' })
+      .trim()
+      .min(1, '車台番号は1文字以上で指定してください')
+      .max(100, '車台番号は100文字以内で指定してください')
+      .optional(),
+    nickname: z
+      .string({
+        invalid_type_error: 'ニックネームは文字列で指定してください',
+      })
+      .trim()
+      .min(1, 'ニックネームは1文字以上で指定してください')
+      .max(50, 'ニックネームは50文字以内で指定してください')
+      .optional(),
+    purchaseDate: z.coerce
+      .date({
+        invalid_type_error: '購入日は日付形式で指定してください',
+      })
+      .optional(),
+    purchasePrice: z
+      .number({ invalid_type_error: '購入価格は数値で指定してください' })
+      .int('購入価格は整数で指定してください')
+      .nonnegative('購入価格は0以上で指定してください')
+      .optional(),
+    purchaseMileage: z
+      .number({ invalid_type_error: '購入時走行距離は数値で指定してください' })
+      .int('購入時走行距離は整数で指定してください')
+      .nonnegative('購入時走行距離は0以上で指定してください')
+      .optional(),
+    totalMileage: z
+      .number({ invalid_type_error: '総走行距離は数値で指定してください' })
+      .int('総走行距離は整数で指定してください')
+      .nonnegative('総走行距離は0以上で指定してください')
+      .optional(),
+  })
+  .refine((data) => data.bikeId !== undefined || data.displacement !== undefined, {
+    message: 'bikeIdまたは排気量を指定してください',
+    path: ['bikeId'],
+  })
 
 export type UserBikeRegisterRequest = z.infer<
   typeof UserBikeRegisterRequestSchema


### PR DESCRIPTION
## Summary
- TUserBikeスキーマに排気量カラムを追加し、bikeIdをNULL許容にした上でバリデーション/型定義を更新
- バイク未選択でも登録できるようAPIサービスとリポジトリを拡張し、レスポンスのnull許容項目と排気量を整備
- OpenAPI/設計ドキュメントを更新し、排気量のみで登録するテストケースを追加

## Testing
- pnpm --filter web lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947a9d6055c8330b2e5afa14fe30582)