### PR TITLE
ツーリング開始・終了時の走行距離入力機能を追加

### DIFF
--- a/apps/web/components/TouringStartEndSection.module.css
+++ b/apps/web/components/TouringStartEndSection.module.css
@@ -149,6 +149,12 @@
   color: rgba(255, 255, 255, 0.8);
 }
 
+.startMileageInfo {
+  font-size: var(--font-size-sm);
+  color: rgba(255, 255, 255, 0.7);
+  margin-top: var(--spacing-1);
+}
+
 /* アクションボタンエリア */
 .actionButtons {
   position: relative;
@@ -288,6 +294,18 @@
 
 .spotModalActions > * {
   flex: 1;
+}
+
+.mileageModalHint {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-3);
+}
+
+.mileageModalError {
+  font-size: var(--font-size-sm);
+  color: var(--color-danger);
+  margin-top: var(--spacing-1);
 }
 
 /* レスポンシブ: モバイル */

--- a/apps/web/components/TouringStartEndSection.tsx
+++ b/apps/web/components/TouringStartEndSection.tsx
@@ -18,10 +18,12 @@ import { GUEST_ACCOUNT_LIMITS } from '@/lib/statics'
 type BikeWithTouring = {
   myUserBikeId: string
   bikeName: string
+  totalMileage: number
   ongoingTouring: {
     touringId: string
     title: string
     startDate: string
+    startMileage: number | null
   } | null
 }
 
@@ -30,6 +32,12 @@ export const TouringStartEndSection = () => {
   const { isGuest } = useAuth()
   const [loadingBikeId, setLoadingBikeId] = useState<string | null>(null)
   const { getCurrentPosition } = useGeolocation()
+  const [pendingStartBike, setPendingStartBike] = useState<{
+    myUserBikeId: string
+    bikeName: string
+    totalMileage: number
+  } | null>(null)
+  const [startMileageInput, setStartMileageInput] = useState('')
 
   // バイク一覧取得
   const {
@@ -72,11 +80,13 @@ export const TouringStartEndSection = () => {
     return {
       myUserBikeId: bike.myUserBikeId,
       bikeName,
+      totalMileage: bike.totalMileage,
       ongoingTouring: ongoingData?.ongoingTouring
         ? {
             touringId: ongoingData.ongoingTouring.touringId,
             title: ongoingData.ongoingTouring.title,
             startDate: ongoingData.ongoingTouring.startDate,
+            startMileage: ongoingData.ongoingTouring.startMileage,
           }
         : null,
     }
@@ -87,7 +97,11 @@ export const TouringStartEndSection = () => {
     (bike) => bike.ongoingTouring !== null
   )
 
-  const handleStartTouring = async (myUserBikeId: string, bikeName: string) => {
+  const handleStartTouring = async (
+    myUserBikeId: string,
+    bikeName: string,
+    startMileage?: number
+  ) => {
     setLoadingBikeId(myUserBikeId)
     try {
       const now = new Date()
@@ -106,6 +120,7 @@ export const TouringStartEndSection = () => {
           startDate: now.toISOString(),
           startLatitude: position?.latitude,
           startLongitude: position?.longitude,
+          startMileage,
         }
       )
 
@@ -123,7 +138,11 @@ export const TouringStartEndSection = () => {
     }
   }
 
-  const handleEndTouring = async (myUserBikeId: string, touringId: string) => {
+  const handleEndTouring = async (
+    myUserBikeId: string,
+    touringId: string,
+    endMileage?: number
+  ) => {
     setLoadingBikeId(myUserBikeId)
     try {
       const { position } = await getCurrentPosition()
@@ -136,6 +155,7 @@ export const TouringStartEndSection = () => {
           endDate: new Date().toISOString(),
           endLatitude: position?.latitude,
           endLongitude: position?.longitude,
+          endMileage,
         }
       )
 
@@ -151,6 +171,28 @@ export const TouringStartEndSection = () => {
     } finally {
       setLoadingBikeId(null)
     }
+  }
+
+  const handleOpenStartModal = (
+    myUserBikeId: string,
+    bikeName: string,
+    totalMileage: number
+  ) => {
+    setPendingStartBike({ myUserBikeId, bikeName, totalMileage })
+    setStartMileageInput(String(totalMileage))
+  }
+
+  const handleConfirmStart = async () => {
+    if (!pendingStartBike) return
+    const parsed = parseInt(startMileageInput, 10)
+    const mileage =
+      startMileageInput !== '' && !isNaN(parsed) ? parsed : undefined
+    setPendingStartBike(null)
+    await handleStartTouring(
+      pendingStartBike.myUserBikeId,
+      pendingStartBike.bikeName,
+      mileage
+    )
   }
 
   if (bikesError) {
@@ -226,10 +268,11 @@ export const TouringStartEndSection = () => {
           bike={activeBike}
           touring={activeBike.ongoingTouring}
           isLoading={loadingBikeId === activeBike.myUserBikeId}
-          onEnd={() =>
+          onEnd={(endMileage) =>
             handleEndTouring(
               activeBike.myUserBikeId,
-              activeBike.ongoingTouring!.touringId
+              activeBike.ongoingTouring!.touringId,
+              endMileage
             )
           }
         />
@@ -269,7 +312,11 @@ export const TouringStartEndSection = () => {
 
               <Button
                 onClick={() =>
-                  handleStartTouring(bike.myUserBikeId, bike.bikeName)
+                  handleOpenStartModal(
+                    bike.myUserBikeId,
+                    bike.bikeName,
+                    bike.totalMileage
+                  )
                 }
                 disabled={isLoading || isAtGuestTouringLimit}
                 variant="primary"
@@ -282,6 +329,55 @@ export const TouringStartEndSection = () => {
           )
         })}
       </div>
+
+      {/* 開始時 走行距離入力モーダル */}
+      {pendingStartBike && (
+        <div
+          className={styles.spotModalOverlay}
+          onClick={() => setPendingStartBike(null)}
+        >
+          <div
+            className={styles.spotModal}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className={styles.spotModalTitle}>出発時の走行距離</h3>
+
+            <div className={styles.spotModalField}>
+              <label className={styles.spotModalLabel}>
+                現在の走行距離（km）
+              </label>
+              <input
+                type="number"
+                className={styles.spotModalInput}
+                placeholder="例：12345"
+                value={startMileageInput}
+                onChange={(e) => setStartMileageInput(e.target.value)}
+                min={0}
+                step={1}
+              />
+            </div>
+
+            <div className={styles.spotModalActions}>
+              <Button
+                onClick={() => setPendingStartBike(null)}
+                variant="cloud"
+                size="md"
+                disabled={loadingBikeId !== null}
+              >
+                キャンセル
+              </Button>
+              <Button
+                onClick={handleConfirmStart}
+                variant="primary"
+                size="md"
+                disabled={loadingBikeId !== null}
+              >
+                開始する
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -291,7 +387,7 @@ type ActiveTouringCardProps = {
   bike: BikeWithTouring
   touring: NonNullable<BikeWithTouring['ongoingTouring']>
   isLoading: boolean
-  onEnd: () => void
+  onEnd: (endMileage?: number) => void
 }
 
 const ActiveTouringCard = ({
@@ -312,6 +408,9 @@ const ActiveTouringCard = ({
   const [geoStatus, setGeoStatus] = useState<
     'loading' | 'success' | 'denied' | 'error'
   >('loading')
+  const [showEndMileageModal, setShowEndMileageModal] = useState(false)
+  const [endMileageInput, setEndMileageInput] = useState('')
+  const [endMileageError, setEndMileageError] = useState('')
   const { getCurrentPosition } = useGeolocation()
 
   useEffect(() => {
@@ -398,6 +497,30 @@ const ActiveTouringCard = ({
     }
   }
 
+  const handleOpenEndMileageModal = () => {
+    setEndMileageInput('')
+    setEndMileageError('')
+    setShowEndMileageModal(true)
+  }
+
+  const handleConfirmEnd = () => {
+    const parsed = parseInt(endMileageInput, 10)
+    const mileage =
+      endMileageInput !== '' && !isNaN(parsed) ? parsed : undefined
+    if (
+      mileage !== undefined &&
+      touring.startMileage !== null &&
+      mileage < touring.startMileage
+    ) {
+      setEndMileageError(
+        `終了時の走行距離は開始時（${touring.startMileage.toLocaleString()}km）以上で入力してください`
+      )
+      return
+    }
+    setShowEndMileageModal(false)
+    onEnd(mileage)
+  }
+
   return (
     <>
       <div className={styles.activeTouringCard}>
@@ -421,6 +544,11 @@ const ActiveTouringCard = ({
           <p className={styles.startDateTime}>
             {formatStartDateTime(touring.startDate)} 開始
           </p>
+          {touring.startMileage !== null && (
+            <p className={styles.startMileageInfo}>
+              出発時走行距離: {touring.startMileage.toLocaleString()}km
+            </p>
+          )}
         </div>
 
         {/* アクションボタン */}
@@ -436,7 +564,7 @@ const ActiveTouringCard = ({
           </Button>
 
           <Button
-            onClick={onEnd}
+            onClick={handleOpenEndMileageModal}
             disabled={isLoading}
             variant="danger"
             size="md"
@@ -446,6 +574,67 @@ const ActiveTouringCard = ({
           </Button>
         </div>
       </div>
+
+      {/* 終了時 走行距離入力モーダル */}
+      {showEndMileageModal && (
+        <div
+          className={styles.spotModalOverlay}
+          onClick={() => setShowEndMileageModal(false)}
+        >
+          <div
+            className={styles.spotModal}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className={styles.spotModalTitle}>到着時の走行距離</h3>
+
+            {touring.startMileage !== null && (
+              <p className={styles.mileageModalHint}>
+                出発時走行距離: {touring.startMileage.toLocaleString()}km
+              </p>
+            )}
+
+            <div className={styles.spotModalField}>
+              <label className={styles.spotModalLabel}>
+                現在の走行距離（km）
+              </label>
+              <input
+                type="number"
+                className={styles.spotModalInput}
+                placeholder="例：12400"
+                value={endMileageInput}
+                onChange={(e) => {
+                  setEndMileageInput(e.target.value)
+                  setEndMileageError('')
+                }}
+                min={touring.startMileage ?? 0}
+                step={1}
+              />
+              {endMileageError && (
+                <p className={styles.mileageModalError}>{endMileageError}</p>
+              )}
+            </div>
+
+            <div className={styles.spotModalActions}>
+              <Button
+                onClick={() => setShowEndMileageModal(false)}
+                variant="cloud"
+                size="md"
+                disabled={isLoading}
+              >
+                キャンセル
+              </Button>
+              <Button
+                onClick={handleConfirmEnd}
+                variant="danger"
+                size="md"
+                disabled={isLoading}
+              >
+                終了する
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* スポット記録モーダル */}
       {showSpotModal && (

--- a/apps/web/components/TouringStartEndSection.tsx
+++ b/apps/web/components/TouringStartEndSection.tsx
@@ -348,6 +348,7 @@ export const TouringStartEndSection = () => {
               </label>
               <input
                 type="number"
+                inputMode="numeric"
                 className={styles.spotModalInput}
                 placeholder="例：12345"
                 value={startMileageInput}
@@ -599,6 +600,7 @@ const ActiveTouringCard = ({
               </label>
               <input
                 type="number"
+                inputMode="numeric"
                 className={styles.spotModalInput}
                 placeholder="例：12400"
                 value={endMileageInput}

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -383,10 +383,8 @@ interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
 チェックボックスコンポーネント。ラベル統合型でエラー状態をサポート。
 
 ```tsx
-interface CheckboxProps extends Omit<
-  InputHTMLAttributes<HTMLInputElement>,
-  'type'
-> {
+interface CheckboxProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
   error?: boolean
   helperText?: string
   label?: string

--- a/packages/ui/src/Checkbox/checkbox.tsx
+++ b/packages/ui/src/Checkbox/checkbox.tsx
@@ -6,10 +6,8 @@ import styles from './checkbox.module.css'
 /**
  * Checkboxコンポーネントのプロパティ
  */
-export interface CheckboxProps extends Omit<
-  InputHTMLAttributes<HTMLInputElement>,
-  'type'
-> {
+export interface CheckboxProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
   /**
    * エラー状態
    * @default false

--- a/packages/ui/src/Textarea/textarea.tsx
+++ b/packages/ui/src/Textarea/textarea.tsx
@@ -6,7 +6,8 @@ import styles from './textarea.module.css'
 /**
  * Textareaコンポーネントのプロパティ
  */
-export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+export interface TextareaProps
+  extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   /**
    * エラー状態
    * @default false


### PR DESCRIPTION
## 概要

ツーリングの開始時と終了時に走行距離（マイレージ）を入力できる機能を追加しました。ユーザーがツーリングを開始・終了する際にモーダルダイアログで走行距離を入力でき、その情報がツーリングレコードに保存されます。

## 主な変更内容

### TouringStartEndSection.tsx
- **型定義の拡張**: `BikeWithTouring`型に`totalMileage`フィールドを追加し、`ongoingTouring`に`startMileage`フィールドを追加
- **開始時モーダル**: `handleOpenStartModal`と`handleConfirmStart`を実装し、ツーリング開始前に走行距離入力モーダルを表示
- **終了時モーダル**: `ActiveTouringCard`コンポーネント内に終了時走行距離入力モーダルを実装
- **バリデーション**: 終了時走行距離が開始時走行距離以上であることを検証
- **API連携**: `handleStartTouring`と`handleEndTouring`に`startMileage`と`endMileage`パラメータを追加

### ActiveTouringCard
- 開始時走行距離を表示する`startMileageInfo`セクションを追加
- 終了時走行距離入力用のモーダルダイアログを実装
- エラーメッセージ表示機能を追加

### TouringStartEndSection.module.css
- `.startMileageInfo`: 開始時走行距離表示用のスタイル
- `.mileageModalHint`: モーダル内のヒントテキスト用スタイル
- `.mileageModalError`: エラーメッセージ用スタイル

## 関連タスク

ツーリング記録に走行距離情報を追加する機能要件

## チェックポイント

- [x] 開始時モーダルで走行距離を入力できる
- [x] 終了時モーダルで走行距離を入力できる
- [x] 終了時走行距離が開始時以上であることを検証
- [x] 入力値がAPIに正しく送信される
- [x] キャンセルボタンで入力をキャンセルできる
- [x] 既存のツーリング開始・終了機能に影響がない

## 影響範囲・懸念

- ツーリング開始・終了時のUIフローが変更されるため、ユーザーへの周知が必要
- 走行距離入力は任意項目（未入力でもツーリング開始・終了可能）
- 既存のツーリングレコードには`startMileage`が`null`として保存される

## 備考

- 走行距離の入力値は数値型で保存され、表示時には`toLocaleString()`でフォーマットされます
- モーダルのスタイルは既存の`spotModal`クラスを再利用しています

https://claude.ai/code/session_01KFhqpVwPDV2YXN7CRJfHBF