### PR TITLE
feat: 認証後ページにホームボタンを追加 (#58)

### DIFF
--- a/apps/web/app/(protected)/layout.tsx
+++ b/apps/web/app/(protected)/layout.tsx
@@ -1,11 +1,19 @@
+import { HomeButton } from '@/components/HomeButton'
+
 type Props = {
   children: React.ReactNode
 }
 
 export default function Layout({ children }: Props) {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-4 gap-8">
-      {children}
-    </div>
+    <>
+      <div className="fixed top-4 left-4 z-50">
+        <HomeButton />
+      </div>
+
+      <div className="min-h-screen flex flex-col items-center justify-center p-4 gap-8">
+        {children}
+      </div>
+    </>
   )
 }

--- a/apps/web/components/HomeButton.tsx
+++ b/apps/web/components/HomeButton.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useRouter, usePathname } from 'next/navigation'
+import { Button } from '@repo/ui/button'
+import { HomeIcon } from '@/components/icons/HomeIcon'
+
+export function HomeButton() {
+  const router = useRouter()
+  const pathname = usePathname()
+
+  const isOnHomePage = pathname === '/home'
+
+  const handleClick = () => {
+    if (!isOnHomePage) {
+      router.push('/home')
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="cloud"
+      size="sm"
+      disabled={isOnHomePage}
+      aria-label="ホームに戻る"
+      aria-disabled={isOnHomePage}
+      onClick={handleClick}
+    >
+      <HomeIcon />
+    </Button>
+  )
+}

--- a/apps/web/components/icons/HomeIcon.tsx
+++ b/apps/web/components/icons/HomeIcon.tsx
@@ -1,0 +1,3 @@
+import { Home } from 'lucide-react'
+
+export const HomeIcon = () => <Home size={24} strokeWidth={2} />


### PR DESCRIPTION
## 概要
Issue #58 の実装です。認証後のページにホームへ戻るボタンを追加しました。

## 変更内容
### 追加された機能
- 認証後のページ（`(protected)`グループ）にホームへ戻るボタンを追加
- 画面左上に固定配置（ThemeToggleButtonと対称的なレイアウト）
- アイコンのみのシンプルでミニマルなデザイン

### 実装詳細
#### 新規ファイル
- `apps/web/components/icons/HomeIcon.tsx`
  - `lucide-react`の`Home`アイコンをラップ
  - 既存のアイコンパターン（BikeIcon等）に準拠

- `apps/web/components/HomeButton.tsx`
  - ホームへ戻るボタンコンポーネント
  - `useRouter`と`usePathname`でナビゲーション制御
  - ホームページ（`/home`）では無効化される
  - `aria-label`でアクセシビリティを確保

#### 修正ファイル
- `apps/web/app/(protected)/layout.tsx`
  - HomeButtonを左上に固定配置（`fixed top-4 left-4 z-50`）

## デザインの特徴
- ThemeToggleButtonと統一されたスタイル
  - 同じボタンバリアント（`variant="cloud"`）
  - 同じサイズ（`size="sm"`）
  - アイコンのみのクリーンなUI
- 対称的な配置
  - 左上：HomeButton
  - 右上：ThemeToggleButton

## 動作
- 認証後のすべてのページで表示される
- クリックで`/home`へ遷移
- ホームページでは無効化される（現在地を視覚的に示す）
- 未認証ページでは表示されない

## スクリーンショット
（必要に応じて追加してください）

## テスト
- [x] リント成功
- [x] フォーマット成功
- [x] ビルド成功
- [x] 認証後のページでボタンが表示される
- [x] ボタンクリックでホームへ遷移
- [x] ホームページでボタンが無効化される

## 関連Issue
Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)