### PR TITLE
Add inputMode attribute to numeric input fields

### DIFF
--- a/apps/web/components/bike/BikeRegisterForm.tsx
+++ b/apps/web/components/bike/BikeRegisterForm.tsx
@@ -110,6 +110,7 @@ export const BikeRegisterForm = ({
             <Input
               id="displacement"
               type="number"
+              inputMode="numeric"
               value={formData.displacement}
               onChange={(e) =>
                 setFormData((prev) => ({
@@ -183,6 +184,7 @@ export const BikeRegisterForm = ({
           <Input
             id="purchasePrice"
             type="number"
+            inputMode="numeric"
             value={formData.purchasePrice}
             onChange={(e) =>
               setFormData((prev) => ({
@@ -201,6 +203,7 @@ export const BikeRegisterForm = ({
           <Input
             id="purchaseMileage"
             type="number"
+            inputMode="numeric"
             value={formData.purchaseMileage}
             onChange={(e) =>
               setFormData((prev) => ({
@@ -219,6 +222,7 @@ export const BikeRegisterForm = ({
           <Input
             id="totalMileage"
             type="number"
+            inputMode="numeric"
             value={formData.totalMileage}
             onChange={(e) =>
               setFormData((prev) => ({

--- a/apps/web/components/bike/MyBikeEditForm.tsx
+++ b/apps/web/components/bike/MyBikeEditForm.tsx
@@ -76,6 +76,7 @@ export const MyBikeEditForm = ({
         <Input
           id="totalMileage"
           type="number"
+          inputMode="numeric"
           value={formData.totalMileage}
           onChange={(e) =>
             setFormData((prev) => ({ ...prev, totalMileage: e.target.value }))
@@ -92,6 +93,7 @@ export const MyBikeEditForm = ({
         <Input
           id="displacement"
           type="number"
+          inputMode="numeric"
           value={formData.displacement}
           onChange={(e) =>
             setFormData((prev) => ({ ...prev, displacement: e.target.value }))

--- a/apps/web/components/fuel-log/FuelLogForm.tsx
+++ b/apps/web/components/fuel-log/FuelLogForm.tsx
@@ -115,6 +115,7 @@ export const FuelLogForm = ({
         <Input
           id="mileage"
           type="number"
+          inputMode="numeric"
           value={formData.mileage}
           onChange={(e) => {
             const newMileage = e.target.value
@@ -155,6 +156,7 @@ export const FuelLogForm = ({
           <Input
             id="previousMileage"
             type="number"
+            inputMode="numeric"
             value={formData.previousMileage}
             onChange={(e) => {
               setFormData((prev) => ({
@@ -175,6 +177,7 @@ export const FuelLogForm = ({
         <Input
           id="amount"
           type="number"
+          inputMode="decimal"
           value={formData.amount}
           onChange={(e) =>
             setFormData((prev) => ({
@@ -194,6 +197,7 @@ export const FuelLogForm = ({
         <Input
           id="totalPrice"
           type="number"
+          inputMode="numeric"
           value={formData.totalPrice}
           onChange={(e) =>
             setFormData((prev) => ({

--- a/apps/web/components/touring/TouringForm.tsx
+++ b/apps/web/components/touring/TouringForm.tsx
@@ -154,6 +154,7 @@ export const TouringForm = ({
         <Input
           id="startMileage"
           type="number"
+          inputMode="numeric"
           value={formData.startMileage}
           onChange={(e) => {
             setFormData((prev) => ({
@@ -173,6 +174,7 @@ export const TouringForm = ({
         <Input
           id="endMileage"
           type="number"
+          inputMode="numeric"
           value={formData.endMileage}
           onChange={(e) => {
             setFormData((prev) => ({

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -383,8 +383,10 @@ interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
 チェックボックスコンポーネント。ラベル統合型でエラー状態をサポート。
 
 ```tsx
-interface CheckboxProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+interface CheckboxProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type'
+> {
   error?: boolean
   helperText?: string
   label?: string

--- a/packages/ui/src/Checkbox/checkbox.tsx
+++ b/packages/ui/src/Checkbox/checkbox.tsx
@@ -6,8 +6,10 @@ import styles from './checkbox.module.css'
 /**
  * Checkboxコンポーネントのプロパティ
  */
-export interface CheckboxProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+export interface CheckboxProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type'
+> {
   /**
    * エラー状態
    * @default false

--- a/packages/ui/src/Textarea/textarea.tsx
+++ b/packages/ui/src/Textarea/textarea.tsx
@@ -6,8 +6,7 @@ import styles from './textarea.module.css'
 /**
  * Textareaコンポーネントのプロパティ
  */
-export interface TextareaProps
-  extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+export interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   /**
    * エラー状態
    * @default false


### PR DESCRIPTION
## 概要

複数のフォームコンポーネントの数値入力フィールドに `inputMode` 属性を追加しました。モバイルデバイスで適切なキーボードタイプ（数値キーボードまたは小数点キーボード）が表示されるようになります。

## 関連タスク

- モバイルUX改善

## チェックポイント

- [x] 数値入力フィールドに `inputMode="numeric"` を追加
- [x] 小数点を含む金額入力に `inputMode="decimal"` を追加
- [x] 全フォームコンポーネントで一貫性を確保

## 影響範囲・懸念

**影響を受けるコンポーネント:**
- `BikeRegisterForm.tsx` - 排気量、購入価格、走行距離関連の4フィールド
- `FuelLogForm.tsx` - 走行距離、金額、合計金額関連の4フィールド
- `MyBikeEditForm.tsx` - 走行距離、排気量の2フィールド
- `TouringForm.tsx` - 開始・終了走行距離の2フィールド

**懸念:**
- なし。HTMLの標準属性追加のため、後方互換性への影響なし

## 備考

- `inputMode="numeric"` は整数入力用（走行距離、排気量など）
- `inputMode="decimal"` は小数点入力用（燃料金額など）
- モバイルブラウザでのキーボード表示が改善され、ユーザー体験が向上します

https://claude.ai/code/session_01DDdnoMoZqeQBnYMZB92uQ1