### PR TITLE
プロフィール編集画面のUI調整

### DIFF
--- a/apps/web/app/app/(protected)/profile/page.tsx
+++ b/apps/web/app/app/(protected)/profile/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
+import { BaseCard } from '@repo/ui/baseCard'
 import { Button } from '@repo/ui/button'
 import { LogoutButton } from '@/components/Navigation/LogoutButton'
 import { ProfileCard } from '@/components/ProfileCard'
@@ -19,7 +20,9 @@ function ProfileEditPage() {
 
       <div className="w-full max-w-md flex flex-col gap-4">
         <ProfileCard />
-        <LogoutButton />
+        <BaseCard title="アカウント">
+          <LogoutButton />
+        </BaseCard>
       </div>
     </>
   )

--- a/apps/web/components/ProfileCard.tsx
+++ b/apps/web/components/ProfileCard.tsx
@@ -7,6 +7,7 @@ import { Button } from '@repo/ui/button'
 import { ErrorMessage } from '@repo/ui/errorMessage'
 import { FormField } from '@repo/ui/formField'
 import { Input } from '@repo/ui/input'
+import { EditIcon } from '@/components/icons/EditIcon'
 import { apiGet, apiPost } from '@/lib/api/client'
 import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
 
@@ -145,12 +146,21 @@ export function ProfileCard() {
 
   // 表示モード
   return (
-    <BaseCard title="プロフィール">
+    <BaseCard
+      title="プロフィール"
+      headerAction={
+        <Button
+          onClick={handleEdit}
+          variant="cloud"
+          size="sm"
+          aria-label="プロフィールを編集"
+        >
+          <EditIcon />
+        </Button>
+      }
+    >
       <div>
         <p>名前: {data?.name || '未設定'}</p>
-        <Button onClick={handleEdit} style={{ marginTop: '8px' }}>
-          編集
-        </Button>
       </div>
     </BaseCard>
   )


### PR DESCRIPTION
### Motivation

- Issue #154 に沿って、編集ボタンとログアウトボタンの表示を控えめにし、将来の「退会」項目追加を見越してログアウトをプロフィールカードから分離する。 

### Description

- `apps/web/components/ProfileCard.tsx` の表示モードで、従来の本文内の `編集` ボタンを削除し、`BaseCard` の `headerAction` に小さなアイコンボタン（`EditIcon`）を追加して編集起点を右上の控えめなアイコンに変更した。 
- `apps/web/app/app/(protected)/profile/page.tsx` で `LogoutButton` を直接表示していた箇所を `BaseCard`（タイトル: `アカウント`）でラップしてログアウト用の専用カードを追加した。 
- UIのみの変更であり、API/認証/DB周りのロジックは変更していない。 

### Testing

- 開発サーバーを起動するために `pnpm dev:web` を実行し、Next 開発サーバーの起動は成功した。 
- Playwright を使った自動ブラウザスクリプトで `http://127.0.0.1:3000/app/profile` にアクセスしてスクリーンショットを取得する自動化を実行し、スクリーンショットは生成されたが認証により `/app/login` へリダイレクトされており認証済みのプロフィール画面は取得できなかった。 
- 単体テストや CI のテストは実行しておらず、ユニット/自動テストの合格報告はない。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696af1ee49348330a2412cd2ad766956)