### PR TITLE
✨ [Feature] SPメニュー表現の改良 (#378)

### DIFF
--- a/apps/admin/.gitignore
+++ b/apps/admin/.gitignore
@@ -1,0 +1,36 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+.yarn/install-state.gz
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# env files (can opt-in for commiting if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/apps/admin/next-env.d.ts
+++ b/apps/admin/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts'
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/app/app/(protected)/layout.tsx
+++ b/apps/web/app/app/(protected)/layout.tsx
@@ -15,7 +15,7 @@ export default function Layout({ children }: Props) {
       <DesktopSidebar />
       <MobileNavigation />
 
-      <div className="min-h-screen w-full flex flex-col items-center p-4 gap-6 pt-16 pb-20 sm:pt-4 sm:pb-4">
+      <div className="min-h-screen w-full flex flex-col items-center p-4 gap-6 pt-16 pb-20 sm:pt-4 sm:pb-4 sm:pl-24">
         <BreadcrumbNav />
         <GuestBanner />
         {children}

--- a/apps/web/app/app/(protected)/layout.tsx
+++ b/apps/web/app/app/(protected)/layout.tsx
@@ -1,6 +1,7 @@
 import { GuestBanner } from '@/components/GuestBanner'
 import { BreadcrumbNav } from '@/components/Navigation/BreadcrumbNav'
 import { DesktopSidebar } from '@/components/Navigation/DesktopSidebar'
+import { MobileHeader } from '@/components/Navigation/MobileHeader'
 import { MobileNavigation } from '@/components/Navigation/MobileNavigation'
 
 type Props = {
@@ -10,10 +11,11 @@ type Props = {
 export default function Layout({ children }: Props) {
   return (
     <>
+      <MobileHeader />
       <DesktopSidebar />
       <MobileNavigation />
 
-      <div className="min-h-screen w-full flex flex-col items-center p-4 gap-6 pb-24 sm:pb-4">
+      <div className="min-h-screen w-full flex flex-col items-center p-4 gap-6 pt-16 pb-20 sm:pt-4 sm:pb-4">
         <BreadcrumbNav />
         <GuestBanner />
         {children}

--- a/apps/web/app/app/layout.tsx
+++ b/apps/web/app/app/layout.tsx
@@ -26,7 +26,8 @@ export default function RootLayout({
   return (
     <>
       <Providers>
-        <div className="fixed top-4 right-4 z-50">
+        {/* デスクトップのみ: モバイルは MobileHeader が担当 */}
+        <div className="hidden sm:block fixed top-4 right-4 z-50">
           <ThemeToggleButton />
         </div>
         {children}

--- a/apps/web/app/sonner-custom.css
+++ b/apps/web/app/sonner-custom.css
@@ -16,6 +16,14 @@
   --warning-text: var(--color-warningActive);
 }
 
+/* モバイル: bottom-bar の高さ分 Toast を上にずらす */
+/* Sonner はモバイル時に --mobile-offset-bottom をインラインスタイルで設定するため !important が必要 */
+@media (max-width: 639px) {
+  [data-sonner-toaster][data-y-position='bottom'] {
+    bottom: calc(4rem + 0.75rem) !important;
+  }
+}
+
 /* ダークモード対応 */
 html[data-theme-mode='dark'] [data-sonner-toaster] {
   /* ダークモードでは背景色の透明度を少し上げる */

--- a/apps/web/components/Navigation/MobileHeader.module.css
+++ b/apps/web/components/Navigation/MobileHeader.module.css
@@ -1,0 +1,34 @@
+.header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 var(--spacing-4);
+  height: 3.5rem;
+  background-color: var(--color-cloud);
+  border-bottom: 1px solid var(--color-cloudHover);
+  box-shadow: var(--shadow-sm);
+}
+
+@media (min-width: 640px) {
+  .header {
+    display: none;
+  }
+}
+
+.appName {
+  font-weight: 700;
+  font-size: 1.125rem;
+  color: var(--color-ink);
+  letter-spacing: -0.01em;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+}

--- a/apps/web/components/Navigation/MobileHeader.module.css
+++ b/apps/web/components/Navigation/MobileHeader.module.css
@@ -9,9 +9,10 @@
   justify-content: space-between;
   padding: 0 var(--spacing-4);
   height: 3.5rem;
-  background-color: var(--color-cloud);
-  border-bottom: 1px solid var(--color-cloudHover);
-  box-shadow: var(--shadow-sm);
+  background-color: color-mix(in srgb, var(--color-background) 80%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-cloudHover) 50%, transparent);
 }
 
 @media (min-width: 640px) {

--- a/apps/web/components/Navigation/MobileHeader.tsx
+++ b/apps/web/components/Navigation/MobileHeader.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import styles from './MobileHeader.module.css'
+import { ThemeToggleButton } from '@/components/ThemeToggleButton'
+import { APP_NAME } from '@/lib/statics'
+
+export function MobileHeader() {
+  return (
+    <header className={styles.header} aria-label="モバイルヘッダー">
+      <span className={styles.appName}>{APP_NAME}</span>
+      <div className={styles.actions}>
+        <ThemeToggleButton />
+      </div>
+    </header>
+  )
+}

--- a/apps/web/components/Navigation/MobileNavigation.module.css
+++ b/apps/web/components/Navigation/MobileNavigation.module.css
@@ -1,17 +1,18 @@
 .bottomNavigation {
   position: fixed;
-  left: 50%;
-  bottom: 1rem;
+  bottom: 0;
+  left: 0;
+  right: 0;
   z-index: 50;
-  transform: translateX(-50%);
   display: flex;
   align-items: center;
-  gap: var(--spacing-2);
-  padding: var(--spacing-2) var(--spacing-3);
+  justify-content: space-around;
+  padding: var(--spacing-1) var(--spacing-2);
+  padding-bottom: max(var(--spacing-2), env(safe-area-inset-bottom));
+  height: 4rem;
   background-color: var(--color-cloud);
-  border: 1px solid var(--color-cloudHover);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-md);
+  border-top: 1px solid var(--color-cloudHover);
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.08);
 }
 
 @media (min-width: 640px) {

--- a/apps/web/components/Navigation/MobileNavigation.module.css
+++ b/apps/web/components/Navigation/MobileNavigation.module.css
@@ -10,9 +10,10 @@
   padding: var(--spacing-1) var(--spacing-2);
   padding-bottom: max(var(--spacing-2), env(safe-area-inset-bottom));
   height: 4rem;
-  background-color: var(--color-cloud);
-  border-top: 1px solid var(--color-cloudHover);
-  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.08);
+  background-color: color-mix(in srgb, var(--color-background) 80%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-top: 1px solid color-mix(in srgb, var(--color-cloudHover) 50%, transparent);
 }
 
 @media (min-width: 640px) {

--- a/apps/web/components/Navigation/MobileNavigation.tsx
+++ b/apps/web/components/Navigation/MobileNavigation.tsx
@@ -16,6 +16,7 @@ export function MobileNavigation() {
           href={item.href}
           label={item.label}
           icon={item.icon}
+          showLabel
         />
       ))}
     </nav>

--- a/apps/web/components/Navigation/NavigationButton.module.css
+++ b/apps/web/components/Navigation/NavigationButton.module.css
@@ -27,6 +27,22 @@
   color: white;
 }
 
+.withLabel {
+  width: auto;
+  height: auto;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0.25rem 0.5rem;
+  min-width: 3rem;
+}
+
+.label {
+  font-size: 0.625rem;
+  font-weight: 500;
+  line-height: 1;
+  text-align: center;
+}
+
 /* アクセシビリティ: モーション削減 */
 @media (prefers-reduced-motion: reduce) {
   .navButton {

--- a/apps/web/components/Navigation/NavigationButton.tsx
+++ b/apps/web/components/Navigation/NavigationButton.tsx
@@ -8,12 +8,14 @@ interface NavigationButtonProps {
   href: string
   label: string
   icon: React.ComponentType
+  showLabel?: boolean
 }
 
 export function NavigationButton({
   href,
   label,
   icon: Icon,
+  showLabel = false,
 }: NavigationButtonProps) {
   const pathname = usePathname()
   const isActive = pathname === href || pathname.startsWith(href + '/')
@@ -21,12 +23,13 @@ export function NavigationButton({
   return (
     <Link
       href={href}
-      className={`${styles.navButton} ${isActive ? styles.active : ''}`}
+      className={`${styles.navButton} ${isActive ? styles.active : ''} ${showLabel ? styles.withLabel : ''}`}
       aria-label={label}
       aria-current={isActive ? 'page' : undefined}
       title={label}
     >
       <Icon />
+      {showLabel && <span className={styles.label}>{label}</span>}
     </Link>
   )
 }

--- a/apps/web/components/common/ModalBase.tsx
+++ b/apps/web/components/common/ModalBase.tsx
@@ -4,6 +4,10 @@ import { useEffect } from 'react'
 import styles from './ModalBase.module.css'
 import { XIcon } from '@/components/icons/XIcon'
 
+// ネストしたモーダルで scroll lock が解除されないようカウンタで管理する
+let scrollLockCount = 0
+let savedScrollY = 0
+
 interface ModalBaseProps {
   title: string
   onClose: () => void
@@ -18,17 +22,21 @@ export function ModalBase({
   size = 'md',
 }: ModalBaseProps) {
   useEffect(() => {
-    // iOS Safari では overflow:hidden だけではスクロールが止まらないため
-    // position:fixed + top で完全にスクロールをロックする
-    const scrollY = window.scrollY
-    document.body.style.position = 'fixed'
-    document.body.style.top = `-${scrollY}px`
-    document.body.style.width = '100%'
+    if (scrollLockCount === 0) {
+      savedScrollY = window.scrollY
+      document.body.style.position = 'fixed'
+      document.body.style.top = `-${savedScrollY}px`
+      document.body.style.width = '100%'
+    }
+    scrollLockCount++
     return () => {
-      document.body.style.position = ''
-      document.body.style.top = ''
-      document.body.style.width = ''
-      window.scrollTo(0, scrollY)
+      scrollLockCount--
+      if (scrollLockCount === 0) {
+        document.body.style.position = ''
+        document.body.style.top = ''
+        document.body.style.width = ''
+        window.scrollTo(0, savedScrollY)
+      }
     }
   }, [])
 

--- a/apps/web/components/common/ModalBase.tsx
+++ b/apps/web/components/common/ModalBase.tsx
@@ -18,13 +18,17 @@ export function ModalBase({
   size = 'md',
 }: ModalBaseProps) {
   useEffect(() => {
-    const originalBodyOverflow = document.body.style.overflow
-    const originalHtmlOverflow = document.documentElement.style.overflow
-    document.body.style.overflow = 'hidden'
-    document.documentElement.style.overflow = 'hidden'
+    // iOS Safari では overflow:hidden だけではスクロールが止まらないため
+    // position:fixed + top で完全にスクロールをロックする
+    const scrollY = window.scrollY
+    document.body.style.position = 'fixed'
+    document.body.style.top = `-${scrollY}px`
+    document.body.style.width = '100%'
     return () => {
-      document.body.style.overflow = originalBodyOverflow
-      document.documentElement.style.overflow = originalHtmlOverflow
+      document.body.style.position = ''
+      document.body.style.top = ''
+      document.body.style.width = ''
+      window.scrollTo(0, scrollY)
     }
   }, [])
 


### PR DESCRIPTION
## 概要

SP（スマートフォン）でのメニュー表示を全面的に改良しました。フローティングピル型のボトムナビゲーションを全幅 bottom-bar に変更し、専用のモバイルヘッダーを新設することで Toast・テーマ切り替えとの競合を解消しています。あわせてモーダルのスクロールロックを iOS Safari 対応の実装に修正しました。

## 変更内容

### モバイルナビゲーション再設計

| ファイル | 変更種別 | 内容 |
|---|---|---|
| `Navigation/MobileNavigation.module.css` | 修正 | フローティングピル → 全幅 bottom-bar（半透明 + `backdrop-filter: blur`）|
| `Navigation/MobileNavigation.tsx` | 修正 | `showLabel` prop を追加してアイコン下にラベルテキストを表示 |
| `Navigation/NavigationButton.module.css` | 修正 | `showLabel` 時のスタイル（縦並び・ラベル）を追加 |
| `Navigation/NavigationButton.tsx` | 修正 | `showLabel` オプション対応 |

### モバイルヘッダー新設

| ファイル | 変更種別 | 内容 |
|---|---|---|
| `Navigation/MobileHeader.tsx` | 追加 | アプリ名 + ThemeToggle を含むモバイル専用ヘッダー |
| `Navigation/MobileHeader.module.css` | 追加 | 半透明 + `backdrop-filter: blur` のすりガラス風スタイル |
| `app/app/(protected)/layout.tsx` | 修正 | `<MobileHeader>` を組み込み、コンテンツの padding を調整 |
| `app/app/layout.tsx` | 修正 | ThemeToggle をデスクトップのみ表示（モバイルは MobileHeader が担当） |

### Toast 競合解消

| ファイル | 変更種別 | 内容 |
|---|---|---|
| `app/sonner-custom.css` | 修正 | モバイル時に Toast を bottom-bar の高さ分上にオフセット（`!important` で Sonner のインラインスタイルを上書き） |

### モーダル修正

| ファイル | 変更種別 | 内容 |
|---|---|---|
| `common/ModalBase.tsx` | 修正 | スクロールロックを `overflow:hidden` から `position:fixed + top` 方式に変更（iOS Safari 対応） |

### その他の修正

| ファイル | 変更種別 | 内容 |
|---|---|---|
| `apps/admin/.gitignore` | 追加 | `next-env.d.ts` を追跡対象外にする設定を追加 |
| `apps/admin/next-env.d.ts` | 削除 | git 追跡解除 |

## 影響範囲

- SP での全保護ルート画面（`/app/**`）のレイアウト
- `ModalBase` を使用しているすべてのモーダル（給油・メンテナンス・ツーリング等）
- `Toaster`（Sonner）の表示位置（モバイルのみ）

## テストプラン

- [ ] モバイル幅（<640px）でヘッダー（MotoReco + ThemeToggle）が上部に表示される
- [ ] モバイル幅でボトムナビが全幅バー + アイコン + ラベルで表示される
- [ ] 各ナビリンクをタップしてページ遷移・アクティブ状態が切り替わる
- [ ] ThemeToggle でダーク/ライトが切り替わる
- [ ] Toast が bottom-bar に重ならず上に表示される
- [ ] モーダル（給油登録など）を開いても背景が動かない（iOS Safari）
- [ ] デスクトップ幅（≥640px）で MobileHeader・MobileNavigation が非表示、サイドバーと ThemeToggle が従来通り表示される

Closes #378