### PR TITLE
[Bug] 公開バイク詳細ページでID取得を安定化

### DIFF
--- a/apps/web/app/(public)/bikes/[id]/page.tsx
+++ b/apps/web/app/(public)/bikes/[id]/page.tsx
@@ -20,9 +20,9 @@ const getPublicBike = async (id: string) => {
 export default async function PublicBikeDetailPage({
   params,
 }: {
-  params: { id: string }
+  params: Promise<{ id: string }>
 }) {
-  const { id } = params
+  const { id } = await params
   const bike = await getPublicBike(id)
 
   if (!bike) {


### PR DESCRIPTION
### Motivation
- 公開バイク一覧から個別ページへ遷移した際に選択したIDではなく常に最初のバイクが表示される不具合が発生しており、その原因はNext.jsのページコンポーネントで受け取る`params`を同期的に扱っていたことにあると考えられるため修正する。 

### Description
- `apps/web/app/(public)/bikes/[id]/page.tsx`で受け取る`params`の型を`Promise<{ id: string }>`に変更し、`const { id } = await params`として非同期に解決してからIDを取得するように修正した。 

### Testing
- 自動テストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975783707f48330a607c1f49a758911)