### PR TITLE
ユーザー復帰APIを追加（/auth/recover）

### DIFF
--- a/apps/web/__tests__/api/v1/user.test.ts
+++ b/apps/web/__tests__/api/v1/user.test.ts
@@ -324,4 +324,98 @@ describe('User API Endpoints', () => {
       ).toBe(true)
     })
   })
+
+  describe('POST /api/v1/user/auth/recover', () => {
+    test('Authorizationヘッダーが未指定の場合にエラーとなる', async () => {
+      await testAuthRequired('/api/v1/user/auth/recover', 'POST', {
+        recoveryCode: '12345',
+      })
+    })
+
+    test('復帰コードが空文字でエラーとなる', async () => {
+      const { token } = await createTestUser()
+      const res = await app.request('/api/v1/user/auth/recover', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          recoveryCode: '',
+        }),
+      })
+
+      const json = await res.json()
+      expect(json.status).toBe('error')
+      expect(json.errorCode).toBe('VALIDATION_ERROR')
+      expect(json.message).toBeDefined()
+      expect(json.details).toEqual(
+        expect.arrayContaining([
+          {
+            field: 'recoveryCode',
+            message: expect.any(String),
+          },
+        ])
+      )
+      expect(res.status).toBe(400)
+    })
+
+    test('復帰処理が完了しユーザーが有効化される', async () => {
+      const { token, userId } = await createTestUser()
+      const quitReason = 'テスト退会理由'
+      const quitRes = await app.request('/api/v1/user/auth/quit', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          quitReason,
+        }),
+      })
+      const quitJson = await quitRes.json()
+
+      const res = await app.request('/api/v1/user/auth/recover', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          recoveryCode: quitJson.data.recoveryCode,
+        }),
+      })
+
+      const json = await res.json()
+      expect(json).toEqual({
+        status: 'success',
+        data: {
+          userId,
+        },
+        message: expect.any(String),
+      })
+      expect(res.status).toBe(200)
+
+      const quitRecord = await prisma.tUserQuit.findUnique({
+        where: { userId },
+      })
+      expect(quitRecord).not.toBeNull()
+      expect(quitRecord?.status).toBe('RECOVERED')
+
+      const userRecord = await prisma.mUser.findUnique({
+        where: { id: userId },
+        select: { status: true },
+      })
+      expect(userRecord?.status).toBe('ACTIVE')
+
+      const authProviders = await prisma.mAuthProvider.findMany({
+        where: { userId },
+        select: { isActive: true },
+      })
+      expect(authProviders.length).toBeGreaterThan(0)
+      expect(
+        authProviders.every((provider) => provider.isActive === true)
+      ).toBe(true)
+    })
+  })
 })

--- a/apps/web/lib/api/server/interfaces/IUserQuitRepository.ts
+++ b/apps/web/lib/api/server/interfaces/IUserQuitRepository.ts
@@ -1,3 +1,4 @@
+import { UserId, UserQuitStatus } from '@repo/shared-types'
 import { UserQuitEntity } from '../entities/UserQuitEntity'
 
 export interface IUserQuitRepository {
@@ -5,4 +6,14 @@ export interface IUserQuitRepository {
    * 退会情報を登録する
    */
   create(userQuit: UserQuitEntity): Promise<UserQuitEntity>
+
+  /**
+   * 退会情報を取得する
+   */
+  findByUserId(userId: UserId): Promise<UserQuitEntity | null>
+
+  /**
+   * 退会情報のステータスを更新する
+   */
+  updateStatus(userId: UserId, status: UserQuitStatus): Promise<void>
 }

--- a/apps/web/lib/api/server/interfaces/IUserRepository.ts
+++ b/apps/web/lib/api/server/interfaces/IUserRepository.ts
@@ -8,6 +8,11 @@ export interface IUserRepository {
    */
   findById(userId: UserId): Promise<UserEntity | null>
 
+  /**
+   * 内部User IDからUserを取得（ステータス不問）
+   */
+  findByIdIncludingInactive(userId: UserId): Promise<UserEntity | null>
+
   findByAuthProvider(
     authProvider: AuthProviderEntity
   ): Promise<UserEntity | null>
@@ -35,4 +40,9 @@ export interface IUserRepository {
    * ユーザーを退会状態にする
    */
   deactivateUser(userId: UserId): Promise<void>
+
+  /**
+   * ユーザーを有効状態にする
+   */
+  activateUser(userId: UserId): Promise<void>
 }

--- a/apps/web/lib/api/server/repositories/PrismaAuthProviderRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaAuthProviderRepository.ts
@@ -29,6 +29,28 @@ export class PrismaAuthProviderRepository extends PrismaRepositoryBase {
   }
 
   /**
+   * 外部ID（Firebase UIDなど）から内部User IDを取得（アクティブ判定なし）
+   */
+  async findUserIdByExternalId(
+    externalId: string,
+    providerType: ProviderType
+  ): Promise<string | null> {
+    const authProvider = await this.connection.mAuthProvider.findFirst({
+      select: {
+        user: {
+          select: { id: true },
+        },
+      },
+      where: {
+        externalId: externalId,
+        providerType: providerType,
+      },
+    })
+
+    return authProvider?.user?.id ?? null
+  }
+
+  /**
    * 指定ユーザーの認証プロバイダを無効化
    */
   async deactivateByUserId(userId: UserId): Promise<void> {
@@ -39,6 +61,21 @@ export class PrismaAuthProviderRepository extends PrismaRepositoryBase {
       },
       data: {
         isActive: false,
+      },
+    })
+  }
+
+  /**
+   * 指定ユーザーの認証プロバイダを有効化
+   */
+  async activateByUserId(userId: UserId): Promise<void> {
+    await this.connection.mAuthProvider.updateMany({
+      where: {
+        userId,
+        isActive: false,
+      },
+      data: {
+        isActive: true,
       },
     })
   }

