### PR TITLE
Extract spot-related touring routes into userBikeSpotRoutes and register them

### DIFF
--- a/apps/web/lib/api/server/v1/userBike.ts
+++ b/apps/web/lib/api/server/v1/userBike.ts
@@ -13,13 +13,10 @@ import {
   ApiResponseTouringDetail,
   ApiResponseTouringList,
   ApiResponseBikesOngoingTourings,
-  ApiResponseSpotDetail,
-  ApiResponseSpotList,
   createBikeId,
   createFuelLogId,
   createMaintenanceLogId,
   createMyUserBikeId,
-  createSpotId,
   createTouringId,
   createUserId,
   FuelInsightPeriod,
@@ -41,9 +38,6 @@ import {
   TouringListQuerySchema,
   TouringUpdateRequestSchema,
   TouringDeleteRequestSchema,
-  SpotRegisterRequestSchema,
-  SpotUpdateRequestSchema,
-  SpotReorderRequestSchema,
   HistoryListQuerySchema,
 } from '@repo/shared-types'
 import { ApiV1Error } from '../errors/ApiV1Error'
@@ -60,19 +54,18 @@ import { PrismaFuelLogRepository } from '../repositories/PrismaFuelLogRepository
 import { PrismaHistoryRepository } from '../repositories/PrismaHistoryRepository'
 import { PrismaMaintenanceLogRepository } from '../repositories/PrismaMaintenanceLogRepository'
 import { PrismaMyUserBikeRepository } from '../repositories/PrismaMyUserBikeRepository'
-import { PrismaSpotRepository } from '../repositories/PrismaSpotRepository'
 import { PrismaTouringRepository } from '../repositories/PrismaTouringRepository'
 import { PrismaUserBikeRepository } from '../repositories/PrismaUserBikeRepository'
 import { FuelInsightService } from '../services/FuelInsightService'
 import { FuelLogService } from '../services/FuelLogService'
 import { MaintenanceLogService } from '../services/MaintenanceLogService'
-import { SpotService } from '../services/SpotService'
 import { TouringService } from '../services/TouringService'
 import { UserBikeService } from '../services/UserBikeService'
 import { FuelInsightSearchParams } from '../valueObjects/FuelInsightSearchParams'
 import { FuelLogSearchParams } from '../valueObjects/FuelLogSearchParams'
 import { TouringSearchParams } from '../valueObjects/TouringSearchParams'
 import { UserBikeSearchParams } from '../valueObjects/UserBikeSearchParams'
+import { registerUserBikeSpotRoutes } from './userBikeSpotRoutes'
 
 const userBike = new Hono()
 
@@ -1384,216 +1377,6 @@ userBike.patch(
   }
 )
 
