### PR TITLE
fix(web): 公開バイク詳細のソフト404を解消し robots に sitemap/host を明示

### DIFF
--- a/apps/web/app/(public)/bikes/[id]/page.tsx
+++ b/apps/web/app/(public)/bikes/[id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
+import { notFound } from 'next/navigation'
 import { prisma } from '@repo/database'
 import { createMyUserBikeId } from '@repo/shared-types'
 import styles from './page.module.css'
@@ -48,20 +49,7 @@ export default async function PublicBikeDetailPage({
   ])
 
   if (!bike) {
-    return (
-      <div className={styles.page}>
-        <header className={styles.header}>
-          <h1 className={styles.title}>公開バイクが見つかりません</h1>
-          <p className={styles.subtitle}>
-            指定されたバイクは公開されていないか削除されています。
-          </p>
-        </header>
-
-        <div className={styles.emptyState}>
-          <Link href="/bikes">公開バイク一覧に戻る</Link>
-        </div>
-      </div>
-    )
+    notFound()
   }
 
   const title =

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,7 +1,10 @@
 import type { MetadataRoute } from 'next'
+import { SITE_URL } from '@/lib/statics'
 
 export default function robots(): MetadataRoute.Robots {
   return {
+    host: SITE_URL,
+    sitemap: `${SITE_URL}/sitemap.xml`,
     rules: {
       userAgent: '*',
       allow: '/',


### PR DESCRIPTION
### Motivation
- 存在しない `GET /bikes/[id]` が `200 OK` で indexable な HTML を返しておりソフト404と見なされる問題があったため、検索エンジンのインデックス品質とクロール効率を改善する必要がありました。 
- `robots` に `Sitemap:` と正規ホストが明示されておらずサイトマップを通した発見性向上の余地があったため、クローラー向けのメタ情報を追加します。

### Description
- `apps/web/app/(public)/bikes/[id]/page.tsx` を修正し、公開バイクが見つからない場合はカスタム404ページを返す代わりに `notFound()` を呼び出して HTTP 404 を返すよう変更しました。 
- `apps/web/app/robots.ts` に `host: SITE_URL` と `sitemap: `${SITE_URL}/sitemap.xml`` を追加してクローラーに正規ホストとサイトマップの位置を明示しました。

### Testing
- 自動チェックとして `pnpm -C apps/web lint` を実行し問題ないことを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec18d243b8833084376dee6d6b3353)