--- a/apps/web/lib/api/server/repositories/PrismaUserQuitRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaUserQuitRepository.ts
@@ -1,4 +1,9 @@
-import { createUserId, createUserQuitId } from '@repo/shared-types'
+import {
+  createUserId,
+  createUserQuitId,
+  type UserId,
+  type UserQuitStatus,
+} from '@repo/shared-types'
 import { UserQuitEntity } from '../entities/UserQuitEntity'
 import { IUserQuitRepository } from '../interfaces/IUserQuitRepository'
 import { PrismaRepositoryBase } from './PrismaRepositoryBase'
@@ -33,6 +38,49 @@ export class PrismaUserQuitRepository
       quitReason: created.quitReason,
       recoveryCode: created.recoveryCode,
       status: created.status,
+    })
+  }
+
+  async findByUserId(userId: UserId): Promise<UserQuitEntity | null> {
+    const userQuit = await this.connection.tUserQuit.findUnique({
+      where: {
+        userId,
+      },
+      select: {
+        id: true,
+        userId: true,
+        quitAt: true,
+        quitReason: true,
+        recoveryCode: true,
+        status: true,
+      },
+    })
+
+    if (!userQuit) {
+      return null
+    }
+
+    return new UserQuitEntity({
+      id: createUserQuitId(userQuit.id),
+      userId: createUserId(userQuit.userId),
+      quitAt: userQuit.quitAt,
+      quitReason: userQuit.quitReason,
+      recoveryCode: userQuit.recoveryCode,
+      status: userQuit.status,
+    })
+  }
+
+  async updateStatus(
+    userId: UserId,
+    status: UserQuitStatus
+  ): Promise<void> {
+    await this.connection.tUserQuit.update({
+      where: {
+        userId,
+      },
+      data: {
+        status,
+      },
     })
   }
 }

--- a/apps/web/lib/api/server/repositories/PrismaUserRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaUserRepository.ts
@@ -32,6 +32,29 @@ export class PrismaUserRepository
       : null
   }
 
+  async findByIdIncludingInactive(userId: UserId): Promise<UserEntity | null> {
+    const user = await this.connection.mUser.findFirst({
+      select: {
+        id: true,
+        name: true,
+        status: true,
+        role: true,
+      },
+      where: {
+        id: userId,
+      },
+    })
+
+    return user
+      ? new UserEntity({
+          id: createUserId(user.id),
+          name: user.name,
+          role: user.role,
+          status: user.status,
+        })
+      : null
+  }
+
   async findByAuthProvider(
     authProvider: AuthProviderEntity
   ): Promise<UserEntity | null> {
@@ -131,6 +154,18 @@ export class PrismaUserRepository
       },
       data: {
         status: 'INACTIVE',
+      },
+    })
+  }
+
+  async activateUser(userId: UserId): Promise<void> {
+    await this.connection.mUser.update({
+      where: {
+        id: userId,
+        status: 'INACTIVE',
+      },
+      data: {
+        status: 'ACTIVE',
       },
     })
   }

--- a/apps/web/lib/api/server/services/UserQuitService.ts
+++ b/apps/web/lib/api/server/services/UserQuitService.ts
@@ -1,5 +1,7 @@
 import {
+  createUserId,
   createUserQuitId,
+  type ProviderType,
   type UserId,
   type UserQuitStatus,
 } from '@repo/shared-types'