-// スポット登録
-userBike.post(
-  '/bike/:myUserBikeId/tourings/:touringId/spots',
-  honoAuthMiddleware,
-  zodValidateJson(SpotRegisterRequestSchema),
-  async (c) => {
-    const { userId } = c.var.user!
-    const myUserBikeId = c.req.param('myUserBikeId')
-    const touringId = c.req.param('touringId')
-    const body = c.req.valid('json')
-
-    const spotRepo = new PrismaSpotRepository(prisma)
-    const touringRepo = new PrismaTouringRepository(prisma)
-    const myUserBikeRepo = new PrismaMyUserBikeRepository(prisma)
-    const service = new SpotService(spotRepo, touringRepo, myUserBikeRepo)
-
-    const spot = await service.registerSpot({
-      touringId: createTouringId(touringId),
-      myUserBikeId: createMyUserBikeId(myUserBikeId),
-      userId: createUserId(userId),
-      type: body.type,
-      name: body.name,
-      memo: body.memo,
-      latitude: body.latitude,
-      longitude: body.longitude,
-      visitedAt: body.visitedAt,
-      endAt: body.endAt,
-    })
-
-    return c.json<SuccessResponse<ApiResponseSpotDetail>>(
-      {
-        status: 'success',
-        data: {
-          spotId: spot.id,
-          touringId: spot.touringId,
-          type: spot.type,
-          name: spot.name,
-          memo: spot.memo,
-          latitude: spot.latitude,
-          longitude: spot.longitude,
-          visitedAt: spot.visitedAt.toISOString(),
-          endAt: spot.endAt?.toISOString() ?? null,
-          sortOrder: spot.sortOrder,
-        },
-        message: 'スポット登録成功',
-      },
-      201
-    )
-  }
-)
-
-// スポット一覧取得
-userBike.get(
-  '/bike/:myUserBikeId/tourings/:touringId/spots',
-  honoAuthMiddleware,
-  async (c) => {
-    const { userId } = c.var.user!
-    const myUserBikeId = c.req.param('myUserBikeId')
-    const touringId = c.req.param('touringId')
-
-    const spotRepo = new PrismaSpotRepository(prisma)
-    const touringRepo = new PrismaTouringRepository(prisma)
-    const myUserBikeRepo = new PrismaMyUserBikeRepository(prisma)
-    const service = new SpotService(spotRepo, touringRepo, myUserBikeRepo)
-
-    const spots = await service.getSpots(
-      createTouringId(touringId),
-      createMyUserBikeId(myUserBikeId),
-      createUserId(userId)
-    )
-
-    return c.json<SuccessResponse<ApiResponseSpotList>>(
-      {
-        status: 'success',
-        data: spots.map((spot) => ({
-          spotId: spot.id,
-          touringId: spot.touringId,
-          type: spot.type,
-          name: spot.name,
-          memo: spot.memo,
-          latitude: spot.latitude,
-          longitude: spot.longitude,
-          visitedAt: spot.visitedAt.toISOString(),
-          endAt: spot.endAt?.toISOString() ?? null,
-          sortOrder: spot.sortOrder,
-        })),
-        message: 'スポット一覧取得成功',
-      },
-      200
-    )
-  }
-)
-
-// スポット並び替え（/:spotId より前に定義）
-userBike.patch(
-  '/bike/:myUserBikeId/tourings/:touringId/spots/reorder',
-  honoAuthMiddleware,
-  zodValidateJson(SpotReorderRequestSchema),
-  async (c) => {
-    const { userId } = c.var.user!
-    const myUserBikeId = c.req.param('myUserBikeId')
-    const touringId = c.req.param('touringId')
-    const body = c.req.valid('json')
-
-    const spotRepo = new PrismaSpotRepository(prisma)
-    const touringRepo = new PrismaTouringRepository(prisma)
-    const myUserBikeRepo = new PrismaMyUserBikeRepository(prisma)
-    const service = new SpotService(spotRepo, touringRepo, myUserBikeRepo)
-
-    await service.reorderSpots(
-      body.spotIds,
-      createTouringId(touringId),
-      createMyUserBikeId(myUserBikeId),
-      createUserId(userId)
-    )
-
-    return c.json<SuccessResponse<undefined>>(
-      {
-        status: 'success',
-        data: undefined,
-        message: 'スポット並び替え成功',
-      },
-      200
-    )
-  }
-)
-
-// スポット更新
-userBike.patch(
-  '/bike/:myUserBikeId/tourings/:touringId/spots/:spotId',
-  honoAuthMiddleware,
-  zodValidateJson(SpotUpdateRequestSchema),
-  async (c) => {
-    const { userId } = c.var.user!
-    const myUserBikeId = c.req.param('myUserBikeId')
-    const touringId = c.req.param('touringId')
-    const spotId = c.req.param('spotId')
-    const body = c.req.valid('json')
-
-    const spotRepo = new PrismaSpotRepository(prisma)
-    const touringRepo = new PrismaTouringRepository(prisma)
-    const myUserBikeRepo = new PrismaMyUserBikeRepository(prisma)
-    const service = new SpotService(spotRepo, touringRepo, myUserBikeRepo)
-
-    const spot = await service.updateSpot({
-      spotId: createSpotId(spotId),
-      touringId: createTouringId(touringId),
-      myUserBikeId: createMyUserBikeId(myUserBikeId),
-      userId: createUserId(userId),
-      name: body.name,
-      memo: body.memo,
-      latitude: body.latitude,
-      longitude: body.longitude,
-      visitedAt: body.visitedAt,
-      endAt: body.endAt,
-    })
-
-    return c.json<SuccessResponse<ApiResponseSpotDetail>>(
-      {
-        status: 'success',
-        data: {
-          spotId: spot.id,
-          touringId: spot.touringId,
-          type: spot.type,
-          name: spot.name,
-          memo: spot.memo,
-          latitude: spot.latitude,
-          longitude: spot.longitude,
-          visitedAt: spot.visitedAt.toISOString(),
-          endAt: spot.endAt?.toISOString() ?? null,
-          sortOrder: spot.sortOrder,
-        },
-        message: 'スポット更新成功',
-      },
-      200
-    )
-  }
-)
-
-// スポット削除
-userBike.delete(
-  '/bike/:myUserBikeId/tourings/:touringId/spots/:spotId',
-  honoAuthMiddleware,
-  async (c) => {
-    const { userId } = c.var.user!
-    const myUserBikeId = c.req.param('myUserBikeId')
-    const touringId = c.req.param('touringId')
-    const spotId = c.req.param('spotId')
-
-    const spotRepo = new PrismaSpotRepository(prisma)
-    const touringRepo = new PrismaTouringRepository(prisma)
-    const myUserBikeRepo = new PrismaMyUserBikeRepository(prisma)
-    const service = new SpotService(spotRepo, touringRepo, myUserBikeRepo)
-
-    await service.deleteSpot(
-      createSpotId(spotId),
-      createTouringId(touringId),
-      createMyUserBikeId(myUserBikeId),
-      createUserId(userId)
-    )
-
-    return c.json<SuccessResponse<undefined>>(
-      {
-        status: 'success',
-        data: undefined,
-        message: 'スポット削除成功',
-      },
-      200
-    )
-  }
-)
+registerUserBikeSpotRoutes(userBike)
 
 export default userBike

