### PR TITLE
Fix touring location update to preserve unmodified coordinates

### DIFF
--- a/apps/web/__tests__/api/v1/userBike.test.ts
+++ b/apps/web/__tests__/api/v1/userBike.test.ts
@@ -2967,6 +2967,94 @@ describe('UserBike API Endpoints', () => {
       expect(json.data.endLongitude).toBeCloseTo(135.5023)
     })
 
+    test('開始地点を更新しても終了地点はリセットされない', async () => {
+      // まず開始・終了位置を両方設定
+      await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            startLatitude: 35.6895,
+            startLongitude: 139.6917,
+            endLatitude: 34.6937,
+            endLongitude: 135.5023,
+          }),
+        }
+      )
+
+      // 開始地点のみ更新
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            startLatitude: 36.0,
+            startLongitude: 140.0,
+          }),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(200)
+      expect(json.data.startLatitude).toBeCloseTo(36.0)
+      expect(json.data.startLongitude).toBeCloseTo(140.0)
+      // 終了地点はリセットされず保持される
+      expect(json.data.endLatitude).toBeCloseTo(34.6937)
+      expect(json.data.endLongitude).toBeCloseTo(135.5023)
+    })
+
+    test('終了地点を更新しても開始地点はリセットされない', async () => {
+      // まず開始・終了位置を両方設定
+      await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            startLatitude: 35.6895,
+            startLongitude: 139.6917,
+            endLatitude: 34.6937,
+            endLongitude: 135.5023,
+          }),
+        }
+      )
+
+      // 終了地点のみ更新
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/tourings/${touringId}`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            endLatitude: 33.0,
+            endLongitude: 130.0,
+          }),
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(200)
+      // 開始地点はリセットされず保持される
+      expect(json.data.startLatitude).toBeCloseTo(35.6895)
+      expect(json.data.startLongitude).toBeCloseTo(139.6917)
+      expect(json.data.endLatitude).toBeCloseTo(33.0)
+      expect(json.data.endLongitude).toBeCloseTo(130.0)
+    })
+
     test('位置情報をnullで削除できる', async () => {
       // まず位置情報を設定
       await app.request(

--- a/apps/web/lib/api/server/services/TouringService.ts
+++ b/apps/web/lib/api/server/services/TouringService.ts
@@ -346,20 +346,20 @@ export class TouringService {
         startMileage: params.startMileage ?? existingTouring.startMileage,
         endMileage: params.endMileage ?? existingTouring.endMileage,
         startLatitude:
-          'startLatitude' in params
-            ? (params.startLatitude ?? null)
+          params.startLatitude !== undefined
+            ? params.startLatitude
             : existingTouring.startLatitude,
         startLongitude:
-          'startLongitude' in params
-            ? (params.startLongitude ?? null)
+          params.startLongitude !== undefined
+            ? params.startLongitude
             : existingTouring.startLongitude,
         endLatitude:
-          'endLatitude' in params
-            ? (params.endLatitude ?? null)
+          params.endLatitude !== undefined
+            ? params.endLatitude
             : existingTouring.endLatitude,
         endLongitude:
-          'endLongitude' in params
-            ? (params.endLongitude ?? null)
+          params.endLongitude !== undefined
+            ? params.endLongitude
             : existingTouring.endLongitude,
         status: newStatus,
       })


### PR DESCRIPTION
## 概要

ツーリング情報の開始地点・終了地点を部分更新する際に、指定されていない座標がリセットされてしまう問題を修正しました。

条件判定を `'key' in params` から `params.key !== undefined` に変更することで、明示的に `null` が渡された場合のみ座標をリセットし、キーが存在しない場合は既存の値を保持するようにしました。

## 関連タスク

-

## チェックポイント

- [x] 開始地点のみ更新時に終了地点が保持される
- [x] 終了地点のみ更新時に開始地点が保持される
- [x] 明示的に `null` を渡した場合は座標がリセットされる

## 影響範囲・懸念

- TouringService の updateTouring メソッドの座標更新ロジック
- ツーリング情報の PATCH エンドポイント

## 備考

新しいテストケースを2つ追加しました：
- `開始地点を更新しても終了地点はリセットされない`
- `終了地点を更新しても開始地点はリセットされない`

既存の位置情報削除テスト（`位置情報をnullで削除できる`）により、`null` による明示的なリセット機能は引き続き動作することが保証されます。

https://claude.ai/code/session_01GFgwGK5ZKUVye9fhMbF3bN