### PR TITLE
[Feature] 項目別メンテナンス画面に残り走行距離と推奨スパンを表示 #349

### DIFF
--- a/apps/web/components/maintenance-log/MaintenanceLogByItemSection.module.css
+++ b/apps/web/components/maintenance-log/MaintenanceLogByItemSection.module.css
@@ -100,7 +100,13 @@
   opacity: 0.6;
 }
 
-.nextInfo {
+.remainingMileage {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-ink);
+}
+
+.recommendedInterval {
   font-size: var(--font-size-xs);
   color: var(--color-ink);
   opacity: 0.5;

--- a/apps/web/components/maintenance-log/MaintenanceLogByItemSection.tsx
+++ b/apps/web/components/maintenance-log/MaintenanceLogByItemSection.tsx
@@ -62,12 +62,21 @@ const buildItemHistoryMap = (
   return map
 }
 
-const getNextMileage = (
+const getRemainingMileage = (
   lastMileage: number,
-  interval: number | null
+  interval: number,
+  currentMileage: number
+): number => lastMileage + interval - currentMileage
+
+const formatRecommendedInterval = (
+  mileageInterval: number | null,
+  periodMonths: number | null
 ): string | null => {
-  if (interval === null) return null
-  return `${(lastMileage + interval).toLocaleString()}km`
+  const parts: string[] = []
+  if (mileageInterval !== null)
+    parts.push(`${mileageInterval.toLocaleString()}km毎`)
+  if (periodMonths !== null) parts.push(`${periodMonths}ヶ月毎`)
+  return parts.length > 0 ? parts.join(' / ') : null
 }
 
 export const MaintenanceLogByItemSection = ({
@@ -110,6 +119,22 @@ export const MaintenanceLogByItemSection = ({
                         masterItem.recommendedMileageInterval
                       : false
 
+                  const recommendedInterval = formatRecommendedInterval(
+                    masterItem.recommendedMileageInterval,
+                    masterItem.recommendedPeriodMonths
+                  )
+
+                  const remainingKm =
+                    currentMileage !== undefined &&
+                    latest &&
+                    masterItem.recommendedMileageInterval !== null
+                      ? getRemainingMileage(
+                          latest.mileage,
+                          masterItem.recommendedMileageInterval,
+                          currentMileage
+                        )
+                      : null
+
                   return (
                     <div
                       key={masterItem.type}
@@ -130,26 +155,26 @@ export const MaintenanceLogByItemSection = ({
                                 ({latest.mileage.toLocaleString()}km)
                               </span>
                             </span>
-                            {masterItem.recommendedMileageInterval !== null && (
-                              <span className={styles.nextInfo}>
-                                次回目安:{' '}
-                                {getNextMileage(
-                                  latest.mileage,
-                                  masterItem.recommendedMileageInterval
-                                )}
+                            {remainingKm !== null && remainingKm > 0 && (
+                              <span className={styles.remainingMileage}>
+                                あと {remainingKm.toLocaleString()} km
                               </span>
                             )}
-                            {masterItem.recommendedPeriodMonths !== null &&
-                              masterItem.recommendedMileageInterval ===
-                                null && (
-                                <span className={styles.nextInfo}>
-                                  推奨: {masterItem.recommendedPeriodMonths}
-                                  ヶ月毎
-                                </span>
-                              )}
+                            {recommendedInterval !== null && (
+                              <span className={styles.recommendedInterval}>
+                                推奨: {recommendedInterval}
+                              </span>
+                            )}
                           </>
                         ) : (
-                          <span className={styles.noRecord}>記録なし</span>
+                          <>
+                            <span className={styles.noRecord}>記録なし</span>
+                            {recommendedInterval !== null && (
+                              <span className={styles.recommendedInterval}>
+                                推奨: {recommendedInterval}
+                              </span>
+                            )}
+                          </>
                         )}
                       </div>
                     </div>


### PR DESCRIPTION
## 概要
メンテナンス履歴の「項目別」表示において、次回メンテナンスまでの残り走行距離が分かりにくいという課題を解消します。
「あとXkm」という相対表示と、各項目の推奨スパン（走行距離・期間）を常に表示するよう改善しました。

## 変更内容

### 項目別メンテナンス画面の表示改善
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `components/maintenance-log/MaintenanceLogByItemSection.tsx` | 修正 | 残りkm計算関数・推奨スパン整形関数を追加、表示ロジックを更新 |
| `components/maintenance-log/MaintenanceLogByItemSection.module.css` | 修正 | `remainingMileage`・`recommendedInterval` スタイルを追加 |

## 影響範囲
- メンテナンス履歴画面の「項目別」タブ表示

## テストプラン
- [x] メンテナンス履歴のある項目で「あと X km」が表示される
- [x] 走行距離と期間の両方がある項目（エンジンオイル等）で「推奨: 3,000km毎 / 6ヶ月毎」と表示される
- [x] 走行距離ベースのみの項目（ブレーキパッド等）で「推奨: 10,000km毎」と表示される
- [x] 期間ベースのみの項目（ブレーキ液等）で「推奨: 24ヶ月毎」と表示される
- [x] 推奨なしの項目（ライト等）は推奨スパンが表示されない
- [x] 履歴なし項目にも推奨スパンが表示される
- [x] 超過項目は「要確認」バッジが引き続き表示される（既存動作の維持）

Closes #349