### PR TITLE
✨ デプロイ後にdevelopからmainへの自動同期機能を追加

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 env:
@@ -24,7 +24,7 @@ jobs:
     environment: production
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout
@@ -159,3 +159,47 @@ jobs:
             --cluster ${{ env.ECS_CLUSTER }} \
             --services ${{ env.ECS_SERVICE }} \
             --region ${{ env.AWS_REGION }}
+
+      - name: Sync develop to main
+        if: success()
+        run: |
+          # Git設定
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          # リモートブランチの最新情報を取得
+          git fetch origin main
+          git fetch origin develop
+
+          # mainブランチにチェックアウト
+          git checkout main
+
+          # developブランチの内容をマージ（Fast-forward）
+          if git merge origin/develop --ff-only --no-edit; then
+            echo "✅ Successfully merged develop into main (fast-forward)"
+
+            # マージコミットメッセージを更新
+            TAG_NAME="${{ github.ref_name }}"
+            git commit --amend -m "🔀 Sync develop to main after deployment
+
+            Deployed version: ${TAG_NAME}
+            Deployment workflow: ${{ github.run_id }}
+
+            Co-Authored-By: github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+
+            # mainブランチにプッシュ
+            git push origin main
+
+            echo "✅ Successfully pushed to main branch"
+          else
+            echo "❌ Failed to merge develop into main"
+            echo "⚠️  Conflict detected or fast-forward merge not possible"
+            echo ""
+            echo "📋 Manual merge required:"
+            echo "  1. git fetch origin"
+            echo "  2. git checkout main"
+            echo "  3. git merge origin/develop"
+            echo "  4. Resolve conflicts"
+            echo "  5. git push origin main"
+            exit 1
+          fi

--- a/.github/workflows/test-branch-sync.yml
+++ b/.github/workflows/test-branch-sync.yml
@@ -1,0 +1,46 @@
+name: Test Branch Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: 'Source branch to merge from'
+        required: true
+        default: 'main'
+      target_branch:
+        description: 'Target branch to merge to'
+        required: true
+        default: 'develop'
+
+permissions:
+  contents: write
+
+jobs:
+  test-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Test branch sync
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          git fetch origin ${{ inputs.source_branch }}
+          git fetch origin ${{ inputs.target_branch }}
+
+          git checkout ${{ inputs.target_branch }}
+
+          if git merge origin/${{ inputs.source_branch }} --ff-only --no-edit; then
+            echo "✅ Merge successful (fast-forward)"
+            echo "⚠️  DRY-RUN: Would push to ${{ inputs.target_branch }}"
+            # テスト完了後にコメント解除
+            # git push origin ${{ inputs.target_branch }}
+          else
+            echo "❌ Merge failed - conflict detected"
+            exit 1
+          fi


### PR DESCRIPTION
## 概要

Issue #146 の対応として、本番デプロイ成功後にdevelopブランチの内容をmainブランチに自動的に同期させる機能を実装しました。

Closes #146

## 変更内容

### 1. deploy-production.yml の変更
- 権限を `contents: write` に変更（ブランチへのpush権限）
- デプロイ成功後に「Sync develop to main」ステップを追加
  - Fast-forwardマージでdevelopの内容をmainに同期
  - コンフリクト発生時はワークフローを失敗させる
  - 詳細なエラーメッセージと手動マージ手順を表示

### 2. test-branch-sync.yml の追加
- 検証用ワークフロー（手動実行）
- 本番適用前の動作テストに使用可能

## ブランチフロー

```
develop（開発） → デプロイ → main（本番リリース済み）
```

## 動作仕様

- **実行タイミング**: ECSデプロイ安定化確認後
- **実行条件**: デプロイが成功した場合のみ（`if: success()`）
- **マージ方法**: Fast-forwardマージ（`--ff-only`）
- **コンフリクト時**: ワークフロー失敗、手動マージを促す

## テスト計画

### テストシナリオ1: 正常系
1. developブランチで変更を加える
2. developブランチから `release/x.x.x` タグを作成・プッシュ
3. デプロイワークフローが実行される
4. デプロイ成功後、developの内容が自動的にmainに同期される
5. mainがdevelopと同じコミットを指していることを確認

### テストシナリオ2: 異常系（コンフリクト発生）
1. mainで独自の変更を加える（developと異なる内容）
2. developでも別の変更を加える（同じファイルを編集）
3. developから `release/x.x.x` タグを作成・プッシュ
4. デプロイワークフローが実行される
5. 同期ステップでコンフリクトが検出され、ワークフローが失敗する
6. エラーメッセージに手動マージの手順が表示される

## 確認事項

- [ ] mainブランチの保護ルール確認（`github-actions[bot]` の直接プッシュ許可が必要な場合）
- [ ] デプロイ成功時の動作確認
- [ ] コンフリクト発生時のエラーハンドリング確認

## 期待される効果

1. **自動化**: デプロイ後の手動マージ作業が不要になる
2. **一貫性**: デプロイ成功後、mainブランチが常にdevelopの最新状態を反映
3. **安全性**: コンフリクト時は自動マージせず、手動対応を促す
4. **透明性**: マージコミットにデプロイ情報が記録される
5. **開発効率**: developで開発 → デプロイ → 自動的にmainへ反映される流れが確立