--- a/apps/web/lib/api/server/v1/userBikeSpotRoutes.ts
+++ b/apps/web/lib/api/server/v1/userBikeSpotRoutes.ts
@@ -1,0 +1,236 @@
+import { Hono } from 'hono'
+import { prisma } from '@repo/database'
+import {
+  ApiResponseSpotDetail,
+  ApiResponseSpotList,
+  createMyUserBikeId,
+  createSpotId,
+  createTouringId,
+  createUserId,
+  SpotRegisterRequestSchema,
+  SpotReorderRequestSchema,
+  SpotUpdateRequestSchema,
+  SuccessResponse,
+} from '@repo/shared-types'
+import { honoAuthMiddleware } from '../middlewares/honoAuth'
+import { zodValidateJson } from '../middlewares/zodValidation'
+import { PrismaMyUserBikeRepository } from '../repositories/PrismaMyUserBikeRepository'
+import { PrismaSpotRepository } from '../repositories/PrismaSpotRepository'
+import { PrismaTouringRepository } from '../repositories/PrismaTouringRepository'
+import { SpotService } from '../services/SpotService'
+
+export const registerUserBikeSpotRoutes = (userBike: Hono) => {
+// スポット登録
+userBike.post(
+  '/bike/:myUserBikeId/tourings/:touringId/spots',
+  honoAuthMiddleware,
+  zodValidateJson(SpotRegisterRequestSchema),
+  async (c) => {
+    const { userId } = c.var.user!
+    const myUserBikeId = c.req.param('myUserBikeId')
+    const touringId = c.req.param('touringId')
+    const body = c.req.valid('json')
+
+    const spotRepo = new PrismaSpotRepository(prisma)
+    const touringRepo = new PrismaTouringRepository(prisma)
+    const myUserBikeRepo = new PrismaMyUserBikeRepository(prisma)
+    const service = new SpotService(spotRepo, touringRepo, myUserBikeRepo)
+
+    const spot = await service.registerSpot({
+      touringId: createTouringId(touringId),
+      myUserBikeId: createMyUserBikeId(myUserBikeId),
+      userId: createUserId(userId),
+      type: body.type,
+      name: body.name,
+      memo: body.memo,
+      latitude: body.latitude,
+      longitude: body.longitude,
+      visitedAt: body.visitedAt,
+      endAt: body.endAt,
+    })
+
+    return c.json<SuccessResponse<ApiResponseSpotDetail>>(
+      {
+        status: 'success',
+        data: {
+          spotId: spot.id,
+          touringId: spot.touringId,
+          type: spot.type,
+          name: spot.name,
+          memo: spot.memo,
+          latitude: spot.latitude,
+          longitude: spot.longitude,
+          visitedAt: spot.visitedAt.toISOString(),
+          endAt: spot.endAt?.toISOString() ?? null,
+          sortOrder: spot.sortOrder,
+        },
+        message: 'スポット登録成功',
+      },
+      201
+    )
+  }
+)
+
+// スポット一覧取得
+userBike.get(
+  '/bike/:myUserBikeId/tourings/:touringId/spots',
+  honoAuthMiddleware,
+  async (c) => {
+    const { userId } = c.var.user!
+    const myUserBikeId = c.req.param('myUserBikeId')
+    const touringId = c.req.param('touringId')
+
+    const spotRepo = new PrismaSpotRepository(prisma)
+    const touringRepo = new PrismaTouringRepository(prisma)
+    const myUserBikeRepo = new PrismaMyUserBikeRepository(prisma)
+    const service = new SpotService(spotRepo, touringRepo, myUserBikeRepo)
+
+    const spots = await service.getSpots(
+      createTouringId(touringId),
+      createMyUserBikeId(myUserBikeId),
+      createUserId(userId)
+    )
+
+    return c.json<SuccessResponse<ApiResponseSpotList>>(
+      {
+        status: 'success',
+        data: spots.map((spot) => ({
+          spotId: spot.id,
+          touringId: spot.touringId,
+          type: spot.type,
+          name: spot.name,
+          memo: spot.memo,
+          latitude: spot.latitude,
+          longitude: spot.longitude,
+          visitedAt: spot.visitedAt.toISOString(),
+          endAt: spot.endAt?.toISOString() ?? null,
+          sortOrder: spot.sortOrder,
+        })),
+        message: 'スポット一覧取得成功',
+      },
+      200
+    )
+  }
+)
+
+// スポット並び替え（/:spotId より前に定義）
+userBike.patch(
+  '/bike/:myUserBikeId/tourings/:touringId/spots/reorder',
+  honoAuthMiddleware,
+  zodValidateJson(SpotReorderRequestSchema),
+  async (c) => {
+    const { userId } = c.var.user!
+    const myUserBikeId = c.req.param('myUserBikeId')
+    const touringId = c.req.param('touringId')
+    const body = c.req.valid('json')
+
+    const spotRepo = new PrismaSpotRepository(prisma)
+    const touringRepo = new PrismaTouringRepository(prisma)
+    const myUserBikeRepo = new PrismaMyUserBikeRepository(prisma)
+    const service = new SpotService(spotRepo, touringRepo, myUserBikeRepo)
+
+    await service.reorderSpots(
+      body.spotIds,
+      createTouringId(touringId),
+      createMyUserBikeId(myUserBikeId),
+      createUserId(userId)
+    )
+
+    return c.json<SuccessResponse<undefined>>(
+      {
+        status: 'success',
+        data: undefined,
+        message: 'スポット並び替え成功',
+      },
+      200
+    )
+  }
+)
+
+// スポット更新
+userBike.patch(
+  '/bike/:myUserBikeId/tourings/:touringId/spots/:spotId',
+  honoAuthMiddleware,
+  zodValidateJson(SpotUpdateRequestSchema),
+  async (c) => {
+    const { userId } = c.var.user!
+    const myUserBikeId = c.req.param('myUserBikeId')
+    const touringId = c.req.param('touringId')
+    const spotId = c.req.param('spotId')
+    const body = c.req.valid('json')
+
+    const spotRepo = new PrismaSpotRepository(prisma)
+    const touringRepo = new PrismaTouringRepository(prisma)
+    const myUserBikeRepo = new PrismaMyUserBikeRepository(prisma)
+    const service = new SpotService(spotRepo, touringRepo, myUserBikeRepo)
+
+    const spot = await service.updateSpot({
+      spotId: createSpotId(spotId),
+      touringId: createTouringId(touringId),
+      myUserBikeId: createMyUserBikeId(myUserBikeId),
+      userId: createUserId(userId),
+      name: body.name,
+      memo: body.memo,
+      latitude: body.latitude,
+      longitude: body.longitude,
+      visitedAt: body.visitedAt,
+      endAt: body.endAt,
+    })
+
+    return c.json<SuccessResponse<ApiResponseSpotDetail>>(
+      {
+        status: 'success',
+        data: {
+          spotId: spot.id,
+          touringId: spot.touringId,
+          type: spot.type,
+          name: spot.name,
+          memo: spot.memo,
+          latitude: spot.latitude,
+          longitude: spot.longitude,
+          visitedAt: spot.visitedAt.toISOString(),
+          endAt: spot.endAt?.toISOString() ?? null,
+          sortOrder: spot.sortOrder,
+        },
+        message: 'スポット更新成功',
+      },
+      200
+    )
+  }
+)
+
+// スポット削除
+userBike.delete(
+  '/bike/:myUserBikeId/tourings/:touringId/spots/:spotId',
+  honoAuthMiddleware,
+  async (c) => {
+    const { userId } = c.var.user!
+    const myUserBikeId = c.req.param('myUserBikeId')
+    const touringId = c.req.param('touringId')
+    const spotId = c.req.param('spotId')
+
+    const spotRepo = new PrismaSpotRepository(prisma)
+    const touringRepo = new PrismaTouringRepository(prisma)
+    const myUserBikeRepo = new PrismaMyUserBikeRepository(prisma)
+    const service = new SpotService(spotRepo, touringRepo, myUserBikeRepo)
+
+    await service.deleteSpot(
+      createSpotId(spotId),
+      createTouringId(touringId),
+      createMyUserBikeId(myUserBikeId),
+      createUserId(userId)
+    )
+
+    return c.json<SuccessResponse<undefined>>(
+      {
+        status: 'success',
+        data: undefined,
+        message: 'スポット削除成功',
+      },
+      200
+    )
+  }
+)
+
+
+}


### PR DESCRIPTION
### Motivation
- Improve code organization by separating spot-related touring HTTP handlers out of the large `userBike` routes file to make routing concerns modular and easier to maintain.

### Description
- Removed spot-specific imports and inline route handlers from `apps/web/lib/api/server/v1/userBike.ts` and replaced them with a call to `registerUserBikeSpotRoutes(userBike)`.
- Added new module `apps/web/lib/api/server/v1/userBikeSpotRoutes.ts` which contains the spot routes (register, list, reorder, update, delete) and registers them against a provided `Hono` instance.
- The new module reuses existing repositories and services (`PrismaSpotRepository`, `PrismaTouringRepository`, `PrismaMyUserBikeRepository`, `SpotService`) and preserves the original request/response shapes and validation schemas.

### Testing
- Ran TypeScript type checking which completed successfully.
- Executed the existing automated test suite which passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f14d092ee08330ae24419f0627c4d2)