### PR TITLE
🐛 fix: SP表示で通知ポップアップが画面外にはみ出るバグを修正 #398

### DIFF
--- a/apps/e2e/tests/notifications/notification-sp.spec.ts
+++ b/apps/e2e/tests/notifications/notification-sp.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '../../fixtures/authenticatedPage'
+import { NotificationsPage } from '../../pages/notificationsPage'
+
+/**
+ * SP（スマートフォン）ビューでの通知ドロップダウン表示テスト
+ *
+ * @remarks
+ * Issue #398: SP表示でお知らせポップアップが画面外に表示される
+ */
+test.describe('通知ドロップダウン SP表示', () => {
+  test.use({ viewport: { width: 375, height: 812 } })
+
+  test('375px幅でドロップダウンが画面内に収まる', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.goto('/app/home')
+    const notifPage = new NotificationsPage(authenticatedPage)
+
+    await notifPage.openDropdown()
+    await expect(notifPage.notificationDropdown).toBeVisible()
+
+    const viewportWidth = authenticatedPage.viewportSize()?.width ?? 375
+    const box = await notifPage.notificationDropdown.boundingBox()
+
+    expect(box).not.toBeNull()
+    if (box) {
+      expect(box.x).toBeGreaterThanOrEqual(0)
+      expect(box.x + box.width).toBeLessThanOrEqual(viewportWidth)
+    }
+  })
+
+  test('320px幅でドロップダウンが画面内に収まる', async ({
+    authenticatedPage,
+  }) => {
+    await authenticatedPage.setViewportSize({ width: 320, height: 568 })
+    await authenticatedPage.goto('/app/home')
+    const notifPage = new NotificationsPage(authenticatedPage)
+
+    await notifPage.openDropdown()
+    await expect(notifPage.notificationDropdown).toBeVisible()
+
+    const box = await notifPage.notificationDropdown.boundingBox()
+
+    expect(box).not.toBeNull()
+    if (box) {
+      expect(box.x).toBeGreaterThanOrEqual(0)
+      expect(box.x + box.width).toBeLessThanOrEqual(320)
+    }
+  })
+})

--- a/apps/web/components/notification/NotificationDropdown.module.css
+++ b/apps/web/components/notification/NotificationDropdown.module.css
@@ -155,3 +155,13 @@
 .viewAllButton:hover {
   background-color: var(--color-cloudHover);
 }
+
+@media (max-width: 639px) {
+  .dropdown {
+    position: fixed;
+    top: 3.5rem;
+    left: var(--spacing-4);
+    right: var(--spacing-4);
+    width: auto;
+  }
+}


### PR DESCRIPTION
## 概要
SP（スマートフォン）表示でお知らせポップアップが画面領域外にはみ出るバグを修正しました。
`position: absolute` + 固定幅320pxの組み合わせにより、狭い画面でドロップダウンが左方向にはみ出していた原因を特定し、モバイル向けに `position: fixed` + viewport相対配置へ変更しました。

## 変更内容

### SP表示バグ修正
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `components/notification/NotificationDropdown.module.css` | 修正 | `max-width: 639px` のメディアクエリを追加。`position: fixed` + `left/right: var(--spacing-4)` でviewport内に収まるよう修正 |

### E2Eテスト追加
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `e2e/tests/notifications/notification-sp.spec.ts` | 追加 | 375px / 320px幅でドロップダウンが画面内に収まることを検証するSPテストを追加 |

## 影響範囲
- `apps/web/components/notification/NotificationDropdown.module.css` — モバイル幅のみ変更（デスクトップ表示は影響なし）

## テストプラン
- [x] 375px幅でベルボタンをタップし、ドロップダウンが画面内に収まることを確認
- [x] 320px幅でベルボタンをタップし、ドロップダウンが画面内に収まることを確認
- [x] デスクトップ幅（640px以上）でドロップダウンが従来通り表示されることを確認
- [x] E2Eテスト `notification-sp.spec.ts` がパスすることを確認

Closes #398