### PR TITLE
🐛 給油走行距離の更新時に前回給油走行距離が連動する不具合を修正

### DIFF
--- a/apps/web/components/fuel-log/FuelLogForm.tsx
+++ b/apps/web/components/fuel-log/FuelLogForm.tsx
@@ -102,12 +102,6 @@ export const FuelLogForm = ({
             setFormData((prev) => ({
               ...prev,
               mileage: newMileage,
-              previousMileage:
-                !isEdit &&
-                (prev.previousMileage === '' ||
-                  prev.previousMileage === prev.mileage)
-                  ? newMileage
-                  : prev.previousMileage,
               // 総走行距離以下になったら自動的にチェックを外す
               updateTotalMileage:
                 totalMileage !== undefined && Number(newMileage) <= totalMileage


### PR DESCRIPTION
給油時走行距離を変更すると前回給油時走行距離も連動して更新されてしまう
UXの問題を修正。

この変更により、ユーザーが給油時走行距離を入力しても、前回給油時走行距離の
フィールドは独立して保持されるようになる。

Fixes #103

<!-- I want to review in Japanese. -->

## 概要

## 関連タスク

## チェックポイント

- [ ]

## 影響範囲・懸念

-

## 備考

<!-- I want to review in Japanese. -->
