### PR TITLE
🐛 [Bug] Dockerfileにpackages/emailのpackage.jsonコピーを追加してビルドエラーを修正

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -16,6 +16,7 @@ COPY packages/database/package.json ./packages/database/
 COPY packages/firebase-auth-server/package.json ./packages/firebase-auth-server/
 COPY packages/shared-types/package.json ./packages/shared-types/
 COPY packages/shared-utils/package.json ./packages/shared-utils/
+COPY packages/email/package.json ./packages/email/
 COPY packages/theme/package.json ./packages/theme/
 COPY packages/ui/package.json ./packages/ui/
 


### PR DESCRIPTION
## 概要
本番Dockerイメージのビルドが `Module not found: Can't resolve 'resend'` エラーで失敗していた問題を修正します。`apps/web` は `@repo/email` パッケージに依存しており、そのパッケージは `resend` を依存関係に持ちますが、Dockerfileの `pnpm install` 前のCOPYリストから `packages/email/package.json` が漏れていたため、pnpm が `resend` をインストールできていませんでした。

## 変更内容

### Dockerfileのビルド修正
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `apps/web/Dockerfile` | 修正 | `packages/email/package.json` のCOPY行を追加 |

## 影響範囲
- Dockerイメージのビルドプロセス
- `@repo/email` パッケージの依存関係インストール

## テストプラン
- [ ] GitHub Actions のCIでビルドが成功することを確認
- [ ] 本番イメージのDockerビルドが exit code 0 で完了することを確認

Closes #339