### PR TITLE
🔥 antd v6不要なReact 19パッチのimportを削除

### DIFF
--- a/apps/admin/components/AdminShell.tsx
+++ b/apps/admin/components/AdminShell.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import '@ant-design/v5-patch-for-react-19'
 import {
   useNotificationProvider,
   ThemedLayout,


### PR DESCRIPTION
## 概要
antd v6 は React 19 をネイティブサポートしているため、`@ant-design/v5-patch-for-react-19` のimportが不要になっていた。
該当のimportを削除し、コンソールの警告を解消する。

## 変更内容

### 不要なimportの削除
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `admin/components/AdminShell.tsx` | 修正 | `@ant-design/v5-patch-for-react-19` のimportを削除 |

## 影響範囲
- `apps/admin/components/AdminShell.tsx`

## テストプラン
- [x] admin画面を開いてコンソールに警告が出ないことを確認