### PR TITLE
🐛 デプロイワークフローのPRラベルエラーを修正

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -254,7 +254,7 @@ jobs:
             --head develop \
             --title "$PR_TITLE" \
             --body "$PR_BODY" \
-            --label "deployment,automated" \
+            --label "Release" \
             2>&1)
 
           if [ $? -eq 0 ]; then


### PR DESCRIPTION
## 概要

Issue #174 で報告されたデプロイ時のPR作成失敗を修正しました。

## 問題

`release/0.0.6` デプロイ時に、develop→main同期PRの自動作成が以下のエラーで失敗していました：

```
could not add label: 'deployment' not found
```

## 原因

ワークフローで指定している `deployment` と `automated` ラベルがリポジトリに存在していませんでした。

## 修正内容

[.github/workflows/deploy-production.yml:257](.github/workflows/deploy-production.yml#L257) のラベル指定を変更：

```yaml
# 変更前
--label "deployment,automated"

# 変更後
--label "Release"
```

## 変更理由

- 新しく作成された `Release` ラベルを使用
- リリース関連のPRであることが明確
- PR本文に「🤖 このPRは GitHub Actions により自動生成されました」と記載されており、自動生成の判別は可能

## テスト

✅ リントチェック: 成功  
✅ ワークフロー構文チェック: 成功  
✅ YAML構文検証: 正常

## 次回リリース時の確認事項

次回 `release/0.0.7` タグをpushした際に以下を確認してください：

- [ ] デプロイワークフローが正常に完了すること
- [ ] develop→main同期PRが自動作成されること
- [ ] 作成されたPRに `Release` ラベルが付与されていること
- [ ] PR作成時にエラーが発生しないこと

## 関連Issue

Closes #174