### PR TITLE
feat(web): ログイン画面にパスワード再設定導線を追加

### DIFF
--- a/apps/web/app/app/(auth)/reset-password/page.tsx
+++ b/apps/web/app/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,11 @@
+import { ResetPasswordCard } from '@/components/ResetPasswordCard'
+
+/**
+ * パスワード再設定ページ
+ *
+ * @remarks
+ * メールアドレス宛にパスワード再設定メールを送信する。
+ */
+export default function ResetPasswordPage() {
+  return <ResetPasswordCard />
+}

--- a/apps/web/components/LoginCard.tsx
+++ b/apps/web/components/LoginCard.tsx
@@ -161,6 +161,10 @@ export function LoginCard() {
           />
         </FormField>
 
+        <div className="mb-4 text-right text-sm">
+          <Link href="/app/reset-password">パスワードをお忘れですか？</Link>
+        </div>
+
         <Button
           type="submit"
           variant="primary"

--- a/apps/web/components/ResetPasswordCard.tsx
+++ b/apps/web/components/ResetPasswordCard.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import Link from 'next/link'
+import { FormEvent, useState } from 'react'
+import { BaseCard } from '@repo/ui/baseCard'
+import { Button } from '@repo/ui/button'
+import { ErrorMessage } from '@repo/ui/errorMessage'
+import { FormField } from '@repo/ui/formField'
+import { Input } from '@repo/ui/input'
+import { useAuth } from '@/lib/hooks/useAuth'
+
+export function ResetPasswordCard() {
+  const { requestPasswordReset } = useAuth()
+
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSuccess(null)
+    setLoading(true)
+
+    try {
+      await requestPasswordReset(email)
+      setSuccess('パスワード再設定メールを送信しました。メールをご確認ください。')
+    } catch (err) {
+      console.error('Password reset error:', err)
+      setError(
+        'パスワード再設定メールの送信に失敗しました。メールアドレスを確認して再度お試しください。'
+      )
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <BaseCard
+      title="パスワード再設定"
+      footer={
+        <p>
+          ログイン画面に戻る <Link href="/app/login">ログイン</Link>
+        </p>
+      }
+    >
+      {error && (
+        <div className="pb-2">
+          <ErrorMessage>{error}</ErrorMessage>
+        </div>
+      )}
+
+      {success && (
+        <div className="pb-2 text-sm text-green-600" role="status">
+          {success}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="flex flex-col">
+        <FormField label="メールアドレス" htmlFor="email" required>
+          <Input
+            id="email"
+            type="email"
+            placeholder="example@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            disabled={loading}
+            autoComplete="email"
+          />
+        </FormField>
+
+        <Button
+          type="submit"
+          variant="primary"
+          size="lg"
+          fullWidth
+          loading={loading}
+        >
+          再設定メールを送信
+        </Button>
+      </form>
+    </BaseCard>
+  )
+}

--- a/apps/web/lib/contexts/AuthContext.tsx
+++ b/apps/web/lib/contexts/AuthContext.tsx
@@ -38,6 +38,10 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     return result.user.getIdToken()
   }
 
+  const handleRequestPasswordReset = async (email: string) => {
+    await authService.requestPasswordReset(email)
+  }
+
   const handleSignInWithGoogle = async () => {
     const result = await authService.signInWithGoogle()
     return result.user.getIdToken()
@@ -62,6 +66,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     loading,
     signInWithEmail: handleSignInWithEmail,
     registerWithEmail: handleRegisterWithEmail,
+    requestPasswordReset: handleRequestPasswordReset,
     signInWithGoogle: handleSignInWithGoogle,
     signOut: handleSignOut,
     getIdToken: handleGetIdToken,

--- a/apps/web/lib/firebase/auth.ts
+++ b/apps/web/lib/firebase/auth.ts
@@ -2,6 +2,7 @@ import {
   signInWithEmailAndPassword,
   createUserWithEmailAndPassword,
   signInWithPopup,
+  sendPasswordResetEmail,
   GoogleAuthProvider,
   signOut as firebaseSignOut,
   type UserCredential,
@@ -29,6 +30,14 @@ export const registerWithEmail = async (
 ): Promise<UserCredential> => {
   const auth = getFirebaseAuth()
   return await createUserWithEmailAndPassword(auth, email, password)
+}
+
+/**
+ * メールアドレス宛にパスワード再設定メールを送信
+ */
+export const requestPasswordReset = async (email: string): Promise<void> => {
+  const auth = getFirebaseAuth()
+  await sendPasswordResetEmail(auth, email)
 }
 
 /**

--- a/apps/web/types/auth.ts
+++ b/apps/web/types/auth.ts
@@ -5,6 +5,7 @@ export interface AuthContextType {
   loading: boolean
   signInWithEmail: (email: string, password: string) => Promise<string>
   registerWithEmail: (email: string, password: string) => Promise<string>
+  requestPasswordReset: (email: string) => Promise<void>
   signInWithGoogle: () => Promise<string>
   signOut: () => Promise<boolean>
   getIdToken: () => Promise<string | null>


### PR DESCRIPTION
### Motivation
- メール/パスワードでのログイン時にパスワードを忘れたユーザーが再設定できる導線を追加するため。

### Description
- ログインフォームに `/app/reset-password` へのリンクを追加し、UIから遷移できるようにしました（`apps/web/components/LoginCard.tsx`）。
- パスワード再設定ページ `ResetPasswordPage` を追加しコンポーネント `ResetPasswordCard` を実装しました（`apps/web/app/app/(auth)/reset-password/page.tsx` と `apps/web/components/ResetPasswordCard.tsx`）。
- Firebase Auth の `sendPasswordResetEmail` をラップする `requestPasswordReset` を追加し、`AuthContext` 経由で呼べるようにしました（`apps/web/lib/firebase/auth.ts` と `apps/web/lib/contexts/AuthContext.tsx`）。
- 認証コンテキスト型に `requestPasswordReset` を追加して `useAuth()` から利用可能にしました（`apps/web/types/auth.ts`）。

### Testing
- `pnpm --filter @apps/web lint` を実行して成功しました。 
- `pnpm --filter @apps/web check-types` を実行したところ、今回の変更とは別の既存型エラーにより失敗しました（既存の型生成/Prisma関連エラー）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3acfd8b288330963db61fa8e814cf)