### PR TITLE
[Feature] プロフィール編集機能を部分更新できるように (#336)

### DIFF
--- a/apps/web/__tests__/api/v1/user.test.ts
+++ b/apps/web/__tests__/api/v1/user.test.ts
@@ -15,10 +15,10 @@ afterEach(() => {
 })
 
 describe('User API Endpoints', () => {
-  describe('POST /api/v1/user/profile', () => {
+  describe('PATCH /api/v1/user/profile', () => {
     test('Authorizationヘッダーが未指定の場合にエラーとなる', async () => {
       const res = await app.request('/api/v1/user/profile', {
-        method: 'POST',
+        method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -53,7 +53,7 @@ describe('User API Endpoints', () => {
       expect(registeredRes.status).toBe(201)
 
       const res = await app.request('/api/v1/user/profile', {
-        method: 'POST',
+        method: 'PATCH',
         headers: {
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
@@ -95,7 +95,7 @@ describe('User API Endpoints', () => {
       expect(registeredRes.status).toBe(201)
 
       const res = await app.request('/api/v1/user/profile', {
-        method: 'POST',
+        method: 'PATCH',
         headers: {
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
@@ -120,7 +120,40 @@ describe('User API Endpoints', () => {
       expect(res.status).toBe(400)
     })
 
-    test('ユーザ名が更新できる', async () => {
+    test('フィールドが1つも指定されない場合にエラーとなる', async () => {
+      const email = createRandomEmail()
+      const credential = await handleRegisterByFirebase(email, 'password')
+      const token = await credential.user.getIdToken()
+      await app.request('/api/v1/user/auth/register', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: 'test_フィールドが1つも指定されない場合にエラーとなる',
+        }),
+      })
+
+      const res = await app.request('/api/v1/user/profile', {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({}),
+      })
+
+      const json = await res.json()
+      expect(json).toMatchObject({
+        status: 'error',
+        errorCode: 'VALIDATION_ERROR',
+        message: expect.any(String),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    test('ユーザ名のみ更新できる', async () => {
       const email = createRandomEmail()
       const credential = await handleRegisterByFirebase(email, 'password')
       const token = await credential.user.getIdToken()
@@ -131,13 +164,13 @@ describe('User API Endpoints', () => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          name: 'test_ユーザ名が更新できる',
+          name: 'test_ユーザ名のみ更新できる',
         }),
       })
       expect(registeredRes.status).toBe(201)
 
       const res = await app.request('/api/v1/user/profile', {
-        method: 'POST',
+        method: 'PATCH',
         headers: {
           Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json',
@@ -154,6 +187,46 @@ describe('User API Endpoints', () => {
           userId: expect.any(String),
           name: '更新後の名前',
           notificationEmail: expect.any(String),
+        },
+        message: expect.any(String),
+      })
+      expect(res.status).toBe(200)
+    })
+
+    test('通知メールアドレスのみ更新できる', async () => {
+      const email = createRandomEmail()
+      const credential = await handleRegisterByFirebase(email, 'password')
+      const token = await credential.user.getIdToken()
+      await app.request('/api/v1/user/auth/register', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: 'test_通知メールアドレスのみ更新できる',
+        }),
+      })
+
+      const notificationEmail = createRandomEmail()
+      const res = await app.request('/api/v1/user/profile', {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          notificationEmail,
+        }),
+      })
+
+      const json = await res.json()
+      expect(json).toEqual({
+        status: 'success',
+        data: {
+          userId: expect.any(String),
+          name: 'test_通知メールアドレスのみ更新できる',
+          notificationEmail,
         },
         message: expect.any(String),
       })

--- a/apps/web/app/app/(protected)/profile/page.tsx
+++ b/apps/web/app/app/(protected)/profile/page.tsx
@@ -24,19 +24,23 @@ function ProfileEditPage() {
   return (
     <div className="w-full max-w-md flex flex-col gap-4">
       <ProfileCard />
-      <BaseCard title="アカウント">
-        <div className="flex flex-col gap-2 text-sm mb-4">
+
+      <BaseCard title="アカウント認証">
+        <div className="flex flex-col gap-2 text-sm">
           <div className="flex justify-between">
             <span className="text-gray-500">認証方式</span>
             <span>{providerLabel}</span>
           </div>
+
           <div className="flex justify-between">
             <span className="text-gray-500">メールアドレス</span>
             <span>{user?.email ?? '-'}</span>
           </div>
         </div>
-        <LogoutButton />
       </BaseCard>
+
+      <LogoutButton />
+
       <FooterCard />
     </div>
   )

--- a/apps/web/components/FooterCard.tsx
+++ b/apps/web/components/FooterCard.tsx
@@ -27,6 +27,7 @@ export function FooterCard() {
         >
           ご意見・ご要望はこちら
         </Link>
+
         <div className="flex flex-col items-center gap-2 sm:flex-row sm:gap-4">
           <p className="m-0 text-sm">Created by SaKho</p>
           <p className="m-0 text-sm">@2025 MotoReco</p>

--- a/apps/web/components/ProfileCard.tsx
+++ b/apps/web/components/ProfileCard.tsx
@@ -5,14 +5,12 @@ import useSWR from 'swr'
 import { BaseCard } from '@repo/ui/baseCard'
 import { Button } from '@repo/ui/button'
 import { ErrorMessage } from '@repo/ui/errorMessage'
-import { FormField } from '@repo/ui/formField'
-import { Input } from '@repo/ui/input'
 import { EditIcon } from '@/components/icons/EditIcon'
-import { apiGet, apiPost } from '@/lib/api/client'
+import { ProfileEditModal } from '@/components/ProfileEditModal'
+import { apiGet } from '@/lib/api/client'
 import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
 
 export function ProfileCard() {
-  // SWRによるデータフェッチ
   const { data, error, isLoading, mutate } = useSWR(
     '/api/v1/user/profile',
     async (url) => {
@@ -21,71 +19,25 @@ export function ProfileCard() {
     }
   )
 
-  // ローカル状態（編集用）
-  const [isEditing, setIsEditing] = useState(false)
-  const [editName, setEditName] = useState('')
-  const [editNotificationEmail, setEditNotificationEmail] = useState('')
-  const [isSaving, setIsSaving] = useState(false)
-  const [updateError, setUpdateError] = useState<string | null>(null)
+  const [isModalOpen, setIsModalOpen] = useState(false)
 
-  // 編集モードの開始
-  const handleEdit = () => {
-    setEditName(data?.name || '')
-    setEditNotificationEmail(data?.notificationEmail || '')
-    setIsEditing(true)
-    setUpdateError(null)
-  }
-
-  // 編集のキャンセル
-  const handleCancel = () => {
-    setIsEditing(false)
-    setEditName('')
-    setEditNotificationEmail('')
-    setUpdateError(null)
-  }
-
-  // プロフィール更新
-  const handleSave = async () => {
-    if (!editName.trim()) {
-      setUpdateError('名前を入力してください')
-      return
-    }
-
-    setIsSaving(true)
-    setUpdateError(null)
-
-    try {
-      const response = await apiPost('/api/v1/user/profile', {
-        name: editName.trim(),
-        notificationEmail: editNotificationEmail.trim() || null,
-      })
-
-      // SWRキャッシュを更新
-      await mutate(response.data)
-
-      setIsEditing(false)
-      setEditName('')
-    } catch (err) {
-      if (err instanceof ApiV1Error) {
-        setUpdateError(err.message)
-      } else {
-        setUpdateError('プロフィールの更新に失敗しました')
-      }
-    } finally {
-      setIsSaving(false)
-    }
-  }
-
-  // ローディング状態
   if (isLoading) {
     return (
       <BaseCard title="プロフィール">
-        <div>読み込み中...</div>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <div className="h-4 w-20 animate-pulse rounded bg-gray-200" />
+            <div className="h-9 w-full animate-pulse rounded bg-gray-200" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <div className="h-4 w-32 animate-pulse rounded bg-gray-200" />
+            <div className="h-9 w-full animate-pulse rounded bg-gray-200" />
+          </div>
+        </div>
       </BaseCard>
     )
   }
 
-  // エラー状態
   if (error) {
     const errorMessage =
       error instanceof ApiV1Error
@@ -100,88 +52,38 @@ export function ProfileCard() {
     )
   }
 
-  // 編集モード
-  if (isEditing) {
-    return (
-      <BaseCard title="プロフィール編集">
-        <form
-          onSubmit={(e) => {
-            e.preventDefault()
-            handleSave()
-          }}
-          className="flex flex-col"
-        >
-          <FormField
-            label="ユーザー名"
-            htmlFor="profile-name"
-            required
-            error={updateError || undefined}
-          >
-            <Input
-              id="profile-name"
-              type="text"
-              placeholder="名前を入力"
-              value={editName}
-              onChange={(e) => setEditName(e.target.value)}
-              error={!!updateError}
-              disabled={isSaving}
-              autoComplete="name"
-              maxLength={50}
-            />
-          </FormField>
-
-          <FormField
-            label="通知メールアドレス"
-            htmlFor="profile-notification-email"
-          >
-            <Input
-              id="profile-notification-email"
-              type="email"
-              placeholder="通知用メールアドレスを入力"
-              value={editNotificationEmail}
-              onChange={(e) => setEditNotificationEmail(e.target.value)}
-              disabled={isSaving}
-              autoComplete="email"
-            />
-          </FormField>
-
-          <div style={{ marginTop: '16px', display: 'flex', gap: '8px' }}>
-            <Button type="submit" disabled={isSaving}>
-              {isSaving ? '保存中...' : '保存'}
-            </Button>
-            <Button
-              type="button"
-              onClick={handleCancel}
-              variant="danger"
-              disabled={isSaving}
-            >
-              キャンセル
-            </Button>
-          </div>
-        </form>
-      </BaseCard>
-    )
-  }
-
-  // 表示モード
   return (
-    <BaseCard
-      title="プロフィール"
-      headerAction={
-        <Button
-          onClick={handleEdit}
-          variant="cloud"
-          size="sm"
-          aria-label="プロフィールを編集"
-        >
-          <EditIcon />
-        </Button>
-      }
-    >
-      <div>
-        <p>名前: {data?.name || '未設定'}</p>
-        <p>通知メールアドレス: {data?.notificationEmail || '未設定'}</p>
-      </div>
-    </BaseCard>
+    <>
+      <BaseCard
+        title="プロフィール"
+        headerAction={
+          <Button
+            onClick={() => setIsModalOpen(true)}
+            variant="cloud"
+            size="sm"
+            aria-label="プロフィールを編集"
+          >
+            <EditIcon />
+          </Button>
+        }
+      >
+        <div>
+          <p>名前: {data?.name || '未設定'}</p>
+          <p>通知メールアドレス: {data?.notificationEmail || '未設定'}</p>
+        </div>
+      </BaseCard>
+
+      {isModalOpen && data && (
+        <ProfileEditModal
+          initialName={data.name}
+          initialNotificationEmail={data.notificationEmail}
+          onClose={() => setIsModalOpen(false)}
+          onSuccess={(updated) => {
+            mutate({ ...data, ...updated })
+            setIsModalOpen(false)
+          }}
+        />
+      )}
+    </>
   )
 }

--- a/apps/web/components/ProfileEditModal.tsx
+++ b/apps/web/components/ProfileEditModal.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@repo/ui/button'
+import { FormField } from '@repo/ui/formField'
+import { Input } from '@repo/ui/input'
+import { ModalBase } from '@/components/common/ModalBase'
+import { apiPatch } from '@/lib/api/client'
+import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
+
+interface ProfileEditModalProps {
+  initialName: string
+  initialNotificationEmail: string | null
+  onClose: () => void
+  onSuccess: (updated: {
+    name: string
+    notificationEmail: string | null
+  }) => void
+}
+
+export function ProfileEditModal({
+  initialName,
+  initialNotificationEmail,
+  onClose,
+  onSuccess,
+}: ProfileEditModalProps) {
+  const [name, setName] = useState(initialName)
+  const [notificationEmail, setNotificationEmail] = useState(
+    initialNotificationEmail ?? ''
+  )
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    const trimmedName = name.trim()
+    if (!trimmedName) {
+      setError('名前を入力してください')
+      return
+    }
+
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      const response = await apiPatch('/api/v1/user/profile', {
+        name: trimmedName,
+        notificationEmail: notificationEmail.trim() || null,
+      })
+      onSuccess({
+        name: response.data.name,
+        notificationEmail: response.data.notificationEmail,
+      })
+    } catch (err) {
+      setError(
+        err instanceof ApiV1Error
+          ? err.message
+          : 'プロフィールの更新に失敗しました'
+      )
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <ModalBase title="プロフィール編集" onClose={onClose}>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4 p-4">
+        <FormField
+          label="ユーザー名"
+          htmlFor="modal-profile-name"
+          required
+          error={error || undefined}
+        >
+          <Input
+            id="modal-profile-name"
+            type="text"
+            placeholder="名前を入力"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value)
+              setError(null)
+            }}
+            disabled={isSubmitting}
+            autoComplete="name"
+            maxLength={50}
+            autoFocus
+          />
+        </FormField>
+
+        <FormField
+          label="通知メールアドレス"
+          htmlFor="modal-profile-notification-email"
+        >
+          <Input
+            id="modal-profile-notification-email"
+            type="email"
+            placeholder="通知用メールアドレスを入力"
+            value={notificationEmail}
+            onChange={(e) => setNotificationEmail(e.target.value)}
+            disabled={isSubmitting}
+            autoComplete="email"
+          />
+        </FormField>
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? '保存中...' : '保存'}
+          </Button>
+        </div>
+      </form>
+    </ModalBase>
+  )
+}

--- a/apps/web/lib/api/client.ts
+++ b/apps/web/lib/api/client.ts
@@ -178,7 +178,7 @@ export const apiDelete = async <U extends keyof API_EP>(
 type API_EP = {
   '/api/v1/user/profile': {
     GET: SuccessResponse<ApiResponseUserProfile>
-    POST: SuccessResponse<ApiResponseUserProfile>
+    PATCH: SuccessResponse<ApiResponseUserProfile>
   }
   '/api/v1/user/auth/register': {
     POST: SuccessResponse<ApiResponseUserProfile>

--- a/apps/web/lib/api/server/v1/user.ts
+++ b/apps/web/lib/api/server/v1/user.ts
@@ -10,7 +10,7 @@ import {
   UserAuthRecoverRequestSchema,
   UserAuthQuitRequestSchema,
   UserAuthRegisterRequestSchema,
-  UserProfileUpdateRequestSchema,
+  UserProfilePatchRequestSchema,
 } from '@repo/shared-types'
 import { ApiV1Error } from '../errors/ApiV1Error'
 import { honoAuthMiddleware } from '../middlewares/honoAuth'
@@ -46,20 +46,21 @@ user.get('/profile', honoAuthMiddleware, async (c) => {
 })
 
 /**
- * ユーザープロフィール更新エンドポイント
+ * ユーザープロフィール部分更新エンドポイント
  *
  * @remarks
  * - 認証必須（honoAuthMiddleware）
  * - リクエストボディのバリデーション（zodValidateJson）
- * - nameフィールド: 1文字以上50文字以下
+ * - nameフィールド: 指定時は1文字以上50文字以下
+ * - 少なくとも1フィールドの指定が必須
  */
-user.post(
+user.patch(
   '/profile',
   honoAuthMiddleware,
-  zodValidateJson(UserProfileUpdateRequestSchema),
+  zodValidateJson(UserProfilePatchRequestSchema),
   async (c) => {
     const { userId } = c.var.user!
-    const body = c.req.valid('json') // 型安全に UserProfileUpdateRequest として取得
+    const body = c.req.valid('json')
 
     const userRepo = new PrismaUserRepository(prisma)
 
@@ -71,7 +72,7 @@ user.post(
 
     const prevNotificationEmail = user.notificationEmail
 
-    if (body.name) {
+    if (body.name !== undefined) {
       user.name = body.name
     }
     if (body.notificationEmail !== undefined) {

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -50,8 +50,8 @@ paths:
           $ref: '#/components/responses/Error404'
         '500':
           $ref: '#/components/responses/Error500'
-    post:
-      summary: ユーザプロフィールの更新
+    patch:
+      summary: ユーザプロフィールの部分更新
       tags:
         - user
       requestBody:
@@ -1305,11 +1305,18 @@ components:
           maxLength: 50
     UserUpdateProfile:
       type: object
+      description: 少なくとも1フィールドの指定が必須
       properties:
         name:
           type: string
           minLength: 1
           maxLength: 50
+          description: ユーザー名（1-50文字）
+        notificationEmail:
+          type: string
+          format: email
+          nullable: true
+          description: 通知用メールアドレス（nullで削除）
     UserRegister:
       type: object
       required:

--- a/packages/shared-types/src/schemas/userProfileSchema.ts
+++ b/packages/shared-types/src/schemas/userProfileSchema.ts
@@ -48,6 +48,44 @@ export type UserAuthRegisterRequest = z.infer<
 >
 
 /**
+ * ユーザープロフィール部分更新リクエストのバリデーションスキーマ（PATCH用）
+ *
+ * @remarks
+ * - name: 省略可、指定時は1文字以上50文字以下
+ * - notificationEmail: 省略可、nullで削除
+ * - 少なくとも1フィールドの指定が必須
+ */
+export const UserProfilePatchRequestSchema = z
+  .object({
+    name: z
+      .string({
+        invalid_type_error: '名前は文字列である必要があります',
+      })
+      .min(1, '名前は1文字以上である必要があります')
+      .max(50, '名前は50文字以内である必要があります')
+      .trim()
+      .optional(),
+    notificationEmail: z
+      .string({
+        invalid_type_error: '通知メールアドレスは文字列である必要があります',
+      })
+      .email('有効なメールアドレスを入力してください')
+      .nullable()
+      .optional(),
+  })
+  .refine(
+    (data) => data.name !== undefined || data.notificationEmail !== undefined,
+    { message: '少なくとも1つのフィールドを指定してください' }
+  )
+
+/**
+ * ユーザープロフィール部分更新リクエストの型
+ */
+export type UserProfilePatchRequest = z.infer<
+  typeof UserProfilePatchRequestSchema
+>
+
+/**
  * ゲストユーザー登録リクエストのバリデーションスキーマ
  *
  * @remarks

--- a/packages/ui/src/BaseCard/baseCard.module.css
+++ b/packages/ui/src/BaseCard/baseCard.module.css
@@ -1,7 +1,7 @@
 .baseCard {
   width: 100%;
   max-width: 28rem;
-  padding: var(--spacing-8);
+  padding: var(--spacing-6);
   background-color: var(--color-background);
   border: 1px solid var(--color-cloud);
   border-radius: var(--radius-lg);


### PR DESCRIPTION
## 概要
プロフィール編集のAPIをPOSTからPATCHに変更し、部分更新に対応しました。
UIはフォーカスアウト自動保存ではなく、カード右上のペンアイコンからモーダルを開いて編集・保存する方式に変更しています。

## 変更内容

### API（PATCH化・部分更新対応）
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `shared-types/src/schemas/userProfileSchema.ts` | 修正 | `UserProfilePatchRequestSchema` を追加（各フィールドoptional・最低1つ必須） |
| `web/lib/api/server/v1/user.ts` | 修正 | `POST /profile` を `PATCH /profile` に変更 |
| `web/lib/api/client.ts` | 修正 | `API_EP` 型の `/api/v1/user/profile` を `POST` → `PATCH` に更新 |

### UI（モーダル編集）
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `web/components/ProfileCard.tsx` | 修正 | 表示カード化。右上ペンアイコンでモーダルを開く |
| `web/components/ProfileEditModal.tsx` | 追加 | `ModalBase` を使ったプロフィール編集モーダル |

### テスト
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `web/__tests__/api/v1/user.test.ts` | 修正 | `POST` → `PATCH` に変更。「フィールドなし」「メールのみ更新」のケースを追加 |

### その他の修正
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `web/app/(protected)/profile/page.tsx` | 修正 | `LogoutButton` をアカウントカード外に移動 |
| `web/components/FooterCard.tsx` | 修正 | レイアウト整理 |
| `ui/src/BaseCard/baseCard.module.css` | 修正 | paddingを `spacing-8` → `spacing-6` に縮小 |

## 影響範囲
- プロフィール編集機能（`/app/profile`）
- `POST /api/v1/user/profile` エンドポイント（`PATCH` に変更）

## テストプラン
- [x] プロフィールページを開き、ロード中はスケルトンが表示されること
- [x] ペンアイコンをクリックするとモーダルが開くこと
- [x] モーダルの × ボタン・オーバーレイクリックで閉じられること
- [x] ユーザー名を変更して保存すると反映されること
- [x] 通知メールアドレスのみ変更して保存すると反映されること
- [x] ユーザー名を空にして保存するとエラーが表示されること

Closes #336