### PR TITLE
🐛 公開ページメタデータを正しく適用されるように修正

### DIFF
--- a/apps/web/app/(public)/about/page.tsx
+++ b/apps/web/app/(public)/about/page.tsx
@@ -20,6 +20,9 @@ export const metadata: Metadata = {
     description: `${APP_NAME} は、バイクのメンテナンス管理を簡単に行うためのアプリです。`,
     images: ['/top_image_1.png'],
   },
+  alternates: {
+    canonical: '/about',
+  },
 }
 
 const features = [

--- a/apps/web/app/(public)/about/page.tsx
+++ b/apps/web/app/(public)/about/page.tsx
@@ -4,7 +4,7 @@ import styles from './page.module.css'
 import { APP_NAME, SITE_URL } from '@/lib/statics'
 
 export const metadata: Metadata = {
-  title: `${APP_NAME} | このアプリについて`,
+  title: `このアプリについて`,
   description: `${APP_NAME} は、バイクのメンテナンス管理を簡単に行うためのアプリです。バイク登録・給油記録・メンテナンス履歴の機能を紹介します。`,
   openGraph: {
     type: 'website',

--- a/apps/web/app/(public)/bikes/[id]/page.tsx
+++ b/apps/web/app/(public)/bikes/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import { prisma } from '@repo/database'
 import { createMyUserBikeId } from '@repo/shared-types'
@@ -7,9 +8,19 @@ import { PrismaMyUserBikeRepository } from '@/lib/api/server/repositories/Prisma
 import { PrismaTouringRepository } from '@/lib/api/server/repositories/PrismaTouringRepository'
 import { APP_NAME } from '@/lib/statics'
 
-export const metadata = {
-  title: `公開バイク詳細`,
-  description: `${APP_NAME}で公開されているバイクの詳細ページです。`,
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}): Promise<Metadata> {
+  const { id } = await params
+  return {
+    title: `公開バイク詳細`,
+    description: `${APP_NAME}で公開されているバイクの詳細ページです。`,
+    alternates: {
+      canonical: `/bikes/${id}`,
+    },
+  }
 }
 
 export const revalidate = 300

--- a/apps/web/app/(public)/bikes/[id]/page.tsx
+++ b/apps/web/app/(public)/bikes/[id]/page.tsx
@@ -8,7 +8,7 @@ import { PrismaTouringRepository } from '@/lib/api/server/repositories/PrismaTou
 import { APP_NAME } from '@/lib/statics'
 
 export const metadata = {
-  title: `${APP_NAME} | 公開バイク詳細`,
+  title: `公開バイク詳細`,
   description: `${APP_NAME}で公開されているバイクの詳細ページです。`,
 }
 

--- a/apps/web/app/(public)/bikes/page.tsx
+++ b/apps/web/app/(public)/bikes/page.tsx
@@ -7,6 +7,9 @@ import { APP_NAME } from '@/lib/statics'
 export const metadata = {
   title: `公開バイク一覧`,
   description: `${APP_NAME}で公開されているバイク情報の一覧です。`,
+  alternates: {
+    canonical: '/bikes',
+  },
 }
 
 export const revalidate = 300

--- a/apps/web/app/(public)/bikes/page.tsx
+++ b/apps/web/app/(public)/bikes/page.tsx
@@ -5,7 +5,7 @@ import { PrismaMyUserBikeRepository } from '@/lib/api/server/repositories/Prisma
 import { APP_NAME } from '@/lib/statics'
 
 export const metadata = {
-  title: `${APP_NAME} | 公開バイク一覧`,
+  title: `公開バイク一覧`,
   description: `${APP_NAME}で公開されているバイク情報の一覧です。`,
 }
 

--- a/apps/web/app/(public)/faq/page.tsx
+++ b/apps/web/app/(public)/faq/page.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
     description: `${APP_NAME}の使い方や機能に関するよくある質問と回答をまとめています。`,
     images: ['/top_image_1.png'],
   },
+  alternates: {
+    canonical: '/faq',
+  },
 }
 
 export default function FaqPage() {

--- a/apps/web/app/(public)/faq/page.tsx
+++ b/apps/web/app/(public)/faq/page.tsx
@@ -5,7 +5,7 @@ import { FaqAccordion } from '@/components/docs/faq/FaqAccordion'
 import { APP_NAME, SITE_URL } from '@/lib/statics'
 
 export const metadata: Metadata = {
-  title: `${APP_NAME} | よくある質問`,
+  title: `よくある質問`,
   description: `${APP_NAME}の使い方や機能に関するよくある質問と回答。バイク登録、給油記録、メンテナンス履歴の管理方法、料金プラン、データの扱いなどについて解説しています。`,
   openGraph: {
     url: `${SITE_URL}/faq`,

--- a/apps/web/app/(public)/layout.tsx
+++ b/apps/web/app/(public)/layout.tsx
@@ -12,9 +12,6 @@ export const metadata: Metadata = {
   description:
     'バイクのメンテナンス履歴・給油記録・整備スケジュールを一元管理するアプリです。',
   metadataBase: new URL(SITE_URL),
-  alternates: {
-    canonical: '/',
-  },
   keywords: [
     'バイク',
     'bike',

--- a/apps/web/app/(public)/layout.tsx
+++ b/apps/web/app/(public)/layout.tsx
@@ -2,23 +2,34 @@ import type { Metadata } from 'next'
 import './globals.css'
 import { Footer } from '@/components/docs/Footer'
 import { Navigation } from '@/components/docs/Navigation'
-import { APP_NAME } from '@/lib/statics'
+import { APP_NAME, SITE_URL } from '@/lib/statics'
 
 export const metadata: Metadata = {
   title: {
-    default: `${APP_NAME} | バイクメンテナンス・給油記録管理アプリ`,
-    template: `%s | ${APP_NAME}`,
+    default: APP_NAME,
+    template: '%s | ' + APP_NAME,
   },
   description:
     'バイクのメンテナンス履歴・給油記録・整備スケジュールを一元管理するアプリです。',
-  openGraph: {
-    type: 'website',
-    locale: 'ja_JP',
-    siteName: APP_NAME,
+  metadataBase: new URL(SITE_URL),
+  alternates: {
+    canonical: '/',
   },
-  twitter: {
-    card: 'summary_large_image',
-  },
+  keywords: [
+    'バイク',
+    'bike',
+    'モーターサイクル',
+    'motorcycle',
+    '原付',
+    'エコ',
+    '給油',
+    '燃費',
+    '整備',
+    'メンテナンス',
+    'バイク管理',
+    'ツーリング',
+    'ツーリング記録',
+  ],
 }
 
 export default function RootLayout({

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -5,7 +5,7 @@ import styles from './page.module.css'
 import { APP_NAME, APP_VERSION, SITE_URL } from '@/lib/statics'
 
 export const metadata: Metadata = {
-  title: `${APP_NAME} | バイクメンテナンス・給油記録管理アプリ`,
+  title: `バイクメンテナンス・給油記録管理アプリ`,
   description:
     'バイクのメンテナンス履歴・給油記録・整備スケジュールを一元管理。走行距離や燃費の推移をグラフで確認でき、次回メンテナンスをリマインド通知。複数台のバイク管理にも対応した無料アプリです。',
   openGraph: {

--- a/apps/web/app/(public)/page.tsx
+++ b/apps/web/app/(public)/page.tsx
@@ -32,6 +32,9 @@ export const metadata: Metadata = {
       'バイクのメンテナンス履歴・給油記録・整備スケジュールを一元管理。走行距離や燃費の推移をグラフで確認。',
     images: ['/top_image_1.png'],
   },
+  alternates: {
+    canonical: '/',
+  },
 }
 
 const features = [

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
     description: `${APP_NAME}の料金プラン。無料プランですべての基本機能をご利用いただけます。`,
     images: ['/top_image_1.png'],
   },
+  alternates: {
+    canonical: '/pricing',
+  },
 }
 
 export default function PricingPage() {

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -5,7 +5,7 @@ import { PricingCard } from '@/components/docs/pricing/PricingCard'
 import { APP_NAME, SITE_URL } from '@/lib/statics'
 
 export const metadata: Metadata = {
-  title: `${APP_NAME} | 料金プラン`,
+  title: `料金プラン`,
   description: `${APP_NAME}の料金プランをご確認いただけます。無料プランですべての基本機能(バイク登録2台まで、メンテナンス記録、給油記録)をご利用いただけます。`,
   openGraph: {
     url: `${SITE_URL}/pricing`,

--- a/apps/web/app/(public)/privacy-policy/page.tsx
+++ b/apps/web/app/(public)/privacy-policy/page.tsx
@@ -3,7 +3,7 @@ import styles from './page.module.css'
 import { APP_NAME, SITE_URL } from '@/lib/statics'
 
 export const metadata: Metadata = {
-  title: `${APP_NAME} | プライバシーポリシー`,
+  title: `プライバシーポリシー`,
   description: `${APP_NAME}のプライバシーポリシーです。取得する情報や利用目的、第三者提供の有無について説明します。`,
   openGraph: {
     url: `${SITE_URL}/privacy-policy`,

--- a/apps/web/app/(public)/privacy-policy/page.tsx
+++ b/apps/web/app/(public)/privacy-policy/page.tsx
@@ -16,6 +16,9 @@ export const metadata: Metadata = {
     description: `${APP_NAME}のプライバシーポリシーです。`,
     images: ['/top_image_1.png'],
   },
+  alternates: {
+    canonical: '/privacy-policy',
+  },
 }
 
 export default function PrivacyPolicyPage() {

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -18,9 +18,16 @@ const geistMono = localFont({
 })
 
 export const metadata: Metadata = {
-  title: APP_NAME,
-  description: 'バイクメンテナンス・給油記録管理アプリ',
+  title: {
+    default: APP_NAME,
+    template: '%s | ' + APP_NAME,
+  },
+  description:
+    'バイクのメンテナンス履歴・給油記録・整備スケジュールを一元管理するアプリです。',
   metadataBase: new URL(SITE_URL),
+  alternates: {
+    canonical: '/',
+  },
   keywords: [
     'バイク',
     'bike',

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -25,9 +25,6 @@ export const metadata: Metadata = {
   description:
     'バイクのメンテナンス履歴・給油記録・整備スケジュールを一元管理するアプリです。',
   metadataBase: new URL(SITE_URL),
-  alternates: {
-    canonical: '/',
-  },
   keywords: [
     'バイク',
     'bike',


### PR DESCRIPTION
## 概要
公開ページ（LP）における各ページのメタデータが正しく適用されていなかった問題を修正しました。
ルートレイアウトおよび公開レイアウトでのメタデータ設定を見直し、各ページで適切なタイトル・説明が反映されるようにしました。

## 変更内容

| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `app/layout.tsx` | 修正 | ルートレイアウトのメタデータ設定を修正 |
| `(public)/layout.tsx` | 修正 | 公開ページ共通レイアウトのメタデータ継承を修正 |
| `(public)/page.tsx` | 修正 | トップページのメタデータを修正 |
| `(public)/about/page.tsx` | 修正 | Aboutページのメタデータを修正 |
| `(public)/bikes/page.tsx` | 修正 | バイク一覧ページのメタデータを修正 |
| `(public)/bikes/[id]/page.tsx` | 修正 | バイク詳細ページのメタデータを修正 |
| `(public)/faq/page.tsx` | 修正 | FAQページのメタデータを修正 |
| `(public)/pricing/page.tsx` | 修正 | 料金ページのメタデータを修正 |
| `(public)/privacy-policy/page.tsx` | 修正 | プライバシーポリシーページのメタデータを修正 |

## 影響範囲
- `apps/web` の公開ページ（LP）全般のメタデータ（タイトル・説明・OGP等）

## テストプラン
- [x] 各公開ページを開き、ブラウザのタブタイトルが正しく表示されること
- [ ] OGPタグ（og:title, og:description）が各ページで正しく設定されていること
- [x] ビルドが正常に完了すること（`NODE_ENV=production pnpm build`）

Closes #226