@@ -13,6 +15,12 @@ import { PrismaAuthProviderRepository } from '../repositories/PrismaAuthProvider
 type QuitUserParams = {
   userId: UserId
   quitReason: string
+}
+
+type RecoverUserParams = {
+  externalId: string
+  providerType: ProviderType
+  recoveryCode: string
 }
 
 export class UserQuitService {
@@ -49,5 +57,54 @@ export class UserQuitService {
     await this.authProviderRepository.deactivateByUserId(params.userId)
 
     return { recoveryCode }
+  }
+
+  public async recoverUser(params: RecoverUserParams): Promise<{
+    userId: UserId
+  }> {
+    const userIdValue = await this.authProviderRepository.findUserIdByExternalId(
+      params.externalId,
+      params.providerType
+    )
+
+    if (!userIdValue) {
+      throw new ApiV1Error(
+        'USER_NOT_REGISTERED',
+        'ユーザー登録が完了していません'
+      )
+    }
+
+    const userId = createUserId(userIdValue)
+    const user = await this.userRepository.findByIdIncludingInactive(userId)
+    if (!user) {
+      throw new ApiV1Error('USER_NOT_REGISTERED', 'ユーザーが見つかりません')
+    }
+
+    if (user.status === 'ACTIVE') {
+      throw new ApiV1Error('INVALID_REQUEST', 'ユーザーは既に有効です')
+    }
+
+    if (user.status !== 'INACTIVE') {
+      throw new ApiV1Error('INVALID_REQUEST', '復帰できない状態です')
+    }
+
+    const userQuit = await this.userQuitRepository.findByUserId(userId)
+    if (!userQuit) {
+      throw new ApiV1Error('NOT_FOUND', '退会情報が見つかりません')
+    }
+
+    if (userQuit.status === 'RECOVERED') {
+      throw new ApiV1Error('INVALID_REQUEST', '既に復帰済みです')
+    }
+
+    if (userQuit.recoveryCode !== params.recoveryCode) {
+      throw new ApiV1Error('INVALID_REQUEST', '復帰コードが一致しません')
+    }
+
+    await this.userRepository.activateUser(userId)
+    await this.authProviderRepository.activateByUserId(userId)
+    await this.userQuitRepository.updateStatus(userId, 'RECOVERED')
+
+    return { userId }
   }
 }

--- a/apps/web/lib/api/server/v1/user.ts
+++ b/apps/web/lib/api/server/v1/user.ts
@@ -3,7 +3,9 @@ import { prisma } from '@repo/database'
 import {
   ApiResponseUserProfile,
   ApiResponseUserQuit,
+  ApiResponseUserRecover,
   SuccessResponse,
+  UserAuthRecoverRequestSchema,
   UserAuthQuitRequestSchema,
   UserAuthRegisterRequestSchema,
   UserProfileUpdateRequestSchema,
@@ -176,6 +178,59 @@ user.post(
         recoveryCode: result.recoveryCode,
       },
       message: '退会処理が完了しました',
+    })
+  }
+)
+
+/**
+ * ユーザー復帰エンドポイント
+ *
+ * @remarks
+ * - Firebase認証トークン必須
+ * - 復帰コードの入力が必須
+ */
+user.post(
+  '/auth/recover',
+  zodValidateJson(UserAuthRecoverRequestSchema),
+  async (c) => {
+    const authHeader = c.req.header('Authorization')
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      throw new ApiV1Error('AUTH_FAILED', '認証トークンが提供されていません')
+    }
+
+    const token = authHeader.substring('Bearer '.length)
+    const firebaseAuthRepo = new FirebaseAuthRepository()
+    const authProvider = await firebaseAuthRepo.authorize(token)
+
+    if (!authProvider) {
+      throw new ApiV1Error('AUTH_FAILED', '認証トークンが無効です')
+    }
+
+    const body = c.req.valid('json')
+
+    const result = await prisma.$transaction(async (t) => {
+      const userRepo = new PrismaUserRepository(t)
+      const authProviderRepo = new PrismaAuthProviderRepository(t)
+      const userQuitRepo = new PrismaUserQuitRepository(t)
+      const service = new UserQuitService(
+        userRepo,
+        authProviderRepo,
+        userQuitRepo
+      )
+
+      return service.recoverUser({
+        externalId: authProvider.externalId,
+        providerType: authProvider.provider,
+        recoveryCode: body.recoveryCode,
+      })
+    })
+
+    return c.json<SuccessResponse<ApiResponseUserRecover>>({
+      status: 'success',
+      data: {
+        userId: result.userId,
+      },
+      message: '復帰処理が完了しました',
     })
   }
 )

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -168,6 +168,48 @@ paths:
         '500':
           $ref: '#/components/responses/Error500'
 
+  /api/v1/user/auth/recover:
+    post:
+      summary: ユーザー復帰
+      description: 復帰コードを受け取り、退会状態のユーザーを復帰させます。
+      tags:
+        - user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRecover'
+      responses:
+        '200':
+          description: 復帰処理成功
+          headers:
+            Authorization:
+              $ref: '#/components/headers/Authorization'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  data:
+                    $ref: '#/components/schemas/UserRecoverResponse'
+                  message:
+                    type: string
+                    example: 復帰処理が完了しました
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '403':
+          $ref: '#/components/responses/Error403'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '500':
+          $ref: '#/components/responses/Error500'
+
   /api/v1/bikes/manufacturers:
     get:
       summary: バイクメーカー一覧の取得
@@ -841,6 +883,22 @@ components:
         recoveryCode:
           type: string
           example: '12345'
+    UserRecover:
+      type: object
+      required:
+        - recoveryCode
+      properties:
+        recoveryCode:
+          type: string
+          minLength: 5
+          maxLength: 5
+          description: 復帰コード（5桁）
+          example: '12345'
+    UserRecoverResponse:
+      type: object
+      properties:
+        userId:
+          type: string
     ManufacturerDetail:
       type: object
       properties:

--- a/packages/shared-types/src/common/ApiIO.ts
+++ b/packages/shared-types/src/common/ApiIO.ts
@@ -49,6 +49,10 @@ export type ApiResponseUserQuit = {
   recoveryCode: string
 }
 
+export type ApiResponseUserRecover = {
+  userId: string
+}
+
 export type ApiResponseManufacturer = {
   manufacturers: {
     manufacturerId: string

--- a/packages/shared-types/src/schemas/userQuitSchema.ts
+++ b/packages/shared-types/src/schemas/userQuitSchema.ts
@@ -18,6 +18,30 @@ export const UserAuthQuitRequestSchema = z.object({
 })
 
 /**
+ * ユーザー復帰リクエストのバリデーションスキーマ
+ *
+ * @remarks
+ * - recoveryCode: 5桁の数字
+ */
+export const UserAuthRecoverRequestSchema = z.object({
+  recoveryCode: z
+    .string({
+      required_error: '復帰コードは必須です',
+      invalid_type_error: '復帰コードは文字列である必要があります',
+    })
+    .trim()
+    .length(5, '復帰コードは5桁である必要があります')
+    .regex(/^\d{5}$/, '復帰コードは5桁の数字である必要があります'),
+})
+
+/**
  * ユーザー退会リクエストの型
  */
 export type UserAuthQuitRequest = z.infer<typeof UserAuthQuitRequestSchema>
+
+/**
+ * ユーザー復帰リクエストの型
+ */
+export type UserAuthRecoverRequest = z.infer<
+  typeof UserAuthRecoverRequestSchema
+>


### PR DESCRIPTION
### Motivation
- 退会後にユーザーを復帰させるAPIが未実装だったため、復帰コードによる復帰処理を提供するための実装を行いました。
- 既存の退会処理で発行している復帰コードを用いて、認証済みユーザーの再有効化を安全に行えるようにします。

### Description
- `POST /api/v1/user/auth/recover` エンドポイントを追加し、Firebaseトークン検証と復帰コードのバリデーションを行って `UserQuitService.recoverUser` を呼び出すようにしました。
- `UserQuitService` に `recoverUser` を実装し、`User` の状態復帰、`mAuthProvider` の再有効化、`tUserQuit` のステータス更新を行う処理を追加しました。
- リポジトリ/インターフェースを拡張して `findByUserId` / `updateStatus` / `findUserIdByExternalId` / `activateByUserId` / `findByIdIncludingInactive` / `activateUser` などのメソッドを追加しました。
- バリデーションスキーマ `UserAuthRecoverRequestSchema`、レスポンス型 `ApiResponseUserRecover`、および `openapi.yaml` のスキーマとエンドポイント定義を追加し、テスト `apps/web/__tests__/api/v1/user.test.ts` に復帰ケースを追加しました。

### Testing
- `apps/web/__tests__/api/v1/user.test.ts` に対する復帰関連のユニットテストを追加しました（認証未指定時、バリデーションエラー、正常復帰のケース）。
- 追加したテストはリポジトリにコミット済みですが、自動実行（CI/ローカルでの `pnpm test` 等）は行っていません。
- 既存の退会処理との統合は `Prisma` モデル（`tUserQuit`, `mUser`, `mAuthProvider`）に合わせて実装しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ca65413083308d84ddc34bfc192a)