### PR TITLE
✨ ツーリング開始・終了位置とスポット位置の編集機能を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directories:
+      - '/'
+      - '/apps/*'
+      - '/packages/*'
+    schedule:
+      interval: daily
+      timezone: 'Asia/Tokyo'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: '⬆️'
+    target-branch: 'develop'
+    groups:
+      npm-dependencies:
+        patterns:
+          - '*'
+        group-by: dependency-name

--- a/apps/web/__tests__/api/v1/userBike.test.ts
+++ b/apps/web/__tests__/api/v1/userBike.test.ts
@@ -18,6 +18,7 @@ import {
 import {
   createMultipleTourings,
   createTestTouring,
+  createTestSpot,
 } from '../../helpers/touringHelper'
 import {
   expectValidationError,
@@ -2633,6 +2634,71 @@ describe('UserBike API Endpoints', () => {
       expect(getTouringJson.data.endDate).toBe(endDate)
       expect(getTouringJson.data.endMileage).toBe(4300)
     })
+
+    test('開始・終了位置を更新できる', async () => {
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            startLatitude: 35.6895,
+            startLongitude: 139.6917,
+            endLatitude: 34.6937,
+            endLongitude: 135.5023,
+          }),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(200)
+      expect(json.data.startLatitude).toBeCloseTo(35.6895)
+      expect(json.data.startLongitude).toBeCloseTo(139.6917)
+      expect(json.data.endLatitude).toBeCloseTo(34.6937)
+      expect(json.data.endLongitude).toBeCloseTo(135.5023)
+    })
+
+    test('位置情報をnullで削除できる', async () => {
+      // まず位置情報を設定
+      await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            startLatitude: 35.6895,
+            startLongitude: 139.6917,
+          }),
+        }
+      )
+
+      // nullで削除
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            startLatitude: null,
+            startLongitude: null,
+          }),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(200)
+      expect(json.data.startLatitude).toBeNull()
+      expect(json.data.startLongitude).toBeNull()
+    })
   })
 
   describe('PATCH /api/v1/user-bike/bike/:myUserBikeId/fuel-logs', () => {
@@ -3241,6 +3307,152 @@ describe('UserBike API Endpoints', () => {
           },
           body: JSON.stringify({
             fuelLogId: otherFuelLogId,
+          }),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(404)
+      expect404Error(json)
+    })
+  })
+
+  describe('PATCH /api/v1/user-bike/bike/:myUserBikeId/tourings/:touringId/spots/:spotId', () => {
+    let token: string
+    let myUserBikeId: string
+    let touringId: string
+    let spotId: string
+
+    beforeEach(async () => {
+      const user = await createTestUser()
+      token = user.token
+
+      const bike = await createTestUserBike(token, {
+        displacement: 500,
+        nickname: 'スポット更新テスト用バイク',
+        totalMileage: 5000,
+      })
+      myUserBikeId = bike.myUserBikeId
+
+      touringId = await createTestTouring(token, myUserBikeId, {
+        title: 'スポット更新テスト用ツーリング',
+        startDate: '2024-11-01T00:00:00.000Z',
+        endDate: '2024-11-02T00:00:00.000Z',
+      })
+
+      spotId = await createTestSpot(token, myUserBikeId, touringId, {
+        visitedAt: '2024-11-01T10:00:00.000Z',
+        name: '更新前スポット',
+        memo: '更新前メモ',
+        latitude: 35.0,
+        longitude: 135.0,
+      })
+    })
+
+    test('Authorizationヘッダーが未指定の場合にエラーとなる', async () => {
+      await testAuthRequired(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}/spots/${spotId}`,
+        'PATCH',
+        { name: '更新後スポット' }
+      )
+    })
+
+    test('更新項目が指定されていない場合はバリデーションエラーとなる', async () => {
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}/spots/${spotId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({}),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(400)
+      expectValidationError(json)
+    })
+
+    test('スポットの名前とメモを更新できる', async () => {
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}/spots/${spotId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            name: '更新後スポット',
+            memo: '更新後メモ',
+          }),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(200)
+      expect(json.data.spotId).toBe(spotId)
+      expect(json.data.name).toBe('更新後スポット')
+      expect(json.data.memo).toBe('更新後メモ')
+    })
+
+    test('スポットの位置情報を更新できる', async () => {
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}/spots/${spotId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            latitude: 36.5,
+            longitude: 136.5,
+          }),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(200)
+      expect(json.data.latitude).toBeCloseTo(36.5)
+      expect(json.data.longitude).toBeCloseTo(136.5)
+    })
+
+    test('スポットの位置情報をnullで削除できる', async () => {
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}/spots/${spotId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            latitude: null,
+            longitude: null,
+          }),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(200)
+      expect(json.data.latitude).toBeNull()
+      expect(json.data.longitude).toBeNull()
+    })
+
+    test('存在しないスポットIDの場合は404となる', async () => {
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}/spots/${randomUUID()}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            name: '更新後スポット',
           }),
         }
       )

--- a/apps/web/__tests__/helpers/touringHelper.ts
+++ b/apps/web/__tests__/helpers/touringHelper.ts
@@ -1,6 +1,37 @@
 import { app } from '@/lib/api/server/app'
 
 /**
+ * テスト用スポットを作成する
+ */
+export async function createTestSpot(
+  token: string,
+  myUserBikeId: string,
+  touringId: string,
+  data: {
+    visitedAt: string
+    name?: string
+    memo?: string
+    latitude?: number
+    longitude?: number
+  }
+): Promise<string> {
+  const res = await app.request(
+    `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}/spots`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    }
+  )
+
+  const json = await res.json()
+  return json.data.spotId
+}
+
+/**
  * テスト用ツーリングを作成する
  */
 export async function createTestTouring(

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.module.css
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.module.css
@@ -64,6 +64,34 @@
   justify-content: center;
 }
 
+.startBadge {
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 9999px;
+  background-color: #10b981;
+  color: white;
+  font-size: 0.6rem;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.endBadge {
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 9999px;
+  background-color: #ef4444;
+  color: white;
+  font-size: 0.6rem;
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .link {
   color: var(--color-product);
   font-size: 0.75rem;

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.module.css
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.module.css
@@ -128,6 +128,30 @@
   overflow: hidden;
 }
 
+.mapWrapper {
+  position: relative;
+}
+
+.googleMapsLink {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: white;
+  color: #1a73e8;
+  font-size: 0.7rem;
+  font-weight: 500;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-md);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+  z-index: 1000;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.googleMapsLink:hover {
+  opacity: 0.85;
+}
+
 .mapContainerLarge {
   height: 400px;
   border-radius: var(--radius-md);

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -16,6 +16,24 @@ import { apiGet } from '@/lib/api/client'
 import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
 import { withAuth } from '@/lib/hoc/withAuth'
 
+function buildGoogleMapsUrl(points: MapPoint[]): string | null {
+  const first = points[0]
+  const last = points[points.length - 1]
+  if (!first) return null
+  if (points.length === 1) {
+    return `https://www.google.com/maps/search/?api=1&query=${first.lat},${first.lng}`
+  }
+  if (!last) return null
+  const origin = `${first.lat},${first.lng}`
+  const destination = `${last.lat},${last.lng}`
+  const waypoints = points
+    .slice(1, -1)
+    .map((p) => `${p.lat},${p.lng}`)
+    .join('|')
+  const base = `https://www.google.com/maps/dir/?api=1&origin=${origin}&destination=${destination}`
+  return waypoints ? `${base}&waypoints=${encodeURIComponent(waypoints)}` : base
+}
+
 function TouringDetailPage() {
   const params = useParams()
   const router = useRouter()
@@ -184,6 +202,7 @@ function TouringDetailPage() {
   }
 
   const hasMap = mapPoints.length > 0
+  const googleMapsUrl = buildGoogleMapsUrl(mapPoints)
 
   const startLocation =
     touring?.startLatitude != null && touring?.startLongitude != null
@@ -364,10 +383,22 @@ function TouringDetailPage() {
         <div className="w-full max-w-5xl flex flex-col md:flex-row md:gap-6 md:items-start gap-4">
           <div className="md:flex-1 min-w-0">
             <div className={`${styles.card} h-full`}>
-              <TouringRouteMap
-                points={mapPoints}
-                containerClassName={styles.mapContainerLarge}
-              />
+              <div className={styles.mapWrapper}>
+                <TouringRouteMap
+                  points={mapPoints}
+                  containerClassName={styles.mapContainerLarge}
+                />
+                {googleMapsUrl && (
+                  <a
+                    href={googleMapsUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.googleMapsLink}
+                  >
+                    Googleマップで経路を表示
+                  </a>
+                )}
+              </div>
             </div>
           </div>
           <div className="md:w-80 lg:w-96 shrink-0 space-y-4">

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -7,6 +7,7 @@ import type { ApiResponseSpotDetail } from '@repo/shared-types'
 import { Button } from '@repo/ui/button'
 import styles from './page.module.css'
 import { EditIcon } from '@/components/icons/EditIcon'
+import { SpotAddModal } from '@/components/spot/SpotAddModal'
 import { SpotEditModal } from '@/components/spot/SpotEditModal'
 import { TouringEditModal } from '@/components/touring/TouringEditModal'
 import { TouringLocationEditModal } from '@/components/touring/TouringLocationEditModal'
@@ -46,6 +47,7 @@ function TouringDetailPage() {
   const [editingSpot, setEditingSpot] = useState<ApiResponseSpotDetail | null>(
     null
   )
+  const [isAddSpotModalOpen, setIsAddSpotModalOpen] = useState(false)
 
   const {
     data: touring,
@@ -201,6 +203,16 @@ function TouringDetailPage() {
     setEditingSpot(null)
   }
 
+  const handleSpotAddSuccess = async () => {
+    await mutate(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`)
+    setIsAddSpotModalOpen(false)
+  }
+
+  const handleSpotDeleteSuccess = async () => {
+    await mutate(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`)
+    setEditingSpot(null)
+  }
+
   const hasMap = mapPoints.length > 0
   const googleMapsUrl = buildGoogleMapsUrl(mapPoints)
 
@@ -259,7 +271,16 @@ function TouringDetailPage() {
 
   const spotsCard = (
     <div className={styles.card}>
-      <h2 className="text-lg font-semibold mb-4">立ち寄りスポット</h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold">立ち寄りスポット</h2>
+        <button
+          onClick={() => setIsAddSpotModalOpen(true)}
+          className={styles.editButton}
+          aria-label="スポットを追加"
+        >
+          ＋
+        </button>
+      </div>
 
       {spotsLoading ? (
         <p className={`text-sm ${styles.mutedText}`}>読み込み中...</p>
@@ -442,6 +463,16 @@ function TouringDetailPage() {
           spot={editingSpot}
           onClose={() => setEditingSpot(null)}
           onSuccess={handleSpotEditSuccess}
+          onDelete={handleSpotDeleteSuccess}
+        />
+      )}
+
+      {isAddSpotModalOpen && (
+        <SpotAddModal
+          bikeId={bikeId}
+          touringId={touringId}
+          onClose={() => setIsAddSpotModalOpen(false)}
+          onSuccess={handleSpotAddSuccess}
         />
       )}
     </>

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -1,19 +1,35 @@
 'use client'
 
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import type { DragEndEvent } from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable'
 import { useParams, useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import useSWR, { mutate } from 'swr'
 import type { ApiResponseSpotDetail } from '@repo/shared-types'
 import { Button } from '@repo/ui/button'
+import { toast } from '@repo/ui/sonner'
 import styles from './page.module.css'
 import { EditIcon } from '@/components/icons/EditIcon'
+import { SortableSpotItem } from '@/components/spot/SortableSpotItem'
 import { SpotAddModal } from '@/components/spot/SpotAddModal'
 import { SpotEditModal } from '@/components/spot/SpotEditModal'
 import { TouringEditModal } from '@/components/touring/TouringEditModal'
 import { TouringLocationEditModal } from '@/components/touring/TouringLocationEditModal'
 import TouringRouteMap from '@/components/touring/TouringRouteMap'
 import type { MapPoint } from '@/components/touring/TouringRouteMap'
-import { apiGet } from '@/lib/api/client'
+import { apiGet, apiPatch } from '@/lib/api/client'
 import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
 import { withAuth } from '@/lib/hoc/withAuth'
 
@@ -48,6 +64,14 @@ function TouringDetailPage() {
     null
   )
   const [isAddSpotModalOpen, setIsAddSpotModalOpen] = useState(false)
+  const [localSpots, setLocalSpots] = useState<ApiResponseSpotDetail[]>([])
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 200, tolerance: 5 },
+    })
+  )
 
   const {
     data: touring,
@@ -77,6 +101,12 @@ function TouringDetailPage() {
     }
   )
 
+  useEffect(() => {
+    if (spots) {
+      setLocalSpots(spots)
+    }
+  }, [spots])
+
   const formatDate = (dateString: string) => {
     try {
       return new Date(dateString).toLocaleDateString('ja-JP', {
@@ -101,6 +131,33 @@ function TouringDetailPage() {
       })
     } catch {
       return dateString
+    }
+  }
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = localSpots.findIndex((s) => s.spotId === active.id)
+    const newIndex = localSpots.findIndex((s) => s.spotId === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+
+    const reordered = arrayMove(localSpots, oldIndex, newIndex)
+    setLocalSpots(reordered)
+
+    try {
+      await apiPatch(
+        `/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots/reorder`,
+        { spotIds: reordered.map((s) => s.spotId) }
+      )
+      await mutate(
+        `/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`
+      )
+    } catch (err) {
+      setLocalSpots(localSpots)
+      toast.error(
+        err instanceof ApiV1Error ? err.message : '並び替えに失敗しました'
+      )
     }
   }
 
@@ -153,8 +210,8 @@ function TouringDetailPage() {
     })
   }
 
-  if (spots) {
-    spots
+  if (localSpots) {
+    localSpots
       .filter(
         (s: ApiResponseSpotDetail) => s.latitude != null && s.longitude != null
       )
@@ -310,46 +367,39 @@ function TouringDetailPage() {
             </div>
           </div>
 
-          {/* 立ち寄りスポット */}
-          {spots && spots.length > 0
-            ? spots.map((spot: ApiResponseSpotDetail, index: number) => (
-                <div key={spot.spotId} className={styles.spotItem}>
-                  <div className={styles.spotBadge}>{index + 1}</div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center justify-between gap-2">
-                      <p className="font-medium text-sm truncate">
-                        {spot.name ?? '無名スポット'}
-                      </p>
-                      <div className="flex items-center gap-1 shrink-0">
-                        <span
-                          className={styles.dimText}
-                          style={{ fontSize: '0.75rem' }}
-                        >
-                          {formatVisitedAt(spot.visitedAt)}
-                        </span>
-                        <button
-                          onClick={() => setEditingSpot(spot)}
-                          className={styles.editButton}
-                          aria-label="スポットを編集"
-                        >
-                          <EditIcon />
-                        </button>
-                      </div>
-                    </div>
-                    {spot.memo && (
-                      <p
-                        className={`text-xs mt-1 wrap-break-word ${styles.mutedText}`}
-                      >
-                        {spot.memo}
-                      </p>
-                    )}
-                  </div>
+          {/* 立ち寄りスポット（DnD） */}
+          {localSpots && localSpots.length > 0 && (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+            >
+              <SortableContext
+                items={localSpots.map((s) => s.spotId)}
+                strategy={verticalListSortingStrategy}
+              >
+                <div className="space-y-3">
+                  {localSpots.map((spot, index) => (
+                    <SortableSpotItem
+                      key={spot.spotId}
+                      spot={spot}
+                      index={index}
+                      editButtonClassName={styles.editButton}
+                      spotItemClassName={styles.spotItem}
+                      spotBadgeClassName={styles.spotBadge}
+                      mutedTextClassName={styles.mutedText}
+                      dimTextClassName={styles.dimText}
+                      formatVisitedAt={formatVisitedAt}
+                      onEdit={setEditingSpot}
+                    />
+                  ))}
                 </div>
-              ))
-            : null}
+              </SortableContext>
+            </DndContext>
+          )}
 
           {/* スポットがない場合のメッセージ */}
-          {(!spots || spots.length === 0) && (
+          {(!localSpots || localSpots.length === 0) && (
             <p className={`text-sm ${styles.mutedText}`}>
               スポットはまだ記録されていません
             </p>

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -7,7 +7,9 @@ import type { ApiResponseSpotDetail } from '@repo/shared-types'
 import { Button } from '@repo/ui/button'
 import styles from './page.module.css'
 import { EditIcon } from '@/components/icons/EditIcon'
+import { SpotEditModal } from '@/components/spot/SpotEditModal'
 import { TouringEditModal } from '@/components/touring/TouringEditModal'
+import { TouringLocationEditModal } from '@/components/touring/TouringLocationEditModal'
 import TouringRouteMap from '@/components/touring/TouringRouteMap'
 import type { MapPoint } from '@/components/touring/TouringRouteMap'
 import { apiGet } from '@/lib/api/client'
@@ -20,6 +22,12 @@ function TouringDetailPage() {
   const bikeId = params.id as string
   const touringId = params.touringId as string
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
+  const [editingLocationTarget, setEditingLocationTarget] = useState<
+    'start' | 'end' | null
+  >(null)
+  const [editingSpot, setEditingSpot] = useState<ApiResponseSpotDetail | null>(
+    null
+  )
 
   const {
     data: touring,
@@ -165,7 +173,27 @@ function TouringDetailPage() {
     }
   }
 
+  const handleLocationEditSuccess = async () => {
+    await mutate(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}`)
+    setEditingLocationTarget(null)
+  }
+
+  const handleSpotEditSuccess = async () => {
+    await mutate(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`)
+    setEditingSpot(null)
+  }
+
   const hasMap = mapPoints.length > 0
+
+  const startLocation =
+    touring?.startLatitude != null && touring?.startLongitude != null
+      ? { lat: touring.startLatitude, lng: touring.startLongitude }
+      : null
+
+  const endLocation =
+    touring?.endLatitude != null && touring?.endLongitude != null
+      ? { lat: touring.endLatitude, lng: touring.endLongitude }
+      : null
 
   const touringInfoCard = (
     <div className={styles.card}>
@@ -216,37 +244,104 @@ function TouringDetailPage() {
 
       {spotsLoading ? (
         <p className={`text-sm ${styles.mutedText}`}>読み込み中...</p>
-      ) : !spots || spots.length === 0 ? (
-        <p className={`text-sm ${styles.mutedText}`}>
-          スポットはまだ記録されていません
-        </p>
       ) : (
         <div className="space-y-3">
-          {spots.map((spot: ApiResponseSpotDetail, index: number) => (
-            <div key={spot.spotId} className={styles.spotItem}>
-              <div className={styles.spotBadge}>{index + 1}</div>
+          {/* 出発地 */}
+          <div className={styles.spotItem}>
+            <div className={styles.startBadge}>出</div>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center justify-between gap-2">
+                <p className="font-medium text-sm">出発地</p>
+                <button
+                  onClick={() => setEditingLocationTarget('start')}
+                  className={styles.editButton}
+                  aria-label="出発地を編集"
+                >
+                  <EditIcon />
+                </button>
+              </div>
+              {startLocation ? (
+                <p className={`text-xs mt-1 ${styles.mutedText}`}>
+                  {startLocation.lat.toFixed(5)}, {startLocation.lng.toFixed(5)}
+                </p>
+              ) : (
+                <p className={`text-xs mt-1 ${styles.mutedText}`}>位置未設定</p>
+              )}
+            </div>
+          </div>
+
+          {/* 立ち寄りスポット */}
+          {spots && spots.length > 0
+            ? spots.map((spot: ApiResponseSpotDetail, index: number) => (
+                <div key={spot.spotId} className={styles.spotItem}>
+                  <div className={styles.spotBadge}>{index + 1}</div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="font-medium text-sm truncate">
+                        {spot.name ?? '無名スポット'}
+                      </p>
+                      <div className="flex items-center gap-1 shrink-0">
+                        <span
+                          className={styles.dimText}
+                          style={{ fontSize: '0.75rem' }}
+                        >
+                          {formatVisitedAt(spot.visitedAt)}
+                        </span>
+                        <button
+                          onClick={() => setEditingSpot(spot)}
+                          className={styles.editButton}
+                          aria-label="スポットを編集"
+                        >
+                          <EditIcon />
+                        </button>
+                      </div>
+                    </div>
+                    {spot.memo && (
+                      <p
+                        className={`text-xs mt-1 wrap-break-word ${styles.mutedText}`}
+                      >
+                        {spot.memo}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              ))
+            : null}
+
+          {/* スポットがない場合のメッセージ */}
+          {(!spots || spots.length === 0) && (
+            <p className={`text-sm ${styles.mutedText}`}>
+              スポットはまだ記録されていません
+            </p>
+          )}
+
+          {/* 終着地（COMPLETEDの場合のみ表示） */}
+          {touring?.status === 'COMPLETED' && (
+            <div className={styles.spotItem}>
+              <div className={styles.endBadge}>着</div>
               <div className="flex-1 min-w-0">
                 <div className="flex items-center justify-between gap-2">
-                  <p className="font-medium text-sm truncate">
-                    {spot.name ?? '無名スポット'}
-                  </p>
-                  <span
-                    className={`shrink-0 ${styles.dimText}`}
-                    style={{ fontSize: '0.75rem' }}
+                  <p className="font-medium text-sm">終着地</p>
+                  <button
+                    onClick={() => setEditingLocationTarget('end')}
+                    className={styles.editButton}
+                    aria-label="終着地を編集"
                   >
-                    {formatVisitedAt(spot.visitedAt)}
-                  </span>
+                    <EditIcon />
+                  </button>
                 </div>
-                {spot.memo && (
-                  <p
-                    className={`text-xs mt-1 wrap-break-word ${styles.mutedText}`}
-                  >
-                    {spot.memo}
+                {endLocation ? (
+                  <p className={`text-xs mt-1 ${styles.mutedText}`}>
+                    {endLocation.lat.toFixed(5)}, {endLocation.lng.toFixed(5)}
+                  </p>
+                ) : (
+                  <p className={`text-xs mt-1 ${styles.mutedText}`}>
+                    位置未設定
                   </p>
                 )}
               </div>
             </div>
-          ))}
+          )}
         </div>
       )}
     </div>
@@ -267,7 +362,6 @@ function TouringDetailPage() {
 
       {hasMap ? (
         <div className="w-full max-w-5xl flex flex-col md:flex-row md:gap-6 md:items-start gap-4">
-          {/* 左: マップ */}
           <div className="md:flex-1 min-w-0">
             <div className={`${styles.card} h-full`}>
               <TouringRouteMap
@@ -276,7 +370,6 @@ function TouringDetailPage() {
               />
             </div>
           </div>
-          {/* 右: 情報 + スポット */}
           <div className="md:w-80 lg:w-96 shrink-0 space-y-4">
             {touringInfoCard}
             {spotsCard}
@@ -295,6 +388,29 @@ function TouringDetailPage() {
           touringId={touringId}
           onClose={() => setIsEditModalOpen(false)}
           onSuccess={handleEditSuccess}
+        />
+      )}
+
+      {editingLocationTarget && (
+        <TouringLocationEditModal
+          bikeId={bikeId}
+          touringId={touringId}
+          type={editingLocationTarget}
+          initialLocation={
+            editingLocationTarget === 'start' ? startLocation : endLocation
+          }
+          onClose={() => setEditingLocationTarget(null)}
+          onSuccess={handleLocationEditSuccess}
+        />
+      )}
+
+      {editingSpot && (
+        <SpotEditModal
+          bikeId={bikeId}
+          touringId={touringId}
+          spot={editingSpot}
+          onClose={() => setEditingSpot(null)}
+          onSuccess={handleSpotEditSuccess}
         />
       )}
     </>

--- a/apps/web/app/app/(protected)/my-bike/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/page.tsx
@@ -11,15 +11,6 @@ function Page() {
   return (
     <>
       <div className="w-full max-w-md flex flex-row gap-2">
-        <Button
-          onClick={() => {
-            router.push('/app/home')
-          }}
-          variant="cloud"
-        >
-          ← 戻る
-        </Button>
-
         <Button onClick={() => router.push('/app/bike/register')}>
           バイクを登録
         </Button>

--- a/apps/web/app/app/(protected)/profile/page.tsx
+++ b/apps/web/app/app/(protected)/profile/page.tsx
@@ -1,8 +1,6 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
 import { BaseCard } from '@repo/ui/baseCard'
-import { Button } from '@repo/ui/button'
 import { LogoutButton } from '@/components/Navigation/LogoutButton'
 import { ProfileCard } from '@/components/ProfileCard'
 import { withAuth } from '@/lib/hoc/withAuth'
@@ -14,7 +12,6 @@ const PROVIDER_LABEL: Record<string, string> = {
 }
 
 function ProfileEditPage() {
-  const router = useRouter()
   const { user } = useAuth()
 
   const providerLabel =
@@ -24,30 +21,22 @@ function ProfileEditPage() {
       : '-'
 
   return (
-    <>
-      <div className="w-full max-w-md">
-        <Button variant="cloud" onClick={() => router.back()}>
-          ← 戻る
-        </Button>
-      </div>
-
-      <div className="w-full max-w-md flex flex-col gap-4">
-        <ProfileCard />
-        <BaseCard title="アカウント">
-          <div className="flex flex-col gap-2 text-sm mb-4">
-            <div className="flex justify-between">
-              <span className="text-gray-500">認証方式</span>
-              <span>{providerLabel}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-gray-500">メールアドレス</span>
-              <span>{user?.email ?? '-'}</span>
-            </div>
+    <div className="w-full max-w-md flex flex-col gap-4">
+      <ProfileCard />
+      <BaseCard title="アカウント">
+        <div className="flex flex-col gap-2 text-sm mb-4">
+          <div className="flex justify-between">
+            <span className="text-gray-500">認証方式</span>
+            <span>{providerLabel}</span>
           </div>
-          <LogoutButton />
-        </BaseCard>
-      </div>
-    </>
+          <div className="flex justify-between">
+            <span className="text-gray-500">メールアドレス</span>
+            <span>{user?.email ?? '-'}</span>
+          </div>
+        </div>
+        <LogoutButton />
+      </BaseCard>
+    </div>
   )
 }
 

--- a/apps/web/components/icons/DragHandleIcon.tsx
+++ b/apps/web/components/icons/DragHandleIcon.tsx
@@ -1,0 +1,3 @@
+import { GripVertical } from 'lucide-react'
+
+export const DragHandleIcon = () => <GripVertical size={16} strokeWidth={2} />

--- a/apps/web/components/map/LocationPickerMap.tsx
+++ b/apps/web/components/map/LocationPickerMap.tsx
@@ -1,0 +1,31 @@
+import dynamic from 'next/dynamic'
+
+export type LocationPickerMapProps = {
+  initialLocation?: { lat: number; lng: number }
+  onLocationChange: (lat: number, lng: number) => void
+  containerClassName?: string
+}
+
+/**
+ * クリックで地点を選択できるマップコンポーネント（SSR無効）
+ */
+const LocationPickerMap = dynamic(() => import('./LocationPickerMapInner'), {
+  ssr: false,
+  loading: () => (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100%',
+        minHeight: '200px',
+        opacity: 0.5,
+        fontSize: '0.875rem',
+      }}
+    >
+      地図を読み込み中...
+    </div>
+  ),
+})
+
+export default LocationPickerMap

--- a/apps/web/components/map/LocationPickerMapInner.tsx
+++ b/apps/web/components/map/LocationPickerMapInner.tsx
@@ -1,0 +1,137 @@
+'use client'
+
+import type L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+import { useEffect, useRef } from 'react'
+
+type Location = {
+  lat: number
+  lng: number
+}
+
+type Props = {
+  initialLocation?: Location
+  onLocationChange: (lat: number, lng: number) => void
+  containerClassName?: string
+}
+
+const DEFAULT_CENTER: Location = { lat: 36.0, lng: 138.0 }
+const DEFAULT_ZOOM = 5
+const SELECTED_ZOOM = 13
+const MARKER_COLOR = '#6366f1'
+
+/**
+ * クリックで地点を選択できるLeafletマップ
+ */
+export default function LocationPickerMapInner({
+  initialLocation,
+  onLocationChange,
+  containerClassName,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<L.Map | null>(null)
+  const markerRef = useRef<L.CircleMarker | null>(null)
+
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    const initMap = async () => {
+      const L = (await import('leaflet')).default
+
+      if (mapRef.current) {
+        mapRef.current.remove()
+        mapRef.current = null
+        markerRef.current = null
+      }
+
+      const center = initialLocation ?? DEFAULT_CENTER
+      const zoom = initialLocation ? SELECTED_ZOOM : DEFAULT_ZOOM
+
+      const map = L.map(containerRef.current!, { zoomControl: true })
+      mapRef.current = map
+
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+        maxZoom: 18,
+      }).addTo(map)
+
+      map.setView([center.lat, center.lng], zoom)
+
+      if (initialLocation) {
+        markerRef.current = L.circleMarker(
+          [initialLocation.lat, initialLocation.lng],
+          {
+            radius: 9,
+            fillColor: MARKER_COLOR,
+            color: '#fff',
+            weight: 2,
+            opacity: 1,
+            fillOpacity: 0.9,
+          }
+        ).addTo(map)
+      }
+
+      map.on('click', (e: L.LeafletMouseEvent) => {
+        const { lat, lng } = e.latlng
+
+        if (markerRef.current) {
+          markerRef.current.setLatLng([lat, lng])
+        } else {
+          markerRef.current = L.circleMarker([lat, lng], {
+            radius: 9,
+            fillColor: MARKER_COLOR,
+            color: '#fff',
+            weight: 2,
+            opacity: 1,
+            fillOpacity: 0.9,
+          }).addTo(map)
+        }
+
+        onLocationChange(lat, lng)
+      })
+    }
+
+    initMap()
+
+    return () => {
+      if (mapRef.current) {
+        mapRef.current.remove()
+        mapRef.current = null
+        markerRef.current = null
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // 外部から初期位置が変わった場合（現在地取得など）にマーカーを更新
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map || !initialLocation) return
+
+    if (markerRef.current) {
+      markerRef.current.setLatLng([initialLocation.lat, initialLocation.lng])
+    } else {
+      import('leaflet').then(({ default: L }) => {
+        markerRef.current = L.circleMarker(
+          [initialLocation.lat, initialLocation.lng],
+          {
+            radius: 9,
+            fillColor: MARKER_COLOR,
+            color: '#fff',
+            weight: 2,
+            opacity: 1,
+            fillOpacity: 0.9,
+          }
+        ).addTo(map)
+      })
+    }
+
+    map.setView(
+      [initialLocation.lat, initialLocation.lng],
+      Math.max(map.getZoom(), SELECTED_ZOOM)
+    )
+  }, [initialLocation])
+
+  return <div ref={containerRef} className={containerClassName} />
+}

--- a/apps/web/components/map/LocationPickerModal.tsx
+++ b/apps/web/components/map/LocationPickerModal.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { useState } from 'react'
+import LocationPickerMap from './LocationPickerMap'
+import { XIcon } from '@/components/icons/XIcon'
+import styles from '@/components/touring/TouringEditModal.module.css'
+import { useGeolocation } from '@/lib/hooks/useGeolocation'
+
+type Location = {
+  lat: number
+  lng: number
+}
+
+type LocationPickerModalProps = {
+  title: string
+  initialLocation: Location | null
+  isSaving: boolean
+  onLocationSaved: (lat: number, lng: number) => void
+  onClose: () => void
+}
+
+/**
+ * 位置編集専用モーダル。マップをクリックすると即時保存する。
+ */
+export function LocationPickerModal({
+  title,
+  initialLocation,
+  isSaving,
+  onLocationSaved,
+  onClose,
+}: LocationPickerModalProps) {
+  const [currentLocation, setCurrentLocation] = useState<Location | null>(
+    initialLocation
+  )
+  const [isGettingLocation, setIsGettingLocation] = useState(false)
+
+  const { getCurrentPosition } = useGeolocation()
+
+  const handleLocationChange = (lat: number, lng: number) => {
+    const loc = { lat, lng }
+    setCurrentLocation(loc)
+    onLocationSaved(lat, lng)
+  }
+
+  const handleGetCurrentLocation = async () => {
+    setIsGettingLocation(true)
+    const result = await getCurrentPosition()
+    setIsGettingLocation(false)
+
+    if (result.denied) {
+      return
+    }
+    if (!result.position) {
+      return
+    }
+
+    const loc = {
+      lat: result.position.latitude,
+      lng: result.position.longitude,
+    }
+    setCurrentLocation(loc)
+    onLocationSaved(loc.lat, loc.lng)
+  }
+
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <h2 className="text-lg font-semibold">{title}</h2>
+          <button
+            onClick={onClose}
+            className={styles.closeButton}
+            aria-label="閉じる"
+          >
+            <XIcon />
+          </button>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="text-xs opacity-50">
+              {currentLocation
+                ? `${currentLocation.lat.toFixed(5)}, ${currentLocation.lng.toFixed(5)}`
+                : '未設定'}
+              {isSaving && ' — 保存中...'}
+            </p>
+            <button
+              type="button"
+              onClick={handleGetCurrentLocation}
+              disabled={isGettingLocation || isSaving}
+              className="text-xs border rounded px-2 py-1 disabled:opacity-50"
+            >
+              {isGettingLocation ? '取得中...' : '現在地を使用'}
+            </button>
+          </div>
+
+          <p className="text-xs opacity-40">
+            地図をクリックして位置を設定できます
+          </p>
+
+          <div
+            className="border rounded overflow-hidden"
+            style={{ height: 320 }}
+          >
+            <LocationPickerMap
+              initialLocation={currentLocation ?? undefined}
+              onLocationChange={handleLocationChange}
+              containerClassName="w-full h-full"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/spot/SortableSpotItem.tsx
+++ b/apps/web/components/spot/SortableSpotItem.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import type { ApiResponseSpotDetail } from '@repo/shared-types'
+import { DragHandleIcon } from '@/components/icons/DragHandleIcon'
+import { EditIcon } from '@/components/icons/EditIcon'
+
+type SortableSpotItemProps = {
+  spot: ApiResponseSpotDetail
+  index: number
+  editButtonClassName: string | undefined
+  spotItemClassName: string | undefined
+  spotBadgeClassName: string | undefined
+  mutedTextClassName: string | undefined
+  dimTextClassName: string | undefined
+  formatVisitedAt: (dateString: string) => string
+  onEdit: (spot: ApiResponseSpotDetail) => void
+}
+
+/**
+ * ドラッグ可能なスポット行コンポーネント
+ */
+export function SortableSpotItem({
+  spot,
+  index,
+  editButtonClassName,
+  spotItemClassName,
+  spotBadgeClassName,
+  mutedTextClassName,
+  dimTextClassName,
+  formatVisitedAt,
+  onEdit,
+}: SortableSpotItemProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: spot.spotId })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+
+  return (
+    <div ref={setNodeRef} style={style} className={spotItemClassName}>
+      <button
+        {...attributes}
+        {...listeners}
+        className={`${editButtonClassName} cursor-grab active:cursor-grabbing shrink-0`}
+        aria-label="ドラッグして並び替え"
+      >
+        <DragHandleIcon />
+      </button>
+      <div className={spotBadgeClassName}>{index + 1}</div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between gap-2">
+          <p className="font-medium text-sm truncate">
+            {spot.name ?? '無名スポット'}
+          </p>
+          <div className="flex items-center gap-1 shrink-0">
+            <span className={dimTextClassName} style={{ fontSize: '0.75rem' }}>
+              {formatVisitedAt(spot.visitedAt)}
+            </span>
+            <button
+              onClick={() => onEdit(spot)}
+              className={editButtonClassName}
+              aria-label="スポットを編集"
+            >
+              <EditIcon />
+            </button>
+          </div>
+        </div>
+        {spot.memo && (
+          <p className={`text-xs mt-1 wrap-break-word ${mutedTextClassName}`}>
+            {spot.memo}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/spot/SpotAddForm.tsx
+++ b/apps/web/components/spot/SpotAddForm.tsx
@@ -1,0 +1,170 @@
+'use client'
+
+import { useState } from 'react'
+import { mutate } from 'swr'
+import { Button } from '@repo/ui/button'
+import { FormField } from '@repo/ui/formField'
+import { Input } from '@repo/ui/input'
+import { toast } from '@repo/ui/sonner'
+import { Textarea } from '@repo/ui/textarea'
+import { LocationPickerModal } from '@/components/map/LocationPickerModal'
+import { apiPost } from '@/lib/api/client'
+import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
+
+type SpotAddFormProps = {
+  bikeId: string
+  touringId: string
+  onSuccess: () => void
+}
+
+type SpotFormState = {
+  name: string
+  memo: string
+  visitedAt: string
+}
+
+const getNowLocalString = () => {
+  const now = new Date()
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`
+}
+
+/**
+ * スポット追加フォーム
+ */
+export function SpotAddForm({
+  bikeId,
+  touringId,
+  onSuccess,
+}: SpotAddFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState('')
+  const [isLocationModalOpen, setIsLocationModalOpen] = useState(false)
+  const [location, setLocation] = useState<{ lat: number; lng: number } | null>(
+    null
+  )
+  const [formState, setFormState] = useState<SpotFormState>({
+    name: '',
+    memo: '',
+    visitedAt: getNowLocalString(),
+  })
+
+  const handleLocationSaved = (lat: number, lng: number) => {
+    setLocation({ lat, lng })
+    setIsLocationModalOpen(false)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setIsSubmitting(true)
+
+    try {
+      await apiPost(
+        `/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`,
+        {
+          name: formState.name !== '' ? formState.name : undefined,
+          memo: formState.memo !== '' ? formState.memo : undefined,
+          visitedAt: new Date(formState.visitedAt),
+          latitude: location?.lat,
+          longitude: location?.lng,
+        }
+      )
+
+      await mutate(
+        `/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`
+      )
+      toast.success('スポットを追加しました')
+      onSuccess()
+    } catch (err) {
+      setError(err instanceof ApiV1Error ? err.message : 'エラーが発生しました')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <FormField label="スポット名" htmlFor="spotName">
+          <Input
+            id="spotName"
+            type="text"
+            value={formState.name}
+            onChange={(e) =>
+              setFormState((prev) => ({ ...prev, name: e.target.value }))
+            }
+            maxLength={100}
+            placeholder="スポット名（任意）"
+            disabled={isSubmitting}
+          />
+        </FormField>
+
+        <FormField label="メモ" htmlFor="spotMemo">
+          <Textarea
+            id="spotMemo"
+            value={formState.memo}
+            onChange={(e) =>
+              setFormState((prev) => ({ ...prev, memo: e.target.value }))
+            }
+            maxLength={500}
+            rows={3}
+            placeholder="メモ（任意）"
+            disabled={isSubmitting}
+          />
+        </FormField>
+
+        <FormField label="訪問日時" htmlFor="spotVisitedAt">
+          <Input
+            id="spotVisitedAt"
+            type="datetime-local"
+            value={formState.visitedAt}
+            onChange={(e) =>
+              setFormState((prev) => ({ ...prev, visitedAt: e.target.value }))
+            }
+            disabled={isSubmitting}
+          />
+        </FormField>
+
+        <FormField label="位置">
+          <div className="flex items-center gap-2">
+            <p className="text-xs opacity-60 flex-1">
+              {location
+                ? `${location.lat.toFixed(5)}, ${location.lng.toFixed(5)}`
+                : '未設定'}
+            </p>
+            <Button
+              type="button"
+              variant="cloud"
+              size="sm"
+              onClick={() => setIsLocationModalOpen(true)}
+            >
+              地図で設定
+            </Button>
+          </div>
+        </FormField>
+
+        {error && <p className="text-sm text-red-500">{error}</p>}
+
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          fullWidth
+          loading={isSubmitting}
+        >
+          登録する
+        </Button>
+      </form>
+
+      {isLocationModalOpen && (
+        <LocationPickerModal
+          title="位置を設定"
+          initialLocation={location}
+          isSaving={false}
+          onLocationSaved={handleLocationSaved}
+          onClose={() => setIsLocationModalOpen(false)}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/web/components/spot/SpotAddModal.tsx
+++ b/apps/web/components/spot/SpotAddModal.tsx
@@ -1,35 +1,30 @@
 'use client'
 
-import type { ApiResponseSpotDetail } from '@repo/shared-types'
-import { SpotEditForm } from './SpotEditForm'
+import { SpotAddForm } from './SpotAddForm'
 import { XIcon } from '@/components/icons/XIcon'
 import styles from '@/components/touring/TouringEditModal.module.css'
 
-interface SpotEditModalProps {
+type SpotAddModalProps = {
   bikeId: string
   touringId: string
-  spot: ApiResponseSpotDetail
   onClose: () => void
   onSuccess: () => void
-  onDelete?: () => void
 }
 
 /**
- * スポット編集モーダル
+ * スポット追加モーダル
  */
-export function SpotEditModal({
+export function SpotAddModal({
   bikeId,
   touringId,
-  spot,
   onClose,
   onSuccess,
-  onDelete,
-}: SpotEditModalProps) {
+}: SpotAddModalProps) {
   return (
     <div className={styles.overlay} onClick={onClose}>
       <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
         <div className={styles.header}>
-          <h2 className="text-lg font-semibold">スポットを編集</h2>
+          <h2 className="text-lg font-semibold">スポットを追加</h2>
           <button
             onClick={onClose}
             className={styles.closeButton}
@@ -38,12 +33,10 @@ export function SpotEditModal({
             <XIcon />
           </button>
         </div>
-        <SpotEditForm
+        <SpotAddForm
           bikeId={bikeId}
           touringId={touringId}
-          spot={spot}
           onSuccess={onSuccess}
-          onDelete={onDelete}
         />
       </div>
     </div>

--- a/apps/web/components/spot/SpotDeleteConfirmModal.tsx
+++ b/apps/web/components/spot/SpotDeleteConfirmModal.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { Button } from '@repo/ui/button'
+import { XIcon } from '@/components/icons/XIcon'
+import styles from '@/components/touring/TouringDeleteConfirmModal.module.css'
+
+type SpotDeleteConfirmModalProps = {
+  onCancel: () => void
+  onConfirm: () => void
+}
+
+/**
+ * スポット削除確認モーダル
+ */
+export function SpotDeleteConfirmModal({
+  onCancel,
+  onConfirm,
+}: SpotDeleteConfirmModalProps) {
+  return (
+    <div className={styles.overlay} onClick={onCancel}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <h2 className="text-lg font-semibold">削除の確認</h2>
+          <button
+            onClick={onCancel}
+            className={styles.closeButton}
+            aria-label="閉じる"
+          >
+            <XIcon />
+          </button>
+        </div>
+        <p className={styles.message}>
+          このスポットを削除しますか？この操作は取り消せません。
+        </p>
+        <div className={styles.actions}>
+          <Button onClick={onCancel} variant="cloud">
+            キャンセル
+          </Button>
+          <Button onClick={onConfirm} variant="danger">
+            削除
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/spot/SpotEditForm.tsx
+++ b/apps/web/components/spot/SpotEditForm.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { mutate } from 'swr'
+import type { ApiResponseSpotDetail } from '@repo/shared-types'
+import { toast } from '@repo/ui/sonner'
+import { LocationPickerModal } from '@/components/map/LocationPickerModal'
+import { apiPatch } from '@/lib/api/client'
+import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
+
+interface SpotEditFormProps {
+  bikeId: string
+  touringId: string
+  spot: ApiResponseSpotDetail
+  onSuccess: () => void
+}
+
+type SpotFormState = {
+  name: string
+  memo: string
+  visitedAt: string
+}
+
+/**
+ * スポット編集フォーム
+ */
+export function SpotEditForm({
+  bikeId,
+  touringId,
+  spot,
+  onSuccess,
+}: SpotEditFormProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isSavingLocation, setIsSavingLocation] = useState(false)
+  const [error, setError] = useState('')
+  const [isLocationModalOpen, setIsLocationModalOpen] = useState(false)
+  const [currentLocation, setCurrentLocation] = useState<{
+    lat: number
+    lng: number
+  } | null>(null)
+  const [formState, setFormState] = useState<SpotFormState>({
+    name: '',
+    memo: '',
+    visitedAt: '',
+  })
+
+  useEffect(() => {
+    const visitedAtLocal = new Date(spot.visitedAt)
+    const pad = (n: number) => String(n).padStart(2, '0')
+    const visitedAtStr = `${visitedAtLocal.getFullYear()}-${pad(visitedAtLocal.getMonth() + 1)}-${pad(visitedAtLocal.getDate())}T${pad(visitedAtLocal.getHours())}:${pad(visitedAtLocal.getMinutes())}`
+
+    setFormState({
+      name: spot.name ?? '',
+      memo: spot.memo ?? '',
+      visitedAt: visitedAtStr,
+    })
+
+    if (spot.latitude != null && spot.longitude != null) {
+      setCurrentLocation({ lat: spot.latitude, lng: spot.longitude })
+    }
+  }, [spot])
+
+  const handleLocationSaved = async (lat: number, lng: number) => {
+    if (isSavingLocation) return
+    setIsSavingLocation(true)
+
+    try {
+      await apiPatch(
+        `/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots/${spot.spotId}`,
+        { latitude: lat, longitude: lng }
+      )
+      setCurrentLocation({ lat, lng })
+      await mutate(
+        `/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`
+      )
+      toast.success('位置を更新しました')
+    } catch (err) {
+      toast.error(
+        err instanceof ApiV1Error ? err.message : '位置の保存に失敗しました'
+      )
+    } finally {
+      setIsSavingLocation(false)
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setIsSubmitting(true)
+
+    try {
+      await apiPatch(
+        `/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots/${spot.spotId}`,
+        {
+          name: formState.name !== '' ? formState.name : null,
+          memo: formState.memo !== '' ? formState.memo : null,
+          visitedAt: new Date(formState.visitedAt),
+        }
+      )
+
+      await mutate(
+        `/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`
+      )
+      toast.success('スポットを更新しました')
+      onSuccess()
+    } catch (err) {
+      setError(err instanceof ApiV1Error ? err.message : 'エラーが発生しました')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-1">スポット名</label>
+          <input
+            type="text"
+            value={formState.name}
+            onChange={(e) =>
+              setFormState((prev) => ({ ...prev, name: e.target.value }))
+            }
+            maxLength={100}
+            placeholder="スポット名（任意）"
+            className="w-full border rounded px-3 py-2 text-sm"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">メモ</label>
+          <textarea
+            value={formState.memo}
+            onChange={(e) =>
+              setFormState((prev) => ({ ...prev, memo: e.target.value }))
+            }
+            maxLength={500}
+            rows={3}
+            placeholder="メモ（任意）"
+            className="w-full border rounded px-3 py-2 text-sm resize-none"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">訪問日時</label>
+          <input
+            type="datetime-local"
+            value={formState.visitedAt}
+            onChange={(e) =>
+              setFormState((prev) => ({ ...prev, visitedAt: e.target.value }))
+            }
+            className="w-full border rounded px-3 py-2 text-sm"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">位置</label>
+          <div className="flex items-center gap-2">
+            <p className="text-xs opacity-60 flex-1">
+              {currentLocation
+                ? `${currentLocation.lat.toFixed(5)}, ${currentLocation.lng.toFixed(5)}`
+                : '未設定'}
+            </p>
+            <button
+              type="button"
+              onClick={() => setIsLocationModalOpen(true)}
+              className="text-xs border rounded px-2 py-1"
+            >
+              地図で変更
+            </button>
+          </div>
+        </div>
+
+        {error && <p className="text-sm text-red-500">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full border rounded px-4 py-2 text-sm font-medium disabled:opacity-50"
+        >
+          {isSubmitting ? '更新中...' : '更新する'}
+        </button>
+      </form>
+
+      {isLocationModalOpen && (
+        <LocationPickerModal
+          title="位置を設定"
+          initialLocation={currentLocation}
+          isSaving={isSavingLocation}
+          onLocationSaved={handleLocationSaved}
+          onClose={() => setIsLocationModalOpen(false)}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/web/components/spot/SpotEditForm.tsx
+++ b/apps/web/components/spot/SpotEditForm.tsx
@@ -3,9 +3,14 @@
 import { useState, useEffect } from 'react'
 import { mutate } from 'swr'
 import type { ApiResponseSpotDetail } from '@repo/shared-types'
+import { Button } from '@repo/ui/button'
+import { FormField } from '@repo/ui/formField'
+import { Input } from '@repo/ui/input'
 import { toast } from '@repo/ui/sonner'
+import { Textarea } from '@repo/ui/textarea'
 import { LocationPickerModal } from '@/components/map/LocationPickerModal'
-import { apiPatch } from '@/lib/api/client'
+import { SpotDeleteConfirmModal } from '@/components/spot/SpotDeleteConfirmModal'
+import { apiDelete, apiPatch } from '@/lib/api/client'
 import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
 
 interface SpotEditFormProps {
@@ -13,6 +18,7 @@ interface SpotEditFormProps {
   touringId: string
   spot: ApiResponseSpotDetail
   onSuccess: () => void
+  onDelete?: () => void
 }
 
 type SpotFormState = {
@@ -29,11 +35,14 @@ export function SpotEditForm({
   touringId,
   spot,
   onSuccess,
+  onDelete,
 }: SpotEditFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
   const [isSavingLocation, setIsSavingLocation] = useState(false)
   const [error, setError] = useState('')
   const [isLocationModalOpen, setIsLocationModalOpen] = useState(false)
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [currentLocation, setCurrentLocation] = useState<{
     lat: number
     lng: number
@@ -83,6 +92,27 @@ export function SpotEditForm({
     }
   }
 
+  const handleDeleteConfirm = async () => {
+    setIsDeleting(true)
+    try {
+      await apiDelete(
+        `/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots/${spot.spotId}`
+      )
+      await mutate(
+        `/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`
+      )
+      toast.success('スポットを削除しました')
+      onDelete?.()
+    } catch (err) {
+      toast.error(
+        err instanceof ApiV1Error ? err.message : 'スポットの削除に失敗しました'
+      )
+    } finally {
+      setIsDeleting(false)
+      setIsDeleteModalOpen(false)
+    }
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
@@ -113,9 +143,9 @@ export function SpotEditForm({
   return (
     <>
       <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label className="block text-sm font-medium mb-1">スポット名</label>
-          <input
+        <FormField label="スポット名" htmlFor="spotName">
+          <Input
+            id="spotName"
             type="text"
             value={formState.name}
             onChange={(e) =>
@@ -123,13 +153,13 @@ export function SpotEditForm({
             }
             maxLength={100}
             placeholder="スポット名（任意）"
-            className="w-full border rounded px-3 py-2 text-sm"
+            disabled={isSubmitting}
           />
-        </div>
+        </FormField>
 
-        <div>
-          <label className="block text-sm font-medium mb-1">メモ</label>
-          <textarea
+        <FormField label="メモ" htmlFor="spotMemo">
+          <Textarea
+            id="spotMemo"
             value={formState.memo}
             onChange={(e) =>
               setFormState((prev) => ({ ...prev, memo: e.target.value }))
@@ -137,50 +167,71 @@ export function SpotEditForm({
             maxLength={500}
             rows={3}
             placeholder="メモ（任意）"
-            className="w-full border rounded px-3 py-2 text-sm resize-none"
+            disabled={isSubmitting}
           />
-        </div>
+        </FormField>
 
-        <div>
-          <label className="block text-sm font-medium mb-1">訪問日時</label>
-          <input
+        <FormField label="訪問日時" htmlFor="spotVisitedAt">
+          <Input
+            id="spotVisitedAt"
             type="datetime-local"
             value={formState.visitedAt}
             onChange={(e) =>
               setFormState((prev) => ({ ...prev, visitedAt: e.target.value }))
             }
-            className="w-full border rounded px-3 py-2 text-sm"
+            disabled={isSubmitting}
           />
-        </div>
+        </FormField>
 
-        <div>
-          <label className="block text-sm font-medium mb-1">位置</label>
+        <FormField label="位置">
           <div className="flex items-center gap-2">
             <p className="text-xs opacity-60 flex-1">
               {currentLocation
                 ? `${currentLocation.lat.toFixed(5)}, ${currentLocation.lng.toFixed(5)}`
                 : '未設定'}
             </p>
-            <button
+            <Button
               type="button"
+              variant="cloud"
+              size="sm"
               onClick={() => setIsLocationModalOpen(true)}
-              className="text-xs border rounded px-2 py-1"
             >
               地図で変更
-            </button>
+            </Button>
           </div>
-        </div>
+        </FormField>
 
         {error && <p className="text-sm text-red-500">{error}</p>}
 
-        <button
+        <Button
           type="submit"
           disabled={isSubmitting}
-          className="w-full border rounded px-4 py-2 text-sm font-medium disabled:opacity-50"
+          fullWidth
+          loading={isSubmitting}
         >
-          {isSubmitting ? '更新中...' : '更新する'}
-        </button>
+          更新する
+        </Button>
+
+        {onDelete && (
+          <Button
+            type="button"
+            variant="danger"
+            fullWidth
+            disabled={isDeleting}
+            loading={isDeleting}
+            onClick={() => setIsDeleteModalOpen(true)}
+          >
+            削除する
+          </Button>
+        )}
       </form>
+
+      {isDeleteModalOpen && (
+        <SpotDeleteConfirmModal
+          onCancel={() => setIsDeleteModalOpen(false)}
+          onConfirm={handleDeleteConfirm}
+        />
+      )}
 
       {isLocationModalOpen && (
         <LocationPickerModal

--- a/apps/web/components/spot/SpotEditModal.tsx
+++ b/apps/web/components/spot/SpotEditModal.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import type { ApiResponseSpotDetail } from '@repo/shared-types'
+import { SpotEditForm } from './SpotEditForm'
+import { XIcon } from '@/components/icons/XIcon'
+import styles from '@/components/touring/TouringEditModal.module.css'
+
+interface SpotEditModalProps {
+  bikeId: string
+  touringId: string
+  spot: ApiResponseSpotDetail
+  onClose: () => void
+  onSuccess: () => void
+}
+
+/**
+ * スポット編集モーダル
+ */
+export function SpotEditModal({
+  bikeId,
+  touringId,
+  spot,
+  onClose,
+  onSuccess,
+}: SpotEditModalProps) {
+  return (
+    <div className={styles.overlay} onClick={onClose}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <h2 className="text-lg font-semibold">スポットを編集</h2>
+          <button
+            onClick={onClose}
+            className={styles.closeButton}
+            aria-label="閉じる"
+          >
+            <XIcon />
+          </button>
+        </div>
+        <SpotEditForm
+          bikeId={bikeId}
+          touringId={touringId}
+          spot={spot}
+          onSuccess={onSuccess}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/components/touring/TouringLocationEditModal.tsx
+++ b/apps/web/components/touring/TouringLocationEditModal.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useState } from 'react'
+import { mutate } from 'swr'
+import { toast } from '@repo/ui/sonner'
+import { LocationPickerModal } from '@/components/map/LocationPickerModal'
+import { apiPatch } from '@/lib/api/client'
+import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
+
+type LocationType = 'start' | 'end'
+
+interface TouringLocationEditModalProps {
+  bikeId: string
+  touringId: string
+  type: LocationType
+  initialLocation: { lat: number; lng: number } | null
+  onClose: () => void
+  onSuccess: () => void
+}
+
+/**
+ * ツーリング開始・終了位置の編集モーダル。マップクリックで即時保存する。
+ */
+export function TouringLocationEditModal({
+  bikeId,
+  touringId,
+  type,
+  initialLocation,
+  onClose,
+  onSuccess,
+}: TouringLocationEditModalProps) {
+  const [isSaving, setIsSaving] = useState(false)
+
+  const title = type === 'start' ? '出発地を設定' : '終着地を設定'
+
+  const handleLocationSaved = async (lat: number, lng: number) => {
+    if (isSaving) return
+    setIsSaving(true)
+
+    const body =
+      type === 'start'
+        ? { startLatitude: lat, startLongitude: lng }
+        : { endLatitude: lat, endLongitude: lng }
+
+    try {
+      await apiPatch(
+        `/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}`,
+        body
+      )
+      await mutate(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}`)
+      toast.success(`${type === 'start' ? '出発地' : '終着地'}を更新しました`)
+      onSuccess()
+    } catch (err) {
+      toast.error(
+        err instanceof ApiV1Error ? err.message : '保存に失敗しました'
+      )
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <LocationPickerModal
+      title={title}
+      initialLocation={initialLocation}
+      isSaving={isSaving}
+      onLocationSaved={handleLocationSaved}
+      onClose={onClose}
+    />
+  )
+}

--- a/apps/web/global.d.ts
+++ b/apps/web/global.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css'

--- a/apps/web/lib/api/server/entities/SpotEntity.ts
+++ b/apps/web/lib/api/server/entities/SpotEntity.ts
@@ -46,6 +46,10 @@ export class SpotEntity {
     return this._value.visitedAt
   }
 
+  public get sortOrder(): number {
+    return this._value.sortOrder
+  }
+
   public toJson(): Spot {
     return this._value
   }

--- a/apps/web/lib/api/server/interfaces/ISpotRepository.ts
+++ b/apps/web/lib/api/server/interfaces/ISpotRepository.ts
@@ -7,4 +7,5 @@ export interface ISpotRepository {
   findSpotById(spotId: SpotId, touringId: TouringId): Promise<SpotEntity | null>
   updateSpot(spot: SpotEntity): Promise<SpotEntity>
   deleteSpot(spotId: SpotId, touringId: TouringId): Promise<void>
+  reorderSpots(spotIds: SpotId[], touringId: TouringId): Promise<void>
 }

--- a/apps/web/lib/api/server/repositories/PrismaSpotRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaSpotRepository.ts
@@ -1,3 +1,4 @@
+import { PrismaClient } from '@repo/database'
 import {
   createSpotId,
   createTouringId,
@@ -13,6 +14,10 @@ export class PrismaSpotRepository
   implements ISpotRepository
 {
   async createSpot(spot: SpotEntity): Promise<SpotEntity> {
+    const count = await this.connection.tUserMyBikeTouringSpot.count({
+      where: { touringId: spot.touringId },
+    })
+
     const created = await this.connection.tUserMyBikeTouringSpot.create({
       data: {
         touringId: spot.touringId,
@@ -21,6 +26,7 @@ export class PrismaSpotRepository
         latitude: spot.latitude,
         longitude: spot.longitude,
         visitedAt: spot.visitedAt,
+        sortOrder: count,
       },
       select: {
         id: true,
@@ -30,6 +36,7 @@ export class PrismaSpotRepository
         latitude: true,
         longitude: true,
         visitedAt: true,
+        sortOrder: true,
       },
     })
 
@@ -41,6 +48,7 @@ export class PrismaSpotRepository
       latitude: created.latitude,
       longitude: created.longitude,
       visitedAt: created.visitedAt,
+      sortOrder: created.sortOrder,
     })
   }
 
@@ -57,9 +65,10 @@ export class PrismaSpotRepository
         latitude: true,
         longitude: true,
         visitedAt: true,
+        sortOrder: true,
       },
       orderBy: {
-        visitedAt: 'asc',
+        sortOrder: 'asc',
       },
     })
 
@@ -73,6 +82,7 @@ export class PrismaSpotRepository
           latitude: spot.latitude,
           longitude: spot.longitude,
           visitedAt: spot.visitedAt,
+          sortOrder: spot.sortOrder,
         })
     )
   }
@@ -94,6 +104,7 @@ export class PrismaSpotRepository
         latitude: true,
         longitude: true,
         visitedAt: true,
+        sortOrder: true,
       },
     })
 
@@ -109,6 +120,7 @@ export class PrismaSpotRepository
       latitude: spot.latitude,
       longitude: spot.longitude,
       visitedAt: spot.visitedAt,
+      sortOrder: spot.sortOrder,
     })
   }
 
@@ -132,6 +144,7 @@ export class PrismaSpotRepository
         latitude: true,
         longitude: true,
         visitedAt: true,
+        sortOrder: true,
       },
     })
 
@@ -143,6 +156,7 @@ export class PrismaSpotRepository
       latitude: updated.latitude,
       longitude: updated.longitude,
       visitedAt: updated.visitedAt,
+      sortOrder: updated.sortOrder,
     })
   }
 
@@ -153,5 +167,16 @@ export class PrismaSpotRepository
         touringId,
       },
     })
+  }
+
+  async reorderSpots(spotIds: SpotId[]): Promise<void> {
+    await (this.connection as PrismaClient).$transaction(
+      spotIds.map((spotId, index) =>
+        this.connection.tUserMyBikeTouringSpot.update({
+          where: { id: spotId },
+          data: { sortOrder: index },
+        })
+      )
+    )
   }
 }

--- a/apps/web/lib/api/server/services/SpotService.ts
+++ b/apps/web/lib/api/server/services/SpotService.ts
@@ -5,6 +5,7 @@ import {
   TouringId,
   UserId,
 } from '@repo/shared-types'
+import type { SpotReorderRequest } from '@repo/shared-types'
 import { SpotEntity } from '../entities/SpotEntity'
 import { ApiV1Error } from '../errors/ApiV1Error'
 import { IMyUserBikeRepository } from '../interfaces/IMyUserBikeRepository'
@@ -69,6 +70,7 @@ export class SpotService {
         latitude: params.latitude ?? null,
         longitude: params.longitude ?? null,
         visitedAt: params.visitedAt ?? new Date(),
+        sortOrder: 0, // createSpot でカウントして末尾に設定される
       })
 
       return await this.spotRepository.createSpot(spot)
@@ -149,6 +151,7 @@ export class SpotService {
             ? params.longitude
             : existingSpot.longitude,
         visitedAt: params.visitedAt ?? existingSpot.visitedAt,
+        sortOrder: existingSpot.sortOrder,
       })
 
       return await this.spotRepository.updateSpot(updatedSpot)
@@ -194,5 +197,35 @@ export class SpotService {
     }
 
     await this.spotRepository.deleteSpot(spotId, touringId)
+  }
+
+  public async reorderSpots(
+    spotIds: SpotReorderRequest['spotIds'],
+    touringId: TouringId,
+    myUserBikeId: MyUserBikeId,
+    userId: UserId
+  ): Promise<void> {
+    const myUserBike = await this.myUserBikeRepository.findMyUserBikeById(
+      myUserBikeId,
+      userId
+    )
+
+    if (!myUserBike) {
+      throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
+    }
+
+    const touring = await this.touringRepository.findTouringById(
+      touringId,
+      myUserBikeId
+    )
+
+    if (!touring) {
+      throw new ApiV1Error('NOT_FOUND', '指定されたツーリングが見つかりません')
+    }
+
+    await this.spotRepository.reorderSpots(
+      spotIds.map((id) => createSpotId(id)),
+      touringId
+    )
   }
 }

--- a/apps/web/lib/api/server/services/TouringService.ts
+++ b/apps/web/lib/api/server/services/TouringService.ts
@@ -60,6 +60,10 @@ type UpdateTouringParams = {
   endMileage?: number
   status?: TouringStatus
   fuelLogIds?: FuelLogId[]
+  startLatitude?: number | null
+  startLongitude?: number | null
+  endLatitude?: number | null
+  endLongitude?: number | null
 }
 
 export class TouringService {
@@ -312,10 +316,22 @@ export class TouringService {
         endDate: params.endDate ?? existingTouring.endDate,
         startMileage: params.startMileage ?? existingTouring.startMileage,
         endMileage: params.endMileage ?? existingTouring.endMileage,
-        startLatitude: existingTouring.startLatitude,
-        startLongitude: existingTouring.startLongitude,
-        endLatitude: existingTouring.endLatitude,
-        endLongitude: existingTouring.endLongitude,
+        startLatitude:
+          'startLatitude' in params
+            ? (params.startLatitude ?? null)
+            : existingTouring.startLatitude,
+        startLongitude:
+          'startLongitude' in params
+            ? (params.startLongitude ?? null)
+            : existingTouring.startLongitude,
+        endLatitude:
+          'endLatitude' in params
+            ? (params.endLatitude ?? null)
+            : existingTouring.endLatitude,
+        endLongitude:
+          'endLongitude' in params
+            ? (params.endLongitude ?? null)
+            : existingTouring.endLongitude,
         status: newStatus,
       })
 

--- a/apps/web/lib/api/server/v1/userBike.ts
+++ b/apps/web/lib/api/server/v1/userBike.ts
@@ -912,6 +912,10 @@ userBike.patch(
         endMileage: body.endMileage,
         status: body.status,
         fuelLogIds: body.fuelLogIds?.map(createFuelLogId),
+        startLatitude: body.startLatitude,
+        startLongitude: body.startLongitude,
+        endLatitude: body.endLatitude,
+        endLongitude: body.endLongitude,
       })
     })
 

--- a/apps/web/lib/api/server/v1/userBike.ts
+++ b/apps/web/lib/api/server/v1/userBike.ts
@@ -35,6 +35,7 @@ import {
   TouringDeleteRequestSchema,
   SpotRegisterRequestSchema,
   SpotUpdateRequestSchema,
+  SpotReorderRequestSchema,
 } from '@repo/shared-types'
 import { MyUserBikeDetail } from '../interfaces/IMyUserBikeRepository'
 import { honoAuthMiddleware } from '../middlewares/honoAuth'
@@ -993,6 +994,7 @@ userBike.post(
           latitude: spot.latitude,
           longitude: spot.longitude,
           visitedAt: spot.visitedAt.toISOString(),
+          sortOrder: spot.sortOrder,
         },
         message: 'スポット登録成功',
       },
@@ -1032,8 +1034,43 @@ userBike.get(
           latitude: spot.latitude,
           longitude: spot.longitude,
           visitedAt: spot.visitedAt.toISOString(),
+          sortOrder: spot.sortOrder,
         })),
         message: 'スポット一覧取得成功',
+      },
+      200
+    )
+  }
+)
+
+// スポット並び替え（/:spotId より前に定義）
+userBike.patch(
+  '/bike/:myUserBikeId/tourings/:touringId/spots/reorder',
+  honoAuthMiddleware,
+  zodValidateJson(SpotReorderRequestSchema),
+  async (c) => {
+    const { userId } = c.var.user!
+    const myUserBikeId = c.req.param('myUserBikeId')
+    const touringId = c.req.param('touringId')
+    const body = c.req.valid('json')
+
+    const spotRepo = new PrismaSpotRepository(prisma)
+    const touringRepo = new PrismaTouringRepository(prisma)
+    const myUserBikeRepo = new PrismaMyUserBikeRepository(prisma)
+    const service = new SpotService(spotRepo, touringRepo, myUserBikeRepo)
+
+    await service.reorderSpots(
+      body.spotIds,
+      createTouringId(touringId),
+      createMyUserBikeId(myUserBikeId),
+      createUserId(userId)
+    )
+
+    return c.json<SuccessResponse<undefined>>(
+      {
+        status: 'success',
+        data: undefined,
+        message: 'スポット並び替え成功',
       },
       200
     )
@@ -1080,6 +1117,7 @@ userBike.patch(
           latitude: spot.latitude,
           longitude: spot.longitude,
           visitedAt: spot.visitedAt.toISOString(),
+          sortOrder: spot.sortOrder,
         },
         message: 'スポット更新成功',
       },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,9 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@dnd-kit/core": "6.3.1",
+    "@dnd-kit/sortable": "10.0.0",
+    "@dnd-kit/utilities": "3.2.2",
     "@hono/zod-validator": "catalog:",
     "@next/third-parties": "catalog:",
     "@repo/database": "workspace:*",
@@ -26,11 +29,11 @@
     "firebase": "catalog:",
     "firebase-admin": "catalog:",
     "hono": "catalog:",
+    "leaflet": "1.9.4",
     "lucide-react": "catalog:",
     "next": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "leaflet": "1.9.4",
     "recharts": "3.6.0",
     "swr": "2.3.8",
     "zod": "catalog:"
@@ -38,10 +41,10 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
+    "@types/leaflet": "1.9.14",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@types/leaflet": "1.9.14",
     "@types/recharts": "2.0.1",
     "@vitest/ui": "catalog:",
     "eslint": "catalog:",

--- a/packages/database/prisma/migrations/20260405004713_add_spot_sort_order/migration.sql
+++ b/packages/database/prisma/migrations/20260405004713_add_spot_sort_order/migration.sql
@@ -1,0 +1,19 @@
+-- DropIndex
+DROP INDEX "TUserMyBikeTouringSpot_touring_id_visited_at_idx";
+
+-- AlterTable
+ALTER TABLE "TUserMyBikeTouringSpot" ADD COLUMN     "sort_order" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateIndex
+CREATE INDEX "TUserMyBikeTouringSpot_touring_id_sort_order_idx" ON "TUserMyBikeTouringSpot"("touring_id", "sort_order");
+
+-- 既存スポットの sort_order を visited_at 順で採番する
+UPDATE "TUserMyBikeTouringSpot"
+SET "sort_order" = sub.row_num - 1
+FROM (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (PARTITION BY touring_id ORDER BY visited_at ASC) AS row_num
+  FROM "TUserMyBikeTouringSpot"
+) sub
+WHERE "TUserMyBikeTouringSpot".id = sub.id;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -196,13 +196,14 @@ model TUserMyBikeTouringSpot {
   latitude  Float?   @map("latitude")
   longitude Float?   @map("longitude")
   visitedAt DateTime @default(now()) @map("visited_at")
+  sortOrder Int      @default(0) @map("sort_order")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
   touring TUserMyBikeTouring @relation(fields: [touringId], references: [id], onDelete: Cascade)
 
-  @@index([touringId, visitedAt])
+  @@index([touringId, sortOrder])
 }
 
 model TUserQuit {

--- a/packages/shared-types/src/common/ApiIO.ts
+++ b/packages/shared-types/src/common/ApiIO.ts
@@ -195,6 +195,7 @@ export type ApiResponseSpotDetail = {
   latitude: number | null
   longitude: number | null
   visitedAt: string
+  sortOrder: number
 }
 
 export type ApiResponseSpotList = ApiResponseSpotDetail[]

--- a/packages/shared-types/src/domain/spot.ts
+++ b/packages/shared-types/src/domain/spot.ts
@@ -11,4 +11,5 @@ export type Spot = {
   latitude: number | null
   longitude: number | null
   visitedAt: Date
+  sortOrder: number
 }

--- a/packages/shared-types/src/schemas/spotSchema.ts
+++ b/packages/shared-types/src/schemas/spotSchema.ts
@@ -93,3 +93,12 @@ export const SpotUpdateRequestSchema = z
   )
 
 export type SpotUpdateRequest = z.infer<typeof SpotUpdateRequestSchema>
+
+/**
+ * スポット並び替えリクエストのバリデーションスキーマ
+ */
+export const SpotReorderRequestSchema = z.object({
+  spotIds: z.array(z.string()).min(1, 'スポットIDを1件以上指定してください'),
+})
+
+export type SpotReorderRequest = z.infer<typeof SpotReorderRequestSchema>

--- a/packages/shared-types/src/schemas/touringSchema.ts
+++ b/packages/shared-types/src/schemas/touringSchema.ts
@@ -114,6 +114,38 @@ export const TouringUpdateRequestSchema = z
           .min(1, '給油履歴IDは1文字以上で指定してください')
       )
       .optional(),
+    startLatitude: z
+      .number({
+        invalid_type_error: '開始地点の緯度は数値で指定してください',
+      })
+      .min(-90, '開始地点の緯度は-90以上で指定してください')
+      .max(90, '開始地点の緯度は90以下で指定してください')
+      .nullable()
+      .optional(),
+    startLongitude: z
+      .number({
+        invalid_type_error: '開始地点の経度は数値で指定してください',
+      })
+      .min(-180, '開始地点の経度は-180以上で指定してください')
+      .max(180, '開始地点の経度は180以下で指定してください')
+      .nullable()
+      .optional(),
+    endLatitude: z
+      .number({
+        invalid_type_error: '終了地点の緯度は数値で指定してください',
+      })
+      .min(-90, '終了地点の緯度は-90以上で指定してください')
+      .max(90, '終了地点の緯度は90以下で指定してください')
+      .nullable()
+      .optional(),
+    endLongitude: z
+      .number({
+        invalid_type_error: '終了地点の経度は数値で指定してください',
+      })
+      .min(-180, '終了地点の経度は-180以上で指定してください')
+      .max(180, '終了地点の経度は180以下で指定してください')
+      .nullable()
+      .optional(),
   })
   .refine(
     (data) =>
@@ -123,7 +155,11 @@ export const TouringUpdateRequestSchema = z
       data.startMileage !== undefined ||
       data.endMileage !== undefined ||
       data.status !== undefined ||
-      data.fuelLogIds !== undefined,
+      data.fuelLogIds !== undefined ||
+      data.startLatitude !== undefined ||
+      data.startLongitude !== undefined ||
+      data.endLatitude !== undefined ||
+      data.endLongitude !== undefined,
     {
       message: 'いずれかの更新項目を指定してください',
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,15 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: 6.3.1
+        version: 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/sortable':
+        specifier: 10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/utilities':
+        specifier: 3.2.2
+        version: 3.2.2(react@19.2.1)
       '@hono/zod-validator':
         specifier: 'catalog:'
         version: 0.4.1(hono@4.10.3)(zod@3.23.8)
@@ -550,6 +559,28 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@electric-sql/pglite-socket@0.0.6':
     resolution: {integrity: sha512-6RjmgzphIHIBA4NrMGJsjNWK4pu+bCWJlEWlwcxFTVY3WT86dFpKwbZaGWZV6C5Rd7sCk1Z0CI76QEfukLAUXw==}
@@ -4945,6 +4976,31 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.1)
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.1)
+      react: 19.2.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+      tslib: 2.8.1
 
   '@electric-sql/pglite-socket@0.0.6(@electric-sql/pglite@0.3.2)':
     dependencies:


### PR DESCRIPTION
## 概要
ツーリングの開始・終了位置（緯度・経度）とスポット位置を後から編集できるようにしました。
位置の編集はLeafletマップ上のクリックで行い、クリックのたびに即時保存されます。
ツーリング詳細ページのスポットセクションに「出発地」「終着地」を統合表示するよう再設計しました。

## 変更内容

| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `schemas/touringSchema.ts` | 修正 | TouringUpdateRequestSchema に位置情報フィールドを追加 |
| `TouringService.ts` | 修正 | UpdateTouringParams に位置情報を追加、null 削除も対応 |
| `userBike.ts` | 修正 | ツーリング PATCH ハンドラに位置情報フィールドを追加 |
| `components/map/LocationPickerMapInner.tsx` | 追加 | クリックで地点を選択できる Leaflet マップ実装 |
| `components/map/LocationPickerMap.tsx` | 追加 | SSR 無効の dynamic import ラッパー |
| `components/map/LocationPickerModal.tsx` | 追加 | 位置編集専用モーダル（クリックで onLocationSaved を呼ぶ） |
| `components/touring/TouringLocationEditModal.tsx` | 追加 | 出発地・終着地の編集モーダル（クリックで即時 PATCH） |
| `components/spot/SpotEditForm.tsx` | 追加 | スポット編集フォーム（位置は「地図で変更」から LocationPickerModal へ） |
| `components/spot/SpotEditModal.tsx` | 追加 | スポット編集モーダル |
| `[touringId]/page.tsx` | 修正 | スポットカードに出発地（緑）・終着地（赤）を常時表示 |
| `[touringId]/page.module.css` | 修正 | 出発地・終着地用バッジスタイルを追加 |
| `__tests__/helpers/touringHelper.ts` | 修正 | createTestSpot ヘルパーを追加 |
| `__tests__/api/v1/userBike.test.ts` | 修正 | ツーリング位置更新・スポット PATCH のテストを追加 |

## 影響範囲
- ツーリング詳細ページのスポットセクション表示
- ツーリング位置情報の更新 API（PATCH）
- スポット位置情報の更新 API（PATCH）

## テストプラン
- [x] ツーリング詳細ページのスポットセクションに「出発地」「終着地」が表示される
- [x] 出発地・終着地の編集ボタンからマップモーダルが開く
- [x] マップをクリックすると位置が即座に保存される（トーストが表示される）
- [x] スポットの編集ボタンからスポット編集フォームが開く
- [x] 「地図で変更」ボタンでマップモーダルが開き、クリックで即時保存される
- [x] マップをズームイン後にクリックしてもズームアウトしない
- [x] `pnpm test` が全件パスすること

Closes #223
