### PR TITLE
Use lucide-react for the profile navigation icon

### DIFF
--- a/apps/web/app/(protected)/home/page.tsx
+++ b/apps/web/app/(protected)/home/page.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation'
 import { Button } from '@packages/ui/button'
+import { ProfileIcon } from '@/components/icons/ProfileIcon'
 import { MyBikeListSection } from '@/components/MyBikeListSection'
 import { NavigationCard } from '@/components/NavigationCard'
 import { withAuth } from '@/lib/hoc/withAuth'
@@ -33,21 +34,7 @@ function Page() {
           href="/profile"
           title="プロフィール編集"
           description="あなたのプロフィール情報を更新できます"
-          icon={
-            <svg
-              width="24"
-              height="24"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-              <circle cx="12" cy="7" r="4" />
-            </svg>
-          }
+          icon={<ProfileIcon />}
         />
       </div>
 

--- a/apps/web/components/icons/ProfileIcon.tsx
+++ b/apps/web/components/icons/ProfileIcon.tsx
@@ -1,0 +1,8 @@
+import { UserRound } from 'lucide-react'
+
+/**
+ * プロフィール画面などで使用するユーザーアイコン
+ */
+export const ProfileIcon = () => (
+  <UserRound aria-hidden="true" size={24} strokeWidth={2} />
+)


### PR DESCRIPTION
## Summary
- add a dedicated ProfileIcon component backed by lucide-react
- replace the profile navigation card’s inline SVG with the shared lucide icon to align with the icon strategy

## Testing
- pnpm format
- pnpm lint
- pnpm --filter @apps/web lint
- NODE_ENV=production pnpm build *(fails: Firebase設定パラメータが未設定のため)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949438f3cb8833088b3e17a70c4fb3e)