### PR TITLE
ツーリング記録編集APIを追加

### DIFF
--- a/apps/web/__tests__/api/v1/userBike.test.ts
+++ b/apps/web/__tests__/api/v1/userBike.test.ts
@@ -1796,6 +1796,172 @@ describe('UserBike API Endpoints', () => {
     })
   })
 
+  describe('PATCH /api/v1/user-bike/bike/:myUserBikeId/tourings/:touringId', () => {
+    let token: string
+    let myUserBikeId: string
+    let touringId: string
+
+    beforeEach(async () => {
+      const user = await createTestUser()
+      token = user.token
+
+      const bike = await createTestUserBike(token, {
+        displacement: 500,
+        nickname: 'ツーリング更新テスト用バイク',
+        totalMileage: 4000,
+      })
+      myUserBikeId = bike.myUserBikeId
+
+      touringId = await createTestTouring(token, myUserBikeId, {
+        title: '更新前ツーリング',
+        startDate: '2024-10-10T00:00:00.000Z',
+        endDate: '2024-10-12T00:00:00.000Z',
+        startMileage: 4000,
+        endMileage: 4200,
+      })
+    })
+
+    test('Authorizationヘッダーが未指定の場合にエラーとなる', async () => {
+      await testAuthRequired(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}`,
+        'PATCH',
+        {
+          title: '更新後ツーリング',
+        }
+      )
+    })
+
+    test('更新項目が指定されていない場合はバリデーションエラーとなる', async () => {
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({}),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(400)
+      expectValidationError(json)
+    })
+
+    test('不正な入力の場合はバリデーションエラーとなる', async () => {
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            startDate: '2024-10-13T00:00:00.000Z',
+            endDate: '2024-10-11T00:00:00.000Z',
+          }),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(400)
+      expectValidationError(json)
+    })
+
+    test('存在しないバイクIDの場合は404となる', async () => {
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${randomUUID()}/tourings/${touringId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            title: '更新後ツーリング',
+          }),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(404)
+      expect404Error(json)
+    })
+
+    test('存在しないツーリングIDの場合は404となる', async () => {
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${randomUUID()}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            title: '更新後ツーリング',
+          }),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(404)
+      expect404Error(json)
+    })
+
+    test('ツーリングを更新できる', async () => {
+      const endDate = '2024-10-13T00:00:00.000Z'
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            title: '更新後ツーリング',
+            endDate,
+            endMileage: 4300,
+          }),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(200)
+      expect(json).toEqual({
+        status: 'success',
+        data: {
+          touringId,
+          title: '更新後ツーリング',
+          startDate: '2024-10-10T00:00:00.000Z',
+          endDate,
+          startMileage: 4000,
+          endMileage: 4300,
+        },
+        message: 'ツーリング更新成功',
+      })
+
+      const getTouringResult = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}`,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      )
+
+      const getTouringJson = await getTouringResult.json()
+      expect(getTouringResult.status).toBe(200)
+      expect(getTouringJson.data.touringId).toBe(touringId)
+      expect(getTouringJson.data.title).toBe('更新後ツーリング')
+      expect(getTouringJson.data.endDate).toBe(endDate)
+      expect(getTouringJson.data.endMileage).toBe(4300)
+    })
+  })
+
   describe('PATCH /api/v1/user-bike/bike/:myUserBikeId/fuel-logs', () => {
     let token: string
     let myUserBikeId: string

--- a/apps/web/lib/api/client.ts
+++ b/apps/web/lib/api/client.ts
@@ -210,6 +210,7 @@ type API_EP = {
 } & {
   [key: `/api/v1/user-bike/bike/${string}/tourings/${string}`]: {
     GET: SuccessResponse<ApiResponseTouringDetail>
+    PATCH: SuccessResponse<ApiResponseTouringDetail>
   }
 } & {
   [key: `/api/v1/user-bike/bike/${string}`]: {

--- a/apps/web/lib/api/server/services/TouringService.ts
+++ b/apps/web/lib/api/server/services/TouringService.ts
@@ -40,6 +40,17 @@ type EndTouringParams = {
 
 type TouringActionParams = StartTouringParams | EndTouringParams
 
+type UpdateTouringParams = {
+  touringId: TouringId
+  myUserBikeId: MyUserBikeId
+  userId: UserId
+  title?: string
+  startDate?: Date
+  endDate?: Date
+  startMileage?: number
+  endMileage?: number
+}
+
 export class TouringService {
   constructor(
     private touringRepository: ITouringRepository,
@@ -180,5 +191,46 @@ export class TouringService {
     }
 
     return touring
+  }
+
+  public async updateTouring(
+    params: UpdateTouringParams
+  ): Promise<TouringEntity> {
+    const myUserBike = await this.myUserBikeRepository.findMyUserBikeById(
+      params.myUserBikeId,
+      params.userId
+    )
+
+    if (!myUserBike) {
+      throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
+    }
+
+    const existingTouring = await this.touringRepository.findTouringById(
+      params.touringId,
+      params.myUserBikeId
+    )
+
+    if (!existingTouring) {
+      throw new ApiV1Error('NOT_FOUND', '指定されたツーリングが見つかりません')
+    }
+
+    try {
+      const updatedTouring = new TouringEntity({
+        touringId: existingTouring.id,
+        myUserBikeId: existingTouring.myUserBikeId,
+        title: params.title ?? existingTouring.title,
+        startDate: params.startDate ?? existingTouring.startDate,
+        endDate: params.endDate ?? existingTouring.endDate,
+        startMileage: params.startMileage ?? existingTouring.startMileage,
+        endMileage: params.endMileage ?? existingTouring.endMileage,
+      })
+
+      return await this.touringRepository.updateTouring(updatedTouring)
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new ApiV1Error('INVALID_REQUEST', error.message)
+      }
+      throw error
+    }
   }
 }

--- a/apps/web/lib/api/server/v1/userBike.ts
+++ b/apps/web/lib/api/server/v1/userBike.ts
@@ -26,6 +26,7 @@ import {
   TouringRegisterRequestSchema,
   TouringStartEndRequestSchema,
   TouringListQuerySchema,
+  TouringUpdateRequestSchema,
 } from '@repo/shared-types'
 import { MyUserBikeDetail } from '../interfaces/IMyUserBikeRepository'
 import { honoAuthMiddleware } from '../middlewares/honoAuth'
@@ -591,6 +592,51 @@ userBike.get(
           endMileage: touring.endMileage,
         },
         message: 'ツーリング取得成功',
+      },
+      200
+    )
+  }
+)
+
+userBike.patch(
+  '/bike/:myUserBikeId/tourings/:touringId',
+  honoAuthMiddleware,
+  zodValidateJson(TouringUpdateRequestSchema),
+  async (c) => {
+    const { userId } = c.var.user!
+    const myUserBikeId = c.req.param('myUserBikeId')
+    const touringId = c.req.param('touringId')
+    const body = c.req.valid('json')
+
+    const result = await prisma.$transaction((t) => {
+      const touringRepo = new PrismaTouringRepository(t)
+      const myUserBikeRepo = new PrismaMyUserBikeRepository(t)
+      const service = new TouringService(touringRepo, myUserBikeRepo)
+
+      return service.updateTouring({
+        touringId: createTouringId(touringId),
+        myUserBikeId: createMyUserBikeId(myUserBikeId),
+        userId: createUserId(userId),
+        title: body.title,
+        startDate: body.startDate,
+        endDate: body.endDate,
+        startMileage: body.startMileage,
+        endMileage: body.endMileage,
+      })
+    })
+
+    return c.json<SuccessResponse<ApiResponseTouringDetail>>(
+      {
+        status: 'success',
+        data: {
+          touringId: result.id,
+          title: result.title,
+          startDate: result.startDate.toISOString(),
+          endDate: result.endDate.toISOString(),
+          startMileage: result.startMileage,
+          endMileage: result.endMileage,
+        },
+        message: 'ツーリング更新成功',
       },
       200
     )

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -1030,6 +1030,58 @@ paths:
           $ref: '#/components/responses/Error404'
         '500':
           $ref: '#/components/responses/Error500'
+    patch:
+      summary: ユーザー所有バイクのツーリング更新
+      tags:
+        - user-bikes
+      parameters:
+        - in: path
+          name: my-user-bike-id
+          required: true
+          schema:
+            type: string
+          description: ユーザー所有バイクID
+        - in: path
+          name: touring-id
+          required: true
+          schema:
+            type: string
+          description: ツーリングID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MyUserBikeTouringUpdateDetail'
+      responses:
+        '200':
+          description: ツーリング更新成功
+          headers:
+            Authorization:
+              $ref: '#/components/headers/Authorization'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  data:
+                    $ref: '#/components/schemas/MyUserBikeTouringDetail'
+                  message:
+                    type: string
+                    example: ツーリング更新成功
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '403':
+          $ref: '#/components/responses/Error403'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '500':
+          $ref: '#/components/responses/Error500'
 
   /api/v1/health:
     get:
@@ -1408,6 +1460,28 @@ components:
         - title
         - startDate
         - endDate
+      properties:
+        title:
+          type: string
+          minLength: 1
+          maxLength: 100
+        startDate:
+          type: string
+          description: 開始日（ISO 8601形式）
+        endDate:
+          type: string
+          description: 終了日（ISO 8601形式）
+        startMileage:
+          type: integer
+          nullable: true
+          description: 開始時の総走行距離（km）
+        endMileage:
+          type: integer
+          nullable: true
+          description: 終了時の総走行距離（km）
+
+    MyUserBikeTouringUpdateDetail:
+      type: object
       properties:
         title:
           type: string

--- a/packages/shared-types/src/schemas/touringSchema.ts
+++ b/packages/shared-types/src/schemas/touringSchema.ts
@@ -56,6 +56,78 @@ export type TouringRegisterRequest = z.infer<
 >
 
 /**
+ * ツーリング更新リクエストのバリデーションスキーマ
+ */
+export const TouringUpdateRequestSchema = z
+  .object({
+    title: z
+      .string({
+        invalid_type_error: 'タイトルは文字列で指定してください',
+      })
+      .min(1, 'タイトルは1文字以上で指定してください')
+      .max(100, 'タイトルは100文字以内で指定してください')
+      .trim()
+      .optional(),
+    startDate: z.coerce
+      .date({
+        invalid_type_error: '開始日は日付形式で指定してください',
+      })
+      .optional(),
+    endDate: z.coerce
+      .date({
+        invalid_type_error: '終了日は日付形式で指定してください',
+      })
+      .optional(),
+    startMileage: z
+      .number({
+        invalid_type_error: '開始時の総走行距離は数値で指定してください',
+      })
+      .int('開始時の総走行距離は整数で指定してください')
+      .nonnegative('開始時の総走行距離は0以上で指定してください')
+      .optional(),
+    endMileage: z
+      .number({
+        invalid_type_error: '終了時の総走行距離は数値で指定してください',
+      })
+      .int('終了時の総走行距離は整数で指定してください')
+      .nonnegative('終了時の総走行距離は0以上で指定してください')
+      .optional(),
+  })
+  .refine(
+    (data) =>
+      data.title !== undefined ||
+      data.startDate !== undefined ||
+      data.endDate !== undefined ||
+      data.startMileage !== undefined ||
+      data.endMileage !== undefined,
+    {
+      message: 'いずれかの更新項目を指定してください',
+    }
+  )
+  .refine(
+    (data) =>
+      data.startDate === undefined ||
+      data.endDate === undefined ||
+      data.startDate <= data.endDate,
+    {
+      message: '開始日は終了日以前の日付で指定してください',
+      path: ['startDate'],
+    }
+  )
+  .refine(
+    (data) =>
+      data.startMileage === undefined ||
+      data.endMileage === undefined ||
+      data.startMileage <= data.endMileage,
+    {
+      message: '開始時の総走行距離は終了時の総走行距離以下で指定してください',
+      path: ['startMileage'],
+    }
+  )
+
+export type TouringUpdateRequest = z.infer<typeof TouringUpdateRequestSchema>
+
+/**
  * ツーリング開始/終了リクエストのバリデーションスキーマ
  */
 const TouringStartRequestSchema = z.object({


### PR DESCRIPTION
### Motivation
- Issue #142 の要望に沿ってツーリング記録を編集するAPI（PATCH）を実装するための変更です。 

### Description
- 追加のバリデーションスキーマとして `TouringUpdateRequestSchema` を `packages/shared-types/src/schemas/touringSchema.ts` に追加しました。 
- ビジネスロジックとして `TouringService` に部分更新を行う `updateTouring` メソッドを追加し、既存データのマージとバリデーションを行うようにしました（`apps/web/lib/api/server/services/TouringService.ts`）。 
- エンドポイント `PATCH /api/v1/user-bike/bike/:myUserBikeId/tourings/:touringId` をルーティングに追加し、`prisma.$transaction` 内で `TouringService.updateTouring` を呼び出す実装を行いました（`apps/web/lib/api/server/v1/userBike.ts`）。 
- クライアント型定義とOpenAPI定義（`apps/web/lib/api/client.ts`、`apps/web/public/openapi.yaml`）にPATCH操作とリクエスト/レスポンススキーマ（`MyUserBikeTouringUpdateDetail`）を追記しました。 
- エンドツーエンド/APIレベルのテストケースを `apps/web/__tests__/api/v1/userBike.test.ts` に追加して、認証未指定・バリデーション・404・正常更新をカバーするテストを追加しました。 

### Testing
- 自動テストの実行は行っておらず、追加したテストはリポジトリにコミット済みであるため、ローカルまたはCIで `pnpm test` 相当のコマンドで実行してください。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb254c8808330be18d5eb474e6052)