### PR TITLE
✨ [Feature] ツーリングプラン機能 (#391)

### DIFF
--- a/apps/e2e/tests/touring/touringPlan.spec.ts
+++ b/apps/e2e/tests/touring/touringPlan.spec.ts
@@ -1,0 +1,266 @@
+import { expect, test } from '../../fixtures/authenticatedPage'
+import { registerTestBike } from '../../helpers/bikeHelper'
+
+const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
+
+async function registerTestTouringPlan(
+  token: string,
+  myUserBikeId: string,
+  title: string
+): Promise<string> {
+  const res = await fetch(
+    `${BASE_URL}/api/v1/user-bike/bike/${myUserBikeId}/tourings`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        title,
+        startDate: new Date('2026-07-01').toISOString(),
+        endDate: new Date('2026-07-03').toISOString(),
+        status: 'PLANNED',
+      }),
+      signal: AbortSignal.timeout(30_000),
+    }
+  )
+  if (!res.ok) {
+    throw new Error(`プラン登録失敗: ${res.status} ${await res.text()}`)
+  }
+  const json = (await res.json()) as { data: { touringId: string } }
+  return json.data.touringId
+}
+
+test.describe('ツーリングプラン機能', () => {
+  test('ツーリング一覧ページに「登録する」ボタンが表示される', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: 'テストバイク',
+    })
+
+    await page.goto(`/app/my-bike/${myUserBikeId}/tourings`)
+
+    // 「登録する」ボタンが表示される
+    await expect(
+      page.getByRole('button', { name: '登録する', exact: true })
+    ).toBeVisible()
+
+    // セクションが分かれていないことを確認（「ツーリングプラン」セクションは存在しない）
+    await expect(page.getByText('ツーリングプラン')).not.toBeAttached()
+  })
+
+  test('登録ページにモード切り替えが表示され、プランモードに切り替えられる', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: 'フォームテストバイク',
+    })
+
+    await page.goto(`/app/my-bike/${myUserBikeId}/tourings/register`)
+
+    // モード切り替えボタンが表示される
+    await expect(
+      page.getByRole('button', { name: 'ツーリングを記録' })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'プランを作成' })
+    ).toBeVisible()
+
+    // 初期状態は「ツーリングを記録」モード
+    await expect(page.getByLabel('開始日')).toBeVisible()
+
+    // 「プランを作成」に切り替え
+    await page.getByRole('button', { name: 'プランを作成' }).click()
+
+    // ラベルが変わることを確認
+    await expect(page.getByLabel('出発予定日')).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: 'プランを保存' })
+    ).toBeVisible()
+  })
+
+  test('プランを作成するとプラン一覧に表示される', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '作成テストバイク',
+    })
+
+    await page.goto(`/app/my-bike/${myUserBikeId}/tourings/register`)
+
+    // プランモードに切り替え
+    await page.getByRole('button', { name: 'プランを作成' }).click()
+
+    // タイトルを入力
+    await page.getByLabel('タイトル').fill('夏の北海道ツーリングプラン')
+    await page.getByLabel('出発予定日').fill('2026-07-10')
+    await page.getByLabel('帰着予定日').fill('2026-07-15')
+
+    // プランを保存
+    await page.getByRole('button', { name: 'プランを保存' }).click()
+
+    // ツーリング一覧ページへリダイレクト
+    await expect(page).toHaveURL(
+      new RegExp(`/app/my-bike/${myUserBikeId}/tourings`),
+      { timeout: 10_000 }
+    )
+
+    // プランが一覧に表示される
+    await expect(
+      page.getByRole('heading', { name: '夏の北海道ツーリングプラン' }).first()
+    ).toBeVisible({ timeout: 10_000 })
+
+    // プランバッジが表示される
+    await expect(page.getByText('プラン').first()).toBeVisible()
+  })
+
+  test('過去のツーリングを記録モードで登録できる', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '記録テストバイク',
+      totalMileage: 10000,
+    })
+
+    await page.goto(`/app/my-bike/${myUserBikeId}/tourings/register`)
+
+    // 初期状態は「ツーリングを記録」モード - ラベルを確認
+    await expect(page.getByLabel('開始日')).toBeVisible()
+    await expect(page.getByLabel('終了日')).toBeVisible()
+
+    await page.getByLabel('タイトル').fill('先週の伊豆ツーリング')
+    await page.getByLabel('開始日').fill('2026-05-24')
+    await page.getByLabel('終了日').fill('2026-05-25')
+    await page.getByLabel('開始時走行距離 (km)').fill('10000')
+    await page.getByLabel('終了時走行距離 (km)').fill('10300')
+
+    await page.getByRole('button', { name: '登録する' }).click()
+
+    await expect(page).toHaveURL(
+      new RegExp(`/app/my-bike/${myUserBikeId}/tourings`),
+      { timeout: 10_000 }
+    )
+
+    await expect(
+      page.getByRole('heading', { name: '先週の伊豆ツーリング' }).first()
+    ).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('詳細ページの「ツーリングを開始する」ボタンでツーリング開始できる', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '開始テストバイク',
+      totalMileage: 5000,
+    })
+
+    const touringId = await registerTestTouringPlan(
+      authToken,
+      myUserBikeId,
+      '開始テスト用プラン'
+    )
+
+    // 詳細ページへ直接遷移
+    await page.goto(`/app/my-bike/${myUserBikeId}/tourings/${touringId}`)
+
+    // 「ツーリングを開始する」ボタンが表示される
+    await expect(
+      page.getByRole('button', { name: 'ツーリングを開始する' })
+    ).toBeVisible({ timeout: 10_000 })
+
+    // クリック
+    await page.getByRole('button', { name: 'ツーリングを開始する' }).click()
+
+    // ホームページへリダイレクト
+    await expect(page).toHaveURL(/\/app\/home/, { timeout: 15_000 })
+
+    // ホームのツーリングセクションに進行中が表示される
+    await expect(page.getByText('開始テスト用プラン')).toBeVisible({
+      timeout: 10_000,
+    })
+  })
+
+  test('一覧の行クリックで詳細ページへ遷移できる', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '詳細テストバイク',
+    })
+
+    const touringId = await registerTestTouringPlan(
+      authToken,
+      myUserBikeId,
+      '詳細確認用プラン'
+    )
+
+    await page.goto(`/app/my-bike/${myUserBikeId}/tourings`)
+
+    await expect(
+      page.getByRole('heading', { name: '詳細確認用プラン' })
+    ).toBeVisible({ timeout: 10_000 })
+
+    // 行クリックで詳細へ遷移
+    await page.getByRole('heading', { name: '詳細確認用プラン' }).click()
+
+    await expect(page).toHaveURL(
+      new RegExp(`/app/my-bike/${myUserBikeId}/tourings/${touringId}`),
+      { timeout: 10_000 }
+    )
+  })
+
+  test('詳細ページからプランを削除できる', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '削除テストバイク',
+    })
+
+    const touringId = await registerTestTouringPlan(
+      authToken,
+      myUserBikeId,
+      '削除テスト用プラン'
+    )
+
+    // 詳細ページへ直接遷移
+    await page.goto(`/app/my-bike/${myUserBikeId}/tourings/${touringId}`)
+
+    // 編集ボタン（鉛筆アイコン）をクリックして編集モーダルを開く（最初のものがツーリング情報の編集）
+    await page.getByRole('button', { name: '編集' }).first().click()
+
+    // 編集モーダルが開く
+    await expect(
+      page.getByRole('button', { name: '削除', exact: true })
+    ).toBeVisible({ timeout: 5_000 })
+
+    // 「削除」をクリックして確認フェーズへ
+    await page.getByRole('button', { name: '削除', exact: true }).click()
+
+    // 「削除する」確認ボタンが表示される
+    await expect(
+      page.getByRole('button', { name: '削除する', exact: true })
+    ).toBeVisible({ timeout: 5_000 })
+
+    // 削除確認
+    await page.getByRole('button', { name: '削除する', exact: true }).click()
+
+    // 一覧ページへリダイレクト
+    await expect(page).toHaveURL(
+      new RegExp(`/app/my-bike/${myUserBikeId}/tourings`),
+      { timeout: 10_000 }
+    )
+
+    // プランが削除されている
+    await expect(
+      page.getByRole('heading', { name: '削除テスト用プラン' })
+    ).not.toBeVisible({ timeout: 10_000 })
+  })
+})

--- a/apps/e2e/tests/touring/touringPlanDestination.spec.ts
+++ b/apps/e2e/tests/touring/touringPlanDestination.spec.ts
@@ -50,9 +50,9 @@ test.describe('ツーリングプラン 終着地登録', () => {
     await page.goto(`/app/my-bike/${myUserBikeId}/tourings/${touringId}`)
 
     // PLANNEDステータスのバッジが表示されている（タイトルと区別するため exact + first）
-    await expect(
-      page.getByText('プラン', { exact: true }).first()
-    ).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('プラン', { exact: true }).first()).toBeVisible(
+      { timeout: 10_000 }
+    )
 
     // 終着地セクションが表示される（修正前は COMPLETED のみ）
     await expect(page.getByText('終着地', { exact: true })).toBeVisible({
@@ -75,9 +75,9 @@ test.describe('ツーリングプラン 終着地登録', () => {
     )
 
     await page.goto(`/app/my-bike/${myUserBikeId}/tourings/${touringId}`)
-    await expect(
-      page.getByText('プラン', { exact: true }).first()
-    ).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('プラン', { exact: true }).first()).toBeVisible(
+      { timeout: 10_000 }
+    )
 
     // 終着地の編集ボタン（aria-label="終着地を編集"）が存在する
     await expect(
@@ -100,9 +100,9 @@ test.describe('ツーリングプラン 終着地登録', () => {
     )
 
     await page.goto(`/app/my-bike/${myUserBikeId}/tourings/${touringId}`)
-    await expect(
-      page.getByText('プラン', { exact: true }).first()
-    ).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByText('プラン', { exact: true }).first()).toBeVisible(
+      { timeout: 10_000 }
+    )
 
     // 終着地の編集ボタンをクリック
     await page.getByRole('button', { name: '終着地を編集' }).click()

--- a/apps/e2e/tests/touring/touringPlanDestination.spec.ts
+++ b/apps/e2e/tests/touring/touringPlanDestination.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '../../fixtures/authenticatedPage'
+import { registerTestBike } from '../../helpers/bikeHelper'
+
+const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
+
+async function registerTestTouringPlan(
+  token: string,
+  myUserBikeId: string,
+  title: string
+): Promise<string> {
+  const res = await fetch(
+    `${BASE_URL}/api/v1/user-bike/bike/${myUserBikeId}/tourings`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        title,
+        startDate: new Date('2026-07-01').toISOString(),
+        endDate: new Date('2026-07-03').toISOString(),
+        status: 'PLANNED',
+      }),
+      signal: AbortSignal.timeout(30_000),
+    }
+  )
+  if (!res.ok) {
+    throw new Error(`プラン登録失敗: ${res.status} ${await res.text()}`)
+  }
+  const json = (await res.json()) as { data: { touringId: string } }
+  return json.data.touringId
+}
+
+test.describe('ツーリングプラン 終着地登録', () => {
+  test('PLANNEDステータスでも終着地セクションが表示される', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '終着地テストバイク',
+    })
+
+    const touringId = await registerTestTouringPlan(
+      authToken,
+      myUserBikeId,
+      '終着地テスト用プラン'
+    )
+
+    await page.goto(`/app/my-bike/${myUserBikeId}/tourings/${touringId}`)
+
+    // PLANNEDステータスのバッジが表示されている（タイトルと区別するため exact + first）
+    await expect(
+      page.getByText('プラン', { exact: true }).first()
+    ).toBeVisible({ timeout: 10_000 })
+
+    // 終着地セクションが表示される（修正前は COMPLETED のみ）
+    await expect(page.getByText('終着地', { exact: true })).toBeVisible({
+      timeout: 5_000,
+    })
+  })
+
+  test('PLANNEDステータスで終着地の編集ボタンが存在する', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '終着地編集テストバイク',
+    })
+
+    const touringId = await registerTestTouringPlan(
+      authToken,
+      myUserBikeId,
+      '終着地編集テスト用プラン'
+    )
+
+    await page.goto(`/app/my-bike/${myUserBikeId}/tourings/${touringId}`)
+    await expect(
+      page.getByText('プラン', { exact: true }).first()
+    ).toBeVisible({ timeout: 10_000 })
+
+    // 終着地の編集ボタン（aria-label="終着地を編集"）が存在する
+    await expect(
+      page.getByRole('button', { name: '終着地を編集' })
+    ).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('PLANNEDステータスで終着地を編集モーダルで設定できる', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '終着地モーダルテストバイク',
+    })
+
+    const touringId = await registerTestTouringPlan(
+      authToken,
+      myUserBikeId,
+      '終着地モーダルテスト用プラン'
+    )
+
+    await page.goto(`/app/my-bike/${myUserBikeId}/tourings/${touringId}`)
+    await expect(
+      page.getByText('プラン', { exact: true }).first()
+    ).toBeVisible({ timeout: 10_000 })
+
+    // 終着地の編集ボタンをクリック
+    await page.getByRole('button', { name: '終着地を編集' }).click()
+
+    // 位置設定モーダルが開く（タイトルが「終着地を設定」）
+    await expect(page.getByText('終着地を設定')).toBeVisible({ timeout: 5_000 })
+  })
+})

--- a/apps/web/__tests__/api/v1/userBike.test.ts
+++ b/apps/web/__tests__/api/v1/userBike.test.ts
@@ -2334,6 +2334,127 @@ describe('UserBike API Endpoints', () => {
         expect(json.data.startMileage).toBe(2000)
       })
     })
+
+    describe('プランからツーリングを開始', () => {
+      test('PLANNEDプランを指定してツーリングを開始できる（新規作成されず既存プランがSTARTEDに更新される）', async () => {
+        // PLANNEDプランを作成
+        const planRes = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              title: '北海道ツーリング計画',
+              startDate: '2024-07-01T06:00:00.000Z',
+              endDate: '2024-07-05T18:00:00.000Z',
+              status: 'PLANNED',
+            }),
+          }
+        )
+        expect(planRes.status).toBe(201)
+        const planJson = await planRes.json()
+        const touringPlanId = planJson.data.touringId
+        expect(planJson.data.status).toBe('PLANNED')
+
+        // プランから開始
+        const startRes = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings/start-end`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              action: 'start',
+              touringPlanId,
+              startDate: '2024-07-01T06:00:00.000Z',
+              startMileage: 5000,
+            }),
+          }
+        )
+
+        const startJson = await startRes.json()
+        expect(startRes.status).toBe(201)
+        // 既存プランのIDと同じであることを確認（新規作成ではない）
+        expect(startJson.data.touringId).toBe(touringPlanId)
+        expect(startJson.data.status).toBe('STARTED')
+        expect(startJson.data.title).toBe('北海道ツーリング計画')
+        // プランの終了日時が保持されている
+        expect(startJson.data.endDate).toBe('2024-07-05T18:00:00.000Z')
+      })
+
+      test('存在しないtouringPlanIdを指定した場合は404となる', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings/start-end`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              action: 'start',
+              touringPlanId: randomUUID(),
+            }),
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(400)
+        expect(json).toMatchObject({
+          status: 'error',
+          errorCode: 'INVALID_REQUEST',
+          message: '指定されたツーリングプランが見つかりません',
+        })
+      })
+
+      test('PLANNEDではないツーリングIDをtouringPlanIdに指定した場合はエラーとなる', async () => {
+        // COMPLETEDのツーリングを作成
+        const completedRes = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              title: '完了したツーリング',
+              startDate: '2024-05-01T09:00:00.000Z',
+              endDate: '2024-05-01T18:00:00.000Z',
+            }),
+          }
+        )
+        const completedId = (await completedRes.json()).data.touringId
+
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings/start-end`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              action: 'start',
+              touringPlanId: completedId,
+            }),
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(400)
+        expect(json).toMatchObject({
+          status: 'error',
+          errorCode: 'INVALID_REQUEST',
+          message: '指定されたツーリングはプラン状態ではありません',
+        })
+      })
+    })
   })
 
   describe('POST /api/v1/user-bike/bike/:myUserBikeId/tourings', () => {
@@ -4329,6 +4450,111 @@ describe('UserBike API Endpoints', () => {
           status: 'error',
           errorCode: 'INVALID_REQUEST',
           message: 'ゲストアカウントはツーリング履歴を2件まで登録できます',
+        })
+      })
+    })
+
+    describe('ツーリングプランモード制限', () => {
+      test('ゲストはPLANNEDステータスのツーリングを登録できない', async () => {
+        const { token } = await createGuestUser()
+        const { myUserBikeId } = await createTestUserBike(token, {
+          displacement: 250,
+        })
+
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              title: 'ゲストプラン',
+              startDate: '2024-06-01T09:00:00.000Z',
+              endDate: '2024-06-03T18:00:00.000Z',
+              status: 'PLANNED',
+            }),
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(400)
+        expect(json).toMatchObject({
+          status: 'error',
+          errorCode: 'INVALID_REQUEST',
+          message: 'ゲストアカウントはツーリングプランを使用できません',
+        })
+      })
+
+      test('ゲストは通常ユーザーと同様にCOMPLETEDステータスのツーリングを登録できる', async () => {
+        const { token } = await createGuestUser()
+        const { myUserBikeId } = await createTestUserBike(token, {
+          displacement: 250,
+        })
+
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              title: 'ゲスト履歴',
+              startDate: '2024-06-01T09:00:00.000Z',
+              endDate: '2024-06-01T18:00:00.000Z',
+            }),
+          }
+        )
+
+        expect(res.status).toBe(201)
+        const json = await res.json()
+        expect(json.data.status).toBe('COMPLETED')
+      })
+
+      test('ゲストは2件のCOMPLETED登録後にPLANNEDを登録しようとした場合もプランエラーが返る', async () => {
+        const { token } = await createGuestUser()
+        const { myUserBikeId } = await createTestUserBike(token, {
+          displacement: 250,
+        })
+
+        // 2件登録
+        await createMultipleTourings(
+          token,
+          myUserBikeId,
+          Array.from({ length: 2 }, (_, i) => ({
+            title: `ゲストツーリング${i + 1}`,
+            startDate: `2024-01-0${i + 1}T09:00:00.000Z`,
+            endDate: `2024-01-0${i + 1}T18:00:00.000Z`,
+          }))
+        )
+
+        // PLANNEDで登録（プラン制限エラーが先に返る）
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings`,
+          {
+            method: 'POST',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              title: 'ゲストプラン',
+              startDate: '2024-06-01T09:00:00.000Z',
+              endDate: '2024-06-03T18:00:00.000Z',
+              status: 'PLANNED',
+            }),
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(400)
+        expect(json).toMatchObject({
+          status: 'error',
+          errorCode: 'INVALID_REQUEST',
+          message: 'ゲストアカウントはツーリングプランを使用できません',
         })
       })
     })

--- a/apps/web/app/app/(protected)/layout.tsx
+++ b/apps/web/app/app/(protected)/layout.tsx
@@ -1,10 +1,8 @@
 import { GuestBanner } from '@/components/GuestBanner'
-import { BreadcrumbNav } from '@/components/Navigation/BreadcrumbNav'
+import { DesktopHeader } from '@/components/Navigation/DesktopHeader'
 import { DesktopSidebar } from '@/components/Navigation/DesktopSidebar'
 import { MobileHeader } from '@/components/Navigation/MobileHeader'
 import { MobileNavigation } from '@/components/Navigation/MobileNavigation'
-import { BellButton } from '@/components/notification/BellButton'
-import { ThemeToggleButton } from '@/components/ThemeToggleButton'
 
 type Props = {
   children: React.ReactNode
@@ -14,17 +12,11 @@ export default function Layout({ children }: Props) {
   return (
     <>
       <MobileHeader />
+      <DesktopHeader />
       <DesktopSidebar />
       <MobileNavigation />
 
-      {/* デスクトップ右上: ベル + テーマ切替 (モバイルは MobileHeader が担当) */}
-      <div className="hidden sm:flex fixed top-4 right-4 z-50 items-center gap-2">
-        <BellButton />
-        <ThemeToggleButton />
-      </div>
-
-      <div className="min-h-screen w-full flex flex-col items-center p-4 gap-6 pt-16 pb-20 sm:pt-4 sm:pb-4 sm:pl-24">
-        <BreadcrumbNav />
+      <div className="min-h-screen w-full flex flex-col items-center p-4 gap-6 pt-16 pb-20 sm:pt-12 sm:pb-4 sm:pl-24">
         <GuestBanner />
         {children}
       </div>

--- a/apps/web/app/app/(protected)/layout.tsx
+++ b/apps/web/app/app/(protected)/layout.tsx
@@ -16,7 +16,7 @@ export default function Layout({ children }: Props) {
       <DesktopSidebar />
       <MobileNavigation />
 
-      <div className="min-h-screen w-full flex flex-col items-center p-4 gap-6 pt-16 pb-20 sm:pt-12 sm:pb-4 sm:pl-24">
+      <div className="min-h-screen w-full flex flex-col items-center p-4 gap-6 pt-20 pb-20 sm:pt-16 sm:pb-4 sm:pl-24">
         <GuestBanner />
         {children}
       </div>

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.module.css
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.module.css
@@ -21,6 +21,16 @@
   opacity: 0.4;
 }
 
+.statusPlanned {
+  background-color: #6366f1;
+  color: white;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  white-space: nowrap;
+}
+
 .statusStarted {
   background-color: #10b981;
   color: white;

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.module.css
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.module.css
@@ -181,9 +181,21 @@
 
 @media (min-width: 768px) {
   .mapContainerLarge {
-    height: calc(100vh - 12rem);
+    height: calc(100vh - 10rem);
     min-height: 400px;
-    max-height: 700px;
+    max-height: 720px;
+  }
+}
+
+.spotsListScroll {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+@media (min-width: 768px) {
+  .spotsListScroll {
+    max-height: calc(100vh - 18rem);
+    padding-right: 0.125rem;
   }
 }
 

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.module.css
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.module.css
@@ -162,6 +162,17 @@
   opacity: 0.85;
 }
 
+.mapStickyWrapper {
+  /* モバイルは通常フロー */
+}
+
+@media (min-width: 768px) {
+  .mapStickyWrapper {
+    position: sticky;
+    top: 1rem;
+  }
+}
+
 .mapContainerLarge {
   height: 400px;
   border-radius: var(--radius-md);
@@ -170,9 +181,18 @@
 
 @media (min-width: 768px) {
   .mapContainerLarge {
-    height: 100%;
-    min-height: 500px;
+    height: calc(100vh - 12rem);
+    min-height: 400px;
+    max-height: 700px;
   }
+}
+
+.mapClickHint {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  text-align: center;
+  color: var(--color-ink);
+  opacity: 0.45;
 }
 
 .breakBanner {

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.module.css
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.module.css
@@ -113,6 +113,21 @@
   opacity: 0.8;
 }
 
+.routeLink {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.68rem;
+  color: var(--color-product);
+  text-decoration: none;
+  opacity: 0.75;
+}
+
+.routeLink:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
 .editButton {
   flex-shrink: 0;
   display: flex;

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -15,7 +15,7 @@ import {
   arrayMove,
 } from '@dnd-kit/sortable'
 import { useParams, useRouter } from 'next/navigation'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, Fragment } from 'react'
 import useSWR, { mutate } from 'swr'
 import type { ApiResponseSpotDetail } from '@repo/shared-types'
 import { Button } from '@repo/ui/button'
@@ -33,24 +33,10 @@ import { apiGet, apiPatch, apiPost } from '@/lib/api/client'
 import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
 import { withAuth } from '@/lib/hoc/withAuth'
 import { useGeolocation } from '@/lib/hooks/useGeolocation'
-
-function buildGoogleMapsUrl(points: MapPoint[]): string | null {
-  const first = points[0]
-  const last = points[points.length - 1]
-  if (!first) return null
-  if (points.length === 1) {
-    return `https://www.google.com/maps/search/?api=1&query=${first.lat},${first.lng}`
-  }
-  if (!last) return null
-  const origin = `${first.lat},${first.lng}`
-  const destination = `${last.lat},${last.lng}`
-  const waypoints = points
-    .slice(1, -1)
-    .map((p) => `${p.lat},${p.lng}`)
-    .join('|')
-  const base = `https://www.google.com/maps/dir/?api=1&origin=${origin}&destination=${destination}`
-  return waypoints ? `${base}&waypoints=${encodeURIComponent(waypoints)}` : base
-}
+import {
+  buildGoogleMapsRouteUrl,
+  buildGoogleMapsTwoPointUrl,
+} from '@/lib/utils/googleMaps'
 
 function TouringDetailPage() {
   const params = useParams()
@@ -361,7 +347,7 @@ function TouringDetailPage() {
   }
 
   const hasMap = mapPoints.length > 0 || touring?.status === 'PLANNED'
-  const googleMapsUrl = buildGoogleMapsUrl(mapPoints)
+  const googleMapsUrl = buildGoogleMapsRouteUrl(mapPoints)
 
   const startLocation =
     touring?.startLatitude != null && touring?.startLongitude != null
@@ -446,6 +432,23 @@ function TouringDetailPage() {
               </div>
             </div>
 
+            {/* 出発地 → スポット1 ルートリンク */}
+            {startLocation != null &&
+              localSpots[0]?.latitude != null &&
+              localSpots[0]?.longitude != null && (
+                <a
+                  href={buildGoogleMapsTwoPointUrl(startLocation, {
+                    lat: localSpots[0]!.latitude!,
+                    lng: localSpots[0]!.longitude!,
+                  })}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.routeLink}
+                >
+                  ↓ Googleマップで経路確認
+                </a>
+              )}
+
             {/* 立ち寄りスポット（DnD） */}
             {localSpots && localSpots.length > 0 && (
               <DndContext
@@ -458,21 +461,45 @@ function TouringDetailPage() {
                   strategy={verticalListSortingStrategy}
                 >
                   <div className="space-y-3">
-                    {localSpots.map((spot, index) => (
-                      <SortableSpotItem
-                        key={spot.spotId}
-                        spot={spot}
-                        index={index}
-                        editButtonClassName={styles.editButton}
-                        spotItemClassName={styles.spotItem}
-                        spotBadgeClassName={styles.spotBadge}
-                        mutedTextClassName={styles.mutedText}
-                        dimTextClassName={styles.dimText}
-                        formatVisitedAt={formatVisitedAt}
-                        touringStatus={touring?.status}
-                        onEdit={setEditingSpot}
-                      />
-                    ))}
+                    {localSpots.map((spot, index) => {
+                      const nextSpot = localSpots[index + 1]
+                      return (
+                        <Fragment key={spot.spotId}>
+                          <SortableSpotItem
+                            spot={spot}
+                            index={index}
+                            editButtonClassName={styles.editButton}
+                            spotItemClassName={styles.spotItem}
+                            spotBadgeClassName={styles.spotBadge}
+                            mutedTextClassName={styles.mutedText}
+                            dimTextClassName={styles.dimText}
+                            formatVisitedAt={formatVisitedAt}
+                            touringStatus={touring?.status}
+                            onEdit={setEditingSpot}
+                          />
+                          {nextSpot &&
+                            spot.latitude != null &&
+                            spot.longitude != null &&
+                            nextSpot.latitude != null &&
+                            nextSpot.longitude != null && (
+                              <a
+                                href={buildGoogleMapsTwoPointUrl(
+                                  { lat: spot.latitude, lng: spot.longitude },
+                                  {
+                                    lat: nextSpot.latitude,
+                                    lng: nextSpot.longitude,
+                                  }
+                                )}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className={styles.routeLink}
+                              >
+                                ↓ Googleマップで経路確認
+                              </a>
+                            )}
+                        </Fragment>
+                      )
+                    })}
                   </div>
                 </SortableContext>
               </DndContext>
@@ -484,6 +511,27 @@ function TouringDetailPage() {
                 スポットはまだ記録されていません
               </p>
             )}
+
+            {/* 最終スポット → 終着地 ルートリンク */}
+            {touring?.status === 'COMPLETED' &&
+              endLocation != null &&
+              localSpots.at(-1)?.latitude != null &&
+              localSpots.at(-1)?.longitude != null && (
+                <a
+                  href={buildGoogleMapsTwoPointUrl(
+                    {
+                      lat: localSpots.at(-1)!.latitude!,
+                      lng: localSpots.at(-1)!.longitude!,
+                    },
+                    endLocation
+                  )}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={styles.routeLink}
+                >
+                  ↓ Googleマップで経路確認
+                </a>
+              )}
 
             {/* 終着地（COMPLETEDの場合のみ表示） */}
             {touring?.status === 'COMPLETED' && (

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -226,7 +226,7 @@ function TouringDetailPage() {
   }
 
   if (
-    touring?.status === 'COMPLETED' &&
+    (touring?.status === 'COMPLETED' || touring?.status === 'PLANNED') &&
     touring?.endLatitude != null &&
     touring?.endLongitude != null
   ) {
@@ -522,7 +522,8 @@ function TouringDetailPage() {
             )}
 
             {/* 最終スポット → 終着地 ルートリンク */}
-            {touring?.status === 'COMPLETED' &&
+            {(touring?.status === 'COMPLETED' ||
+              touring?.status === 'PLANNED') &&
               endLocation != null &&
               localSpots.at(-1)?.latitude != null &&
               localSpots.at(-1)?.longitude != null && (
@@ -542,8 +543,9 @@ function TouringDetailPage() {
                 </a>
               )}
 
-            {/* 終着地（COMPLETEDの場合のみ表示） */}
-            {touring?.status === 'COMPLETED' && (
+            {/* 終着地（COMPLETED・PLANNEDの場合に表示） */}
+            {(touring?.status === 'COMPLETED' ||
+              touring?.status === 'PLANNED') && (
               <div className={styles.spotItem}>
                 <div className={styles.endBadge}>着</div>
                 <div className="flex-1 min-w-0">

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -434,7 +434,8 @@ function TouringDetailPage() {
       {spotsLoading ? (
         <p className={`text-sm ${styles.mutedText}`}>読み込み中...</p>
       ) : (
-        <div className="space-y-3">
+        <div className={styles.spotsListScroll}>
+          <div className="space-y-3">
           {/* 出発地 */}
           <div className={styles.spotItem}>
             <div className={styles.startBadge}>出</div>
@@ -525,6 +526,7 @@ function TouringDetailPage() {
               </div>
             </div>
           )}
+          </div>
         </div>
       )}
     </div>
@@ -546,7 +548,7 @@ function TouringDetailPage() {
   return (
     <>
       <div
-        className={`w-full flex flex-row items-start gap-3 ${hasMap ? 'max-w-5xl' : 'max-w-md'}`}
+        className={`w-full flex flex-row items-start gap-3 mb-4 ${hasMap ? 'max-w-5xl' : 'max-w-md'}`}
       >
         <div className="shrink-0 pt-0.5">
           <Button
@@ -666,6 +668,7 @@ function TouringDetailPage() {
           bikeId={bikeId}
           touringId={touringId}
           spot={editingSpot}
+          touringStatus={touring?.status}
           onClose={() => setEditingSpot(null)}
           onSuccess={handleSpotEditSuccess}
           onDelete={handleSpotDeleteSuccess}
@@ -678,6 +681,7 @@ function TouringDetailPage() {
           touringId={touringId}
           initialType={addModalType}
           initialLocation={mapClickLocation}
+          touringStatus={touring?.status}
           onClose={() => {
             setAddModalType(null)
             setMapClickLocation(null)

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -21,6 +21,7 @@ import type { ApiResponseSpotDetail } from '@repo/shared-types'
 import { Button } from '@repo/ui/button'
 import { toast } from '@repo/ui/sonner'
 import styles from './page.module.css'
+import { ModalBase } from '@/components/common/ModalBase'
 import { EditIcon } from '@/components/icons/EditIcon'
 import { SortableSpotItem } from '@/components/spot/SortableSpotItem'
 import { SpotAddModal } from '@/components/spot/SpotAddModal'
@@ -45,6 +46,7 @@ function TouringDetailPage() {
   const touringId = params.touringId as string
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
   const [isStarting, setIsStarting] = useState(false)
+  const [isStartConfirmOpen, setIsStartConfirmOpen] = useState(false)
   const { getCurrentPosition } = useGeolocation()
   const [editingLocationTarget, setEditingLocationTarget] = useState<
     'start' | 'end' | null
@@ -346,6 +348,13 @@ function TouringDetailPage() {
     }
   }
 
+  const lastPlannedSpot =
+    touring?.status === 'PLANNED' && localSpots.length > 0
+      ? ([...localSpots].reverse().find((s) => s.type === 'SPOT') ??
+        localSpots.at(-1) ??
+        null)
+      : null
+
   const hasMap = mapPoints.length > 0 || touring?.status === 'PLANNED'
   const googleMapsUrl = buildGoogleMapsRouteUrl(mapPoints)
 
@@ -609,6 +618,13 @@ function TouringDetailPage() {
               {formatDate(touring.startDate)} → {formatDate(touring.endDate)}
               {distance !== null && ` · ${distance.toLocaleString()}km`}
             </p>
+            {lastPlannedSpot && (
+              <p className={`text-xs mt-0.5 ${styles.mutedText}`}>
+                最終スポット到着予定:{' '}
+                {lastPlannedSpot.name ? `${lastPlannedSpot.name} ` : ''}
+                {formatVisitedAt(lastPlannedSpot.visitedAt)}
+              </p>
+            )}
           </div>
         )}
       </div>
@@ -648,7 +664,7 @@ function TouringDetailPage() {
           <div className="md:w-80 lg:w-96 shrink-0 space-y-4">
             {touring?.status === 'PLANNED' && (
               <Button
-                onClick={handleStartFromPlan}
+                onClick={() => setIsStartConfirmOpen(true)}
                 variant="primary"
                 fullWidth
                 disabled={isStarting}
@@ -663,7 +679,7 @@ function TouringDetailPage() {
         <div className="w-full max-w-md space-y-4">
           {touring?.status === 'PLANNED' && (
             <Button
-              onClick={handleStartFromPlan}
+              onClick={() => setIsStartConfirmOpen(true)}
               variant="primary"
               fullWidth
               disabled={isStarting}
@@ -722,6 +738,52 @@ function TouringDetailPage() {
           }}
           onSuccess={handleSpotAddSuccess}
         />
+      )}
+
+      {isStartConfirmOpen && touring && (
+        <ModalBase
+          title="ツーリングを開始する"
+          onClose={() => setIsStartConfirmOpen(false)}
+          size="sm"
+        >
+          <div className="space-y-4">
+            <p className="text-sm">
+              予定日:{' '}
+              <strong>
+                {new Date(touring.startDate).toLocaleDateString('ja-JP', {
+                  year: 'numeric',
+                  month: 'long',
+                  day: 'numeric',
+                })}
+              </strong>
+            </p>
+            <p className="text-sm opacity-60">
+              今すぐ開始すると、現在地と現在時刻でツーリングが記録されます。
+            </p>
+            <div className="flex gap-3">
+              <Button
+                variant="cloud"
+                fullWidth
+                onClick={() => setIsStartConfirmOpen(false)}
+                disabled={isStarting}
+              >
+                キャンセル
+              </Button>
+              <Button
+                variant="primary"
+                fullWidth
+                onClick={async () => {
+                  setIsStartConfirmOpen(false)
+                  await handleStartFromPlan()
+                }}
+                disabled={isStarting}
+                loading={isStarting}
+              >
+                開始する
+              </Button>
+            </div>
+          </div>
+        </ModalBase>
       )}
     </>
   )

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -283,13 +283,20 @@ function TouringDetailPage() {
     setEditingLocationTarget(null)
   }
 
+  const _mutateTouringAndSpots = async () => {
+    await Promise.all([
+      mutate(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}`),
+      mutate(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`),
+    ])
+  }
+
   const handleSpotEditSuccess = async () => {
-    await mutate(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`)
+    await _mutateTouringAndSpots()
     setEditingSpot(null)
   }
 
   const handleSpotAddSuccess = async () => {
-    await mutate(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`)
+    await _mutateTouringAndSpots()
     setAddModalType(null)
     setMapClickLocation(null)
   }
@@ -300,7 +307,7 @@ function TouringDetailPage() {
   }
 
   const handleSpotDeleteSuccess = async () => {
-    await mutate(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`)
+    await _mutateTouringAndSpots()
     setEditingSpot(null)
   }
 
@@ -347,13 +354,6 @@ function TouringDetailPage() {
       setIsBreakLoading(false)
     }
   }
-
-  const lastPlannedSpot =
-    touring?.status === 'PLANNED' && localSpots.length > 0
-      ? ([...localSpots].reverse().find((s) => s.type === 'SPOT') ??
-        localSpots.at(-1) ??
-        null)
-      : null
 
   const hasMap = mapPoints.length > 0 || touring?.status === 'PLANNED'
   const googleMapsUrl = buildGoogleMapsRouteUrl(mapPoints)
@@ -618,13 +618,6 @@ function TouringDetailPage() {
               {formatDate(touring.startDate)} → {formatDate(touring.endDate)}
               {distance !== null && ` · ${distance.toLocaleString()}km`}
             </p>
-            {lastPlannedSpot && (
-              <p className={`text-xs mt-0.5 ${styles.mutedText}`}>
-                最終スポット到着予定:{' '}
-                {lastPlannedSpot.name ? `${lastPlannedSpot.name} ` : ''}
-                {formatVisitedAt(lastPlannedSpot.visitedAt)}
-              </p>
-            )}
           </div>
         )}
       </div>
@@ -732,6 +725,11 @@ function TouringDetailPage() {
           initialType={addModalType}
           initialLocation={mapClickLocation}
           touringStatus={touring?.status}
+          prevSpotVisitedAt={
+            touring?.status === 'PLANNED' && localSpots.length > 0
+              ? (localSpots.at(-1)!.endAt ?? localSpots.at(-1)!.visitedAt)
+              : undefined
+          }
           onClose={() => {
             setAddModalType(null)
             setMapClickLocation(null)

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -29,9 +29,11 @@ import { TouringEditModal } from '@/components/touring/TouringEditModal'
 import { TouringLocationEditModal } from '@/components/touring/TouringLocationEditModal'
 import TouringRouteMap from '@/components/touring/TouringRouteMap'
 import type { MapPoint } from '@/components/touring/TouringRouteMap'
-import { apiGet, apiPatch, apiPost } from '@/lib/api/client'
+import { TouringDeleteConfirmModal } from '@/components/touring/TouringDeleteConfirmModal'
+import { apiGet, apiDelete, apiPatch, apiPost } from '@/lib/api/client'
 import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
 import { withAuth } from '@/lib/hoc/withAuth'
+import { useGeolocation } from '@/lib/hooks/useGeolocation'
 
 function buildGoogleMapsUrl(points: MapPoint[]): string | null {
   const first = points[0]
@@ -57,6 +59,8 @@ function TouringDetailPage() {
   const bikeId = params.id as string
   const touringId = params.touringId as string
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
+  const [isStarting, setIsStarting] = useState(false)
+  const { getCurrentPosition } = useGeolocation()
   const [editingLocationTarget, setEditingLocationTarget] = useState<
     'start' | 'end' | null
   >(null)
@@ -255,6 +259,50 @@ function TouringDetailPage() {
     }
   }
 
+  const handleConfirmDelete = async () => {
+    try {
+      await apiDelete(`/api/v1/user-bike/bike/${bikeId}/tourings`, {
+        touringId,
+      })
+      await mutate(
+        `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=start-date&sort-order=desc`
+      )
+      router.push(`/app/my-bike/${bikeId}/tourings`)
+    } catch (err) {
+      toast.error(
+        err instanceof ApiV1Error ? err.message : '削除に失敗しました'
+      )
+    }
+  }
+
+  const handleStartFromPlan = async () => {
+    setIsStarting(true)
+    try {
+      const { position } = await getCurrentPosition()
+      await apiPost(
+        `/api/v1/user-bike/bike/${bikeId}/tourings/start-end` as const,
+        {
+          action: 'start',
+          touringPlanId: touringId,
+          startDate: new Date().toISOString(),
+          startLatitude: position?.latitude,
+          startLongitude: position?.longitude,
+        }
+      )
+      toast.success('ツーリングを開始しました')
+      await mutate('/api/v1/user-bike/bikes/ongoing-tourings')
+      router.push('/app/home')
+    } catch (err) {
+      toast.error(
+        err instanceof ApiV1Error
+          ? err.message
+          : 'ツーリングの開始に失敗しました'
+      )
+    } finally {
+      setIsStarting(false)
+    }
+  }
+
   const handleLocationEditSuccess = async () => {
     await mutate(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}`)
     setEditingLocationTarget(null)
@@ -339,12 +387,18 @@ function TouringDetailPage() {
           <h1 className="text-xl font-bold truncate">{touring?.title}</h1>
           <span
             className={
-              touring?.status === 'STARTED'
-                ? styles.statusStarted
-                : styles.statusCompleted
+              touring?.status === 'PLANNED'
+                ? styles.statusPlanned
+                : touring?.status === 'STARTED'
+                  ? styles.statusStarted
+                  : styles.statusCompleted
             }
           >
-            {touring?.status === 'STARTED' ? '進行中' : '完了'}
+            {touring?.status === 'PLANNED'
+              ? 'プラン'
+              : touring?.status === 'STARTED'
+                ? '進行中'
+                : '完了'}
           </span>
         </div>
         <button
@@ -550,12 +604,32 @@ function TouringDetailPage() {
             </div>
           </div>
           <div className="md:w-80 lg:w-96 shrink-0 space-y-4">
+            {touring?.status === 'PLANNED' && (
+              <Button
+                onClick={handleStartFromPlan}
+                variant="primary"
+                fullWidth
+                disabled={isStarting}
+              >
+                {isStarting ? '開始中...' : 'ツーリングを開始する'}
+              </Button>
+            )}
             {touringInfoCard}
             {spotsCard}
           </div>
         </div>
       ) : (
         <div className="w-full max-w-md space-y-4">
+          {touring?.status === 'PLANNED' && (
+            <Button
+              onClick={handleStartFromPlan}
+              variant="primary"
+              fullWidth
+              disabled={isStarting}
+            >
+              {isStarting ? '開始中...' : 'ツーリングを開始する'}
+            </Button>
+          )}
           {touringInfoCard}
           {spotsCard}
         </div>

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -29,8 +29,7 @@ import { TouringEditModal } from '@/components/touring/TouringEditModal'
 import { TouringLocationEditModal } from '@/components/touring/TouringLocationEditModal'
 import TouringRouteMap from '@/components/touring/TouringRouteMap'
 import type { MapPoint } from '@/components/touring/TouringRouteMap'
-import { TouringDeleteConfirmModal } from '@/components/touring/TouringDeleteConfirmModal'
-import { apiGet, apiDelete, apiPatch, apiPost } from '@/lib/api/client'
+import { apiGet, apiPatch, apiPost } from '@/lib/api/client'
 import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
 import { withAuth } from '@/lib/hoc/withAuth'
 import { useGeolocation } from '@/lib/hooks/useGeolocation'
@@ -263,22 +262,6 @@ function TouringDetailPage() {
     }
   }
 
-  const handleConfirmDelete = async () => {
-    try {
-      await apiDelete(`/api/v1/user-bike/bike/${bikeId}/tourings`, {
-        touringId,
-      })
-      await mutate(
-        `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=start-date&sort-order=desc`
-      )
-      router.push(`/app/my-bike/${bikeId}/tourings`)
-    } catch (err) {
-      toast.error(
-        err instanceof ApiV1Error ? err.message : '削除に失敗しました'
-      )
-    }
-  }
-
   const handleStartFromPlan = async () => {
     setIsStarting(true)
     try {
@@ -436,87 +419,24 @@ function TouringDetailPage() {
       ) : (
         <div className={styles.spotsListScroll}>
           <div className="space-y-3">
-          {/* 出発地 */}
-          <div className={styles.spotItem}>
-            <div className={styles.startBadge}>出</div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center justify-between gap-2">
-                <p className="font-medium text-sm">出発地</p>
-                <button
-                  onClick={() => setEditingLocationTarget('start')}
-                  className={styles.editButton}
-                  aria-label="出発地を編集"
-                >
-                  <EditIcon />
-                </button>
-              </div>
-              {startLocation ? (
-                <p className={`text-xs mt-1 ${styles.mutedText}`}>
-                  {startLocation.lat.toFixed(5)}, {startLocation.lng.toFixed(5)}
-                </p>
-              ) : (
-                <p className={`text-xs mt-1 ${styles.mutedText}`}>位置未設定</p>
-              )}
-            </div>
-          </div>
-
-          {/* 立ち寄りスポット（DnD） */}
-          {localSpots && localSpots.length > 0 && (
-            <DndContext
-              sensors={sensors}
-              collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
-            >
-              <SortableContext
-                items={localSpots.map((s) => s.spotId)}
-                strategy={verticalListSortingStrategy}
-              >
-                <div className="space-y-3">
-                  {localSpots.map((spot, index) => (
-                    <SortableSpotItem
-                      key={spot.spotId}
-                      spot={spot}
-                      index={index}
-                      editButtonClassName={styles.editButton}
-                      spotItemClassName={styles.spotItem}
-                      spotBadgeClassName={styles.spotBadge}
-                      mutedTextClassName={styles.mutedText}
-                      dimTextClassName={styles.dimText}
-                      formatVisitedAt={formatVisitedAt}
-                      touringStatus={touring?.status}
-                      onEdit={setEditingSpot}
-                    />
-                  ))}
-                </div>
-              </SortableContext>
-            </DndContext>
-          )}
-
-          {/* スポットがない場合のメッセージ */}
-          {(!localSpots || localSpots.length === 0) && (
-            <p className={`text-sm ${styles.mutedText}`}>
-              スポットはまだ記録されていません
-            </p>
-          )}
-
-          {/* 終着地（COMPLETEDの場合のみ表示） */}
-          {touring?.status === 'COMPLETED' && (
+            {/* 出発地 */}
             <div className={styles.spotItem}>
-              <div className={styles.endBadge}>着</div>
+              <div className={styles.startBadge}>出</div>
               <div className="flex-1 min-w-0">
                 <div className="flex items-center justify-between gap-2">
-                  <p className="font-medium text-sm">終着地</p>
+                  <p className="font-medium text-sm">出発地</p>
                   <button
-                    onClick={() => setEditingLocationTarget('end')}
+                    onClick={() => setEditingLocationTarget('start')}
                     className={styles.editButton}
-                    aria-label="終着地を編集"
+                    aria-label="出発地を編集"
                   >
                     <EditIcon />
                   </button>
                 </div>
-                {endLocation ? (
+                {startLocation ? (
                   <p className={`text-xs mt-1 ${styles.mutedText}`}>
-                    {endLocation.lat.toFixed(5)}, {endLocation.lng.toFixed(5)}
+                    {startLocation.lat.toFixed(5)},{' '}
+                    {startLocation.lng.toFixed(5)}
                   </p>
                 ) : (
                   <p className={`text-xs mt-1 ${styles.mutedText}`}>
@@ -525,7 +445,73 @@ function TouringDetailPage() {
                 )}
               </div>
             </div>
-          )}
+
+            {/* 立ち寄りスポット（DnD） */}
+            {localSpots && localSpots.length > 0 && (
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={localSpots.map((s) => s.spotId)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div className="space-y-3">
+                    {localSpots.map((spot, index) => (
+                      <SortableSpotItem
+                        key={spot.spotId}
+                        spot={spot}
+                        index={index}
+                        editButtonClassName={styles.editButton}
+                        spotItemClassName={styles.spotItem}
+                        spotBadgeClassName={styles.spotBadge}
+                        mutedTextClassName={styles.mutedText}
+                        dimTextClassName={styles.dimText}
+                        formatVisitedAt={formatVisitedAt}
+                        touringStatus={touring?.status}
+                        onEdit={setEditingSpot}
+                      />
+                    ))}
+                  </div>
+                </SortableContext>
+              </DndContext>
+            )}
+
+            {/* スポットがない場合のメッセージ */}
+            {(!localSpots || localSpots.length === 0) && (
+              <p className={`text-sm ${styles.mutedText}`}>
+                スポットはまだ記録されていません
+              </p>
+            )}
+
+            {/* 終着地（COMPLETEDの場合のみ表示） */}
+            {touring?.status === 'COMPLETED' && (
+              <div className={styles.spotItem}>
+                <div className={styles.endBadge}>着</div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="font-medium text-sm">終着地</p>
+                    <button
+                      onClick={() => setEditingLocationTarget('end')}
+                      className={styles.editButton}
+                      aria-label="終着地を編集"
+                    >
+                      <EditIcon />
+                    </button>
+                  </div>
+                  {endLocation ? (
+                    <p className={`text-xs mt-1 ${styles.mutedText}`}>
+                      {endLocation.lat.toFixed(5)}, {endLocation.lng.toFixed(5)}
+                    </p>
+                  ) : (
+                    <p className={`text-xs mt-1 ${styles.mutedText}`}>
+                      位置未設定
+                    </p>
+                  )}
+                </div>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -70,6 +70,10 @@ function TouringDetailPage() {
   const [addModalType, setAddModalType] = useState<'SPOT' | 'BREAK' | null>(
     null
   )
+  const [mapClickLocation, setMapClickLocation] = useState<{
+    lat: number
+    lng: number
+  } | null>(null)
   const [localSpots, setLocalSpots] = useState<ApiResponseSpotDetail[]>([])
   const [isBreakLoading, setIsBreakLoading] = useState(false)
 
@@ -316,6 +320,12 @@ function TouringDetailPage() {
   const handleSpotAddSuccess = async () => {
     await mutate(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}/spots`)
     setAddModalType(null)
+    setMapClickLocation(null)
+  }
+
+  const handleMapClick = (lat: number, lng: number) => {
+    setMapClickLocation({ lat, lng })
+    setAddModalType('SPOT')
   }
 
   const handleSpotDeleteSuccess = async () => {
@@ -367,7 +377,7 @@ function TouringDetailPage() {
     }
   }
 
-  const hasMap = mapPoints.length > 0
+  const hasMap = mapPoints.length > 0 || touring?.status === 'PLANNED'
   const googleMapsUrl = buildGoogleMapsUrl(mapPoints)
 
   const startLocation =
@@ -379,55 +389,6 @@ function TouringDetailPage() {
     touring?.endLatitude != null && touring?.endLongitude != null
       ? { lat: touring.endLatitude, lng: touring.endLongitude }
       : null
-
-  const touringInfoCard = (
-    <div className={styles.card}>
-      <div className="flex items-start justify-between gap-2 mb-4">
-        <div className="flex items-center gap-2 flex-1 min-w-0">
-          <h1 className="text-xl font-bold truncate">{touring?.title}</h1>
-          <span
-            className={
-              touring?.status === 'PLANNED'
-                ? styles.statusPlanned
-                : touring?.status === 'STARTED'
-                  ? styles.statusStarted
-                  : styles.statusCompleted
-            }
-          >
-            {touring?.status === 'PLANNED'
-              ? 'プラン'
-              : touring?.status === 'STARTED'
-                ? '進行中'
-                : '完了'}
-          </span>
-        </div>
-        <button
-          onClick={() => setIsEditModalOpen(true)}
-          className={styles.editButton}
-          aria-label="編集"
-        >
-          <EditIcon />
-        </button>
-      </div>
-
-      <div className={`space-y-2 text-sm ${styles.bodyText}`}>
-        <div>
-          <span className="font-medium">開始: </span>
-          {touring?.startDate ? formatDate(touring.startDate) : '-'}
-        </div>
-        <div>
-          <span className="font-medium">終了: </span>
-          {touring?.endDate ? formatDate(touring.endDate) : '-'}
-        </div>
-        {distance !== null && (
-          <div>
-            <span className="font-medium">走行距離: </span>
-            {distance.toLocaleString()}km
-          </div>
-        )}
-      </div>
-    </div>
-  )
 
   const spotsCard = (
     <div className={styles.card}>
@@ -521,6 +482,7 @@ function TouringDetailPage() {
                       mutedTextClassName={styles.mutedText}
                       dimTextClassName={styles.dimText}
                       formatVisitedAt={formatVisitedAt}
+                      touringStatus={touring?.status}
                       onEdit={setEditingSpot}
                     />
                   ))}
@@ -568,37 +530,81 @@ function TouringDetailPage() {
     </div>
   )
 
+  const statusLabel =
+    touring?.status === 'PLANNED'
+      ? 'プラン'
+      : touring?.status === 'STARTED'
+        ? '進行中'
+        : '完了'
+  const statusBadgeClass =
+    touring?.status === 'PLANNED'
+      ? styles.statusPlanned
+      : touring?.status === 'STARTED'
+        ? styles.statusStarted
+        : styles.statusCompleted
+
   return (
     <>
       <div
-        className={`w-full flex flex-row gap-2 mb-4 ${hasMap ? 'max-w-5xl' : 'max-w-md'}`}
+        className={`w-full flex flex-row items-start gap-3 ${hasMap ? 'max-w-5xl' : 'max-w-md'}`}
       >
-        <Button
-          onClick={() => router.push(`/app/my-bike/${bikeId}/tourings`)}
-          variant="cloud"
-        >
-          ← 戻る
-        </Button>
+        <div className="shrink-0 pt-0.5">
+          <Button
+            onClick={() => router.push(`/app/my-bike/${bikeId}/tourings`)}
+            variant="cloud"
+          >
+            ← 戻る
+          </Button>
+        </div>
+        {touring && (
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h1 className="text-xl font-bold truncate">{touring.title}</h1>
+              <span className={statusBadgeClass}>{statusLabel}</span>
+              <button
+                onClick={() => setIsEditModalOpen(true)}
+                className={styles.editButton}
+                aria-label="編集"
+              >
+                <EditIcon />
+              </button>
+            </div>
+            <p className={`text-xs mt-1 ${styles.mutedText}`}>
+              {formatDate(touring.startDate)} → {formatDate(touring.endDate)}
+              {distance !== null && ` · ${distance.toLocaleString()}km`}
+            </p>
+          </div>
+        )}
       </div>
 
       {hasMap ? (
         <div className="w-full max-w-5xl flex flex-col md:flex-row md:gap-6 md:items-start gap-4">
           <div className="md:flex-1 min-w-0">
-            <div className={`${styles.card} h-full`}>
-              <div className={styles.mapWrapper}>
-                <TouringRouteMap
-                  points={mapPoints}
-                  containerClassName={styles.mapContainerLarge}
-                />
-                {googleMapsUrl && (
-                  <a
-                    href={googleMapsUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={styles.googleMapsLink}
-                  >
-                    Googleマップで経路を表示
-                  </a>
+            <div className={styles.mapStickyWrapper}>
+              <div className={styles.card}>
+                <div className={styles.mapWrapper}>
+                  <TouringRouteMap
+                    points={mapPoints}
+                    containerClassName={styles.mapContainerLarge}
+                    onMapClick={
+                      touring?.status === 'PLANNED' ? handleMapClick : undefined
+                    }
+                  />
+                  {googleMapsUrl && (
+                    <a
+                      href={googleMapsUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={styles.googleMapsLink}
+                    >
+                      Googleマップで経路を表示
+                    </a>
+                  )}
+                </div>
+                {touring?.status === 'PLANNED' && (
+                  <p className={styles.mapClickHint}>
+                    地図をタップしてスポットを追加
+                  </p>
                 )}
               </div>
             </div>
@@ -614,7 +620,6 @@ function TouringDetailPage() {
                 {isStarting ? '開始中...' : 'ツーリングを開始する'}
               </Button>
             )}
-            {touringInfoCard}
             {spotsCard}
           </div>
         </div>
@@ -630,7 +635,6 @@ function TouringDetailPage() {
               {isStarting ? '開始中...' : 'ツーリングを開始する'}
             </Button>
           )}
-          {touringInfoCard}
           {spotsCard}
         </div>
       )}
@@ -673,7 +677,11 @@ function TouringDetailPage() {
           bikeId={bikeId}
           touringId={touringId}
           initialType={addModalType}
-          onClose={() => setAddModalType(null)}
+          initialLocation={mapClickLocation}
+          onClose={() => {
+            setAddModalType(null)
+            setMapClickLocation(null)
+          }}
           onSuccess={handleSpotAddSuccess}
         />
       )}

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/page.tsx
@@ -61,8 +61,8 @@ function TouringsPage() {
     router.push(`/app/my-bike/${bikeId}/tourings/${touringId}`)
   }
 
-  const handleRegister = () => {
-    router.push(`/app/my-bike/${bikeId}/tourings/register`)
+  const handleRegisterHistory = () => {
+    router.push(`/app/my-bike/${bikeId}/tourings/register?mode=history`)
   }
 
   if (isLoading) {
@@ -110,8 +110,8 @@ function TouringsPage() {
         >
           ← 戻る
         </Button>
-        <Button onClick={handleRegister} variant="primary">
-          登録する
+        <Button onClick={handleRegisterHistory} variant="primary">
+          ツーリングを作成
         </Button>
       </div>
 
@@ -123,7 +123,7 @@ function TouringsPage() {
         <TouringListSection
           tourings={sortedTourings}
           onDetail={handleDetail}
-          onRegister={handleRegister}
+          onRegister={handleRegisterHistory}
         />
       </div>
     </>

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useParams, useRouter } from 'next/navigation'
-import { useState } from 'react'
 import useSWR, { mutate } from 'swr'
 import type {
   ApiResponseTouringDetail,
@@ -9,38 +8,15 @@ import type {
 } from '@repo/shared-types'
 import { Button } from '@repo/ui/button'
 import { InfoBox } from '@/components/bike/InfoBox'
-import { TouringDeleteConfirmModal } from '@/components/touring/TouringDeleteConfirmModal'
 import { TouringListSection } from '@/components/touring/TouringListSection'
-import { authenticatedFetch, apiDelete } from '@/lib/api/client'
+import { authenticatedFetch } from '@/lib/api/client'
 import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
 import { withAuth } from '@/lib/hoc/withAuth'
-import { useAuth } from '@/lib/hooks/useAuth'
-import { GUEST_ACCOUNT_LIMITS } from '@/lib/statics'
 
 function TouringsPage() {
   const params = useParams()
   const router = useRouter()
-  const { isGuest } = useAuth()
   const bikeId = params.id as string
-
-  const [pendingDeleteTouringId, setPendingDeleteTouringId] = useState<
-    string | null
-  >(null)
-
-  const fetchTourings = async (url: string) => {
-    const response = await authenticatedFetch(url, { method: 'GET' })
-    if (!response.ok) {
-      const errorData = await response.json()
-      throw new ApiV1Error(
-        errorData.errorCode || 'SERVER_ERROR',
-        errorData.message || 'エラーが発生しました'
-      )
-    }
-    const json = (await response.json()) as SuccessResponse<
-      ApiResponseTouringDetail[]
-    >
-    return json.data
-  }
 
   const {
     data: tourings,
@@ -48,34 +24,38 @@ function TouringsPage() {
     isLoading,
   } = useSWR(
     bikeId
-      ? `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=end-date&sort-order=desc`
+      ? `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=start-date&sort-order=desc`
       : null,
-    fetchTourings
+    async (url: string) => {
+      const response = await authenticatedFetch(url, { method: 'GET' })
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new ApiV1Error(
+          errorData.errorCode || 'SERVER_ERROR',
+          errorData.message || 'エラーが発生しました'
+        )
+      }
+      const json = (await response.json()) as SuccessResponse<
+        ApiResponseTouringDetail[]
+      >
+      return json.data
+    }
   )
 
-  const handleDelete = (touringId: string) => {
-    setPendingDeleteTouringId(touringId)
-  }
-
-  const handleConfirmDelete = async () => {
-    if (!pendingDeleteTouringId) return
-    const touringId = pendingDeleteTouringId
-    setPendingDeleteTouringId(null)
-    try {
-      await apiDelete(`/api/v1/user-bike/bike/${bikeId}/tourings`, {
-        touringId,
+  // 表示順: PLANNED (予定日昇順) → STARTED → COMPLETED (開始日降順)
+  const sortedTourings = tourings
+    ? [...tourings].sort((a, b) => {
+        const order = { PLANNED: 0, STARTED: 1, COMPLETED: 2 }
+        const statusDiff = order[a.status] - order[b.status]
+        if (statusDiff !== 0) return statusDiff
+        if (a.status === 'PLANNED') {
+          return (
+            new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+          )
+        }
+        return new Date(b.startDate).getTime() - new Date(a.startDate).getTime()
       })
-      await mutate(
-        `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=end-date&sort-order=desc`
-      )
-    } catch {
-      // エラーは無視（toast通知は不要）
-    }
-  }
-
-  const handleCancelDelete = () => {
-    setPendingDeleteTouringId(null)
-  }
+    : []
 
   const handleDetail = (touringId: string) => {
     router.push(`/app/my-bike/${bikeId}/tourings/${touringId}`)
@@ -106,7 +86,6 @@ function TouringsPage() {
             ← 戻る
           </Button>
         </div>
-
         <div className="bg-white rounded-lg shadow-sm p-6 border border-gray-200">
           <h1 className="text-2xl font-bold mb-4 text-red-600">エラー</h1>
           <p className="text-gray-700 mb-4">
@@ -122,59 +101,31 @@ function TouringsPage() {
     )
   }
 
-  const isAtGuestTouringLimit =
-    isGuest && (tourings?.length ?? 0) >= GUEST_ACCOUNT_LIMITS.TOURING
-
   return (
     <>
-      <div className="w-full max-w-md flex flex-col gap-2">
-        <div className="flex flex-row gap-2">
-          <Button
-            onClick={() => router.push(`/app/my-bike/${bikeId}`)}
-            variant="cloud"
-          >
-            ← 戻る
-          </Button>
-
-          <Button
-            onClick={handleRegister}
-            variant="primary"
-            disabled={isAtGuestTouringLimit}
-          >
-            ツーリング履歴を登録
-          </Button>
-        </div>
-        {isGuest && !isLoading && (
-          <InfoBox
-            variant={isAtGuestTouringLimit ? 'warning' : 'info'}
-            className="text-sm"
-          >
-            ゲストアカウントはツーリングを{GUEST_ACCOUNT_LIMITS.TOURING}
-            件まで登録できます（
-            {tourings?.length ?? 0}/{GUEST_ACCOUNT_LIMITS.TOURING}件）
-          </InfoBox>
-        )}
+      <div className="w-full max-w-md flex flex-row gap-2">
+        <Button
+          onClick={() => router.push(`/app/my-bike/${bikeId}`)}
+          variant="cloud"
+        >
+          ← 戻る
+        </Button>
+        <Button onClick={handleRegister} variant="primary">
+          登録する
+        </Button>
       </div>
 
       <InfoBox variant="info" className="w-full max-w-md mt-3 text-sm">
         開始・終了地点の位置情報は本人のみ閲覧でき、他のユーザーには公開されません。
       </InfoBox>
 
-      <div className="w-full max-w-md">
+      <div className="w-full max-w-md mt-3">
         <TouringListSection
-          tourings={tourings || []}
+          tourings={sortedTourings}
           onDetail={handleDetail}
-          onDelete={handleDelete}
           onRegister={handleRegister}
         />
       </div>
-
-      {pendingDeleteTouringId !== null && (
-        <TouringDeleteConfirmModal
-          onCancel={handleCancelDelete}
-          onConfirm={handleConfirmDelete}
-        />
-      )}
     </>
   )
 }

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useParams, useRouter } from 'next/navigation'
-import useSWR, { mutate } from 'swr'
+import useSWR from 'swr'
 import type {
   ApiResponseTouringDetail,
   SuccessResponse,

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/register/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/register/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useParams, useRouter } from 'next/navigation'
+import { useParams, useRouter, useSearchParams } from 'next/navigation'
 import { useState } from 'react'
 import { mutate } from 'swr'
 import { BaseCard } from '@repo/ui/baseCard'
@@ -18,8 +18,12 @@ import { useAuth } from '@/lib/hooks/useAuth'
 function TouringRegisterPage() {
   const router = useRouter()
   const params = useParams()
+  const searchParams = useSearchParams()
   const bikeId = params.id as string
   const { isGuest } = useAuth()
+
+  const modeParam = searchParams.get('mode')
+  const initialMode = modeParam === 'plan' ? 'plan' : 'history'
 
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState('')
@@ -82,6 +86,7 @@ function TouringRegisterPage() {
 
       <BaseCard title="ツーリングを登録">
         <TouringForm
+          initialData={{ mode: initialMode }}
           onSubmit={handleFormSubmit}
           isSubmitting={isSubmitting}
           error={error}

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/register/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/register/page.tsx
@@ -13,11 +13,13 @@ import {
 import { apiPost } from '@/lib/api/client'
 import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
 import { withAuth } from '@/lib/hoc/withAuth'
+import { useAuth } from '@/lib/hooks/useAuth'
 
 function TouringRegisterPage() {
   const router = useRouter()
   const params = useParams()
   const bikeId = params.id as string
+  const { isGuest } = useAuth()
 
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState('')
@@ -83,6 +85,7 @@ function TouringRegisterPage() {
           onSubmit={handleFormSubmit}
           isSubmitting={isSubmitting}
           error={error}
+          disablePlanMode={isGuest}
         />
       </BaseCard>
     </>

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/register/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/register/page.tsx
@@ -26,24 +26,37 @@ function TouringRegisterPage() {
     setError('')
     setIsSubmitting(true)
 
+    const isPlan = formData.mode === 'plan'
+
     try {
       await apiPost(`/api/v1/user-bike/bike/${bikeId}/tourings`, {
         title: formData.title,
         startDate: new Date(formData.startDate),
         endDate: new Date(formData.endDate),
-        startMileage: formData.startMileage
-          ? Number(formData.startMileage)
-          : null,
-        endMileage: formData.endMileage ? Number(formData.endMileage) : null,
-        status: 'COMPLETED',
+        ...(formData.startMileage
+          ? { startMileage: Number(formData.startMileage) }
+          : {}),
+        ...(!isPlan && formData.endMileage
+          ? { endMileage: Number(formData.endMileage) }
+          : {}),
+        status: isPlan ? 'PLANNED' : 'COMPLETED',
       })
 
-      await mutate(
-        `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=end-date&sort-order=desc`
+      await Promise.all([
+        mutate(
+          `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=end-date&sort-order=desc`
+        ),
+        mutate(
+          `/api/v1/user-bike/bike/${bikeId}/tourings?status=PLANNED&sort-by=start-date&sort-order=asc`
+        ),
+      ])
+
+      toast.success(
+        isPlan
+          ? 'ツーリングプランを保存しました'
+          : 'ツーリング履歴を登録しました',
+        { description: 'ツーリング一覧へ移動します。' }
       )
-      toast.success('ツーリング履歴を登録しました', {
-        description: 'ツーリング履歴一覧へ移動します。',
-      })
       router.push(`/app/my-bike/${bikeId}/tourings`)
     } catch (err) {
       setError(err instanceof ApiV1Error ? err.message : 'エラーが発生しました')
@@ -63,7 +76,7 @@ function TouringRegisterPage() {
         </Button>
       </div>
 
-      <BaseCard title="ツーリング履歴を登録">
+      <BaseCard title="ツーリングを登録">
         <TouringForm
           onSubmit={handleFormSubmit}
           isSubmitting={isSubmitting}

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/register/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/register/page.tsx
@@ -31,8 +31,10 @@ function TouringRegisterPage() {
     try {
       await apiPost(`/api/v1/user-bike/bike/${bikeId}/tourings`, {
         title: formData.title,
-        startDate: new Date(formData.startDate),
-        endDate: new Date(formData.endDate),
+        startDate: new Date(
+          `${formData.startDate}T${formData.startTime || '00:00'}`
+        ),
+        endDate: new Date(`${formData.endDate}T${formData.endTime || '00:00'}`),
         ...(formData.startMileage
           ? { startMileage: Number(formData.startMileage) }
           : {}),

--- a/apps/web/components/Navigation/BreadcrumbNav.module.css
+++ b/apps/web/components/Navigation/BreadcrumbNav.module.css
@@ -1,12 +1,6 @@
 .wrapper {
-  position: sticky;
-  top: 0;
-  z-index: 40;
-  width: 100%;
-  max-width: 40rem;
-  background-color: var(--color-background);
-  padding-block: 0.5rem;
-  margin-block: -0.5rem;
+  flex: 1;
+  min-width: 0;
 }
 
 .list {
@@ -26,6 +20,7 @@
   align-items: center;
   gap: 0.25rem;
   min-width: 0;
+  white-space: nowrap;
 }
 
 .link {

--- a/apps/web/components/Navigation/BreadcrumbNav.tsx
+++ b/apps/web/components/Navigation/BreadcrumbNav.tsx
@@ -45,10 +45,12 @@ function buildBreadcrumbs(pathname: string): BreadcrumbItem[] {
 
     if (segments[3] === 'tourings') {
       items.push({
-        label: 'ツーリング履歴',
+        label: 'ツーリング一覧',
         href: `/app/my-bike/${segments[2]}/tourings`,
       })
-      if (segments[4]) {
+      if (segments[4] === 'register') {
+        items.push({ label: 'ツーリング登録' })
+      } else if (segments[4]) {
         items.push({ label: 'ツーリング詳細' })
       }
       return items

--- a/apps/web/components/Navigation/BreadcrumbNav.tsx
+++ b/apps/web/components/Navigation/BreadcrumbNav.tsx
@@ -16,7 +16,7 @@ function buildBreadcrumbs(pathname: string): BreadcrumbItem[] {
     return [{ label: 'ホーム' }]
   }
 
-  const items: BreadcrumbItem[] = [{ label: 'ホーム', href: '/app/home' }]
+  const items: BreadcrumbItem[] = []
 
   if (segments[1] === 'my-bike') {
     items.push({ label: 'マイバイク', href: '/app/my-bike' })
@@ -78,7 +78,7 @@ function buildBreadcrumbs(pathname: string): BreadcrumbItem[] {
     return items
   }
 
-  return [{ label: 'ホーム', href: '/app/home' }, { label: 'ページ' }]
+  return [{ label: 'ページ' }]
 }
 
 export function BreadcrumbNav() {

--- a/apps/web/components/Navigation/DesktopHeader.module.css
+++ b/apps/web/components/Navigation/DesktopHeader.module.css
@@ -3,12 +3,12 @@
   top: 0;
   left: 0;
   right: 0;
-  z-index: 50;
-  display: flex;
+  z-index: 49;
+  display: none;
   align-items: center;
   justify-content: space-between;
-  padding: 0 var(--spacing-4);
-  height: 3.5rem;
+  padding: 0 1rem 0 6rem;
+  height: 3rem;
   background-color: color-mix(in srgb, var(--color-background) 80%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -17,12 +17,13 @@
 
 @media (min-width: 640px) {
   .header {
-    display: none;
+    display: flex;
   }
 }
 
 .actions {
   display: flex;
   align-items: center;
-  gap: var(--spacing-2);
+  gap: 0.5rem;
+  flex-shrink: 0;
 }

--- a/apps/web/components/Navigation/DesktopHeader.tsx
+++ b/apps/web/components/Navigation/DesktopHeader.tsx
@@ -1,13 +1,13 @@
 'use client'
 
 import { BreadcrumbNav } from './BreadcrumbNav'
-import styles from './MobileHeader.module.css'
+import styles from './DesktopHeader.module.css'
 import { BellButton } from '@/components/notification/BellButton'
 import { ThemeToggleButton } from '@/components/ThemeToggleButton'
 
-export function MobileHeader() {
+export function DesktopHeader() {
   return (
-    <header className={styles.header} aria-label="モバイルヘッダー">
+    <header className={styles.header} aria-label="ヘッダー">
       <BreadcrumbNav />
       <div className={styles.actions}>
         <BellButton />

--- a/apps/web/components/Navigation/DesktopSidebar.module.css
+++ b/apps/web/components/Navigation/DesktopSidebar.module.css
@@ -1,6 +1,6 @@
 .sidebar {
   position: fixed;
-  top: 3rem;
+  top: 4rem;
   left: 1rem;
   z-index: 50;
   display: flex;

--- a/apps/web/components/notification/BellButton.module.css
+++ b/apps/web/components/notification/BellButton.module.css
@@ -2,26 +2,6 @@
   position: relative;
 }
 
-.bell {
-  width: 2.5rem;
-  height: 2.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  border-radius: var(--radius-md);
-  background-color: var(--color-cloud);
-  border: 1px solid var(--color-cloudHover);
-  color: var(--color-ink);
-  cursor: pointer;
-  transition: all var(--transition-fast);
-  position: relative;
-}
-
-.bell:hover {
-  background-color: var(--color-cloudHover);
-}
-
 .badge {
   position: absolute;
   top: -4px;

--- a/apps/web/components/notification/BellButton.tsx
+++ b/apps/web/components/notification/BellButton.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { Button } from '@repo/ui/button'
 import styles from './BellButton.module.css'
 import { NotificationDropdown } from './NotificationDropdown'
 import { useNotificationUnreadCount } from '@/lib/hooks/useNotifications'
@@ -32,13 +33,15 @@ export function BellButton() {
 
   return (
     <div ref={ref} className={styles.container}>
-      <button
+      <Button
         type="button"
-        className={styles.bell}
+        variant="cloud"
+        size="sm"
         onClick={handleOpen}
         aria-label={`通知${unreadCount > 0 ? `（未読${unreadCount}件）` : ''}`}
         aria-expanded={isOpen}
         aria-haspopup="true"
+        style={{ width: '2rem', padding: 0 }}
       >
         <BellIcon />
         {unreadCount > 0 && (
@@ -46,7 +49,7 @@ export function BellButton() {
             {unreadCount > 99 ? '99+' : unreadCount}
           </span>
         )}
-      </button>
+      </Button>
 
       {isOpen && <NotificationDropdown onClose={handleClose} />}
     </div>

--- a/apps/web/components/spot/SortableSpotItem.tsx
+++ b/apps/web/components/spot/SortableSpotItem.tsx
@@ -110,9 +110,12 @@ export function SortableSpotItem({
               {isBreak
                 ? (touringStatus === 'PLANNED' ? '予定 ' : '') +
                   formatBreakDuration(spot.visitedAt, spot.endAt)
-                : touringStatus === 'PLANNED'
-                  ? formatPlannedArrival(spot.visitedAt)
-                  : formatVisitedAt(spot.visitedAt)}
+                : spot.endAt
+                  ? (touringStatus === 'PLANNED' ? '予定 ' : '') +
+                    formatBreakDuration(spot.visitedAt, spot.endAt)
+                  : touringStatus === 'PLANNED'
+                    ? formatPlannedArrival(spot.visitedAt)
+                    : formatVisitedAt(spot.visitedAt)}
             </span>
             <button
               onClick={() => onEdit(spot)}

--- a/apps/web/components/spot/SortableSpotItem.tsx
+++ b/apps/web/components/spot/SortableSpotItem.tsx
@@ -115,7 +115,10 @@ export function SortableSpotItem({
                     formatBreakDuration(spot.visitedAt, spot.endAt)
                   : touringStatus === 'PLANNED'
                     ? formatPlannedArrival(spot.visitedAt)
-                    : formatVisitedAt(spot.visitedAt)}
+                    : touringStatus === 'STARTED' &&
+                        new Date(spot.visitedAt) > new Date()
+                      ? `${formatVisitedAt(spot.visitedAt)} 訪問予定`
+                      : formatVisitedAt(spot.visitedAt)}
             </span>
             <button
               onClick={() => onEdit(spot)}

--- a/apps/web/components/spot/SortableSpotItem.tsx
+++ b/apps/web/components/spot/SortableSpotItem.tsx
@@ -15,15 +15,17 @@ type SortableSpotItemProps = {
   mutedTextClassName: string | undefined
   dimTextClassName: string | undefined
   formatVisitedAt: (dateString: string) => string
+  touringStatus?: 'PLANNED' | 'STARTED' | 'COMPLETED'
   onEdit: (spot: ApiResponseSpotDetail) => void
 }
+
+const pad = (n: number) => String(n).padStart(2, '0')
 
 const formatBreakDuration = (
   visitedAt: string,
   endAt: string | null
 ): string => {
   const start = new Date(visitedAt)
-  const pad = (n: number) => String(n).padStart(2, '0')
   const startStr = `${pad(start.getHours())}:${pad(start.getMinutes())}`
 
   if (!endAt) return `${startStr}〜`
@@ -38,6 +40,11 @@ const formatBreakDuration = (
   return `${startStr}〜${endStr}`
 }
 
+const formatPlannedArrival = (visitedAt: string): string => {
+  const d = new Date(visitedAt)
+  return `${pad(d.getHours())}:${pad(d.getMinutes())} 着予定`
+}
+
 /**
  * ドラッグ可能なスポット・休憩行コンポーネント
  */
@@ -50,6 +57,7 @@ export function SortableSpotItem({
   mutedTextClassName,
   dimTextClassName,
   formatVisitedAt,
+  touringStatus,
   onEdit,
 }: SortableSpotItemProps) {
   const {
@@ -100,8 +108,11 @@ export function SortableSpotItem({
           <div className="flex items-center gap-1 shrink-0">
             <span className={dimTextClassName} style={{ fontSize: '0.75rem' }}>
               {isBreak
-                ? formatBreakDuration(spot.visitedAt, spot.endAt)
-                : formatVisitedAt(spot.visitedAt)}
+                ? (touringStatus === 'PLANNED' ? '予定 ' : '') +
+                  formatBreakDuration(spot.visitedAt, spot.endAt)
+                : touringStatus === 'PLANNED'
+                  ? formatPlannedArrival(spot.visitedAt)
+                  : formatVisitedAt(spot.visitedAt)}
             </span>
             <button
               onClick={() => onEdit(spot)}

--- a/apps/web/components/spot/SpotAddForm.tsx
+++ b/apps/web/components/spot/SpotAddForm.tsx
@@ -90,8 +90,7 @@ export function SpotAddForm({
           name: formState.name !== '' ? formState.name : undefined,
           memo: formState.memo !== '' ? formState.memo : undefined,
           visitedAt: new Date(formState.visitedAt),
-          endAt:
-            formState.endAt !== '' ? new Date(formState.endAt) : undefined,
+          endAt: formState.endAt !== '' ? new Date(formState.endAt) : undefined,
           latitude: location?.lat,
           longitude: location?.lng,
         }

--- a/apps/web/components/spot/SpotAddForm.tsx
+++ b/apps/web/components/spot/SpotAddForm.tsx
@@ -16,6 +16,7 @@ type SpotAddFormProps = {
   touringId: string
   initialType?: 'SPOT' | 'BREAK'
   initialLocation?: { lat: number; lng: number } | null
+  touringStatus?: 'PLANNED' | 'STARTED' | 'COMPLETED'
   onSuccess: () => void
 }
 
@@ -41,6 +42,7 @@ export function SpotAddForm({
   touringId,
   initialType = 'SPOT',
   initialLocation = null,
+  touringStatus,
   onSuccess,
 }: SpotAddFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -58,6 +60,17 @@ export function SpotAddForm({
   })
 
   const isBreak = formState.type === 'BREAK'
+  const isPlanned = touringStatus === 'PLANNED'
+
+  const stayMinutes = (() => {
+    if (!formState.visitedAt || !formState.endAt) return null
+    const diff = Math.round(
+      (new Date(formState.endAt).getTime() -
+        new Date(formState.visitedAt).getTime()) /
+        60000
+    )
+    return diff > 0 ? diff : null
+  })()
 
   const handleLocationSaved = (lat: number, lng: number) => {
     setLocation({ lat, lng })
@@ -78,9 +91,7 @@ export function SpotAddForm({
           memo: formState.memo !== '' ? formState.memo : undefined,
           visitedAt: new Date(formState.visitedAt),
           endAt:
-            isBreak && formState.endAt !== ''
-              ? new Date(formState.endAt)
-              : undefined,
+            formState.endAt !== '' ? new Date(formState.endAt) : undefined,
           latitude: location?.lat,
           longitude: location?.lng,
         }
@@ -161,7 +172,15 @@ export function SpotAddForm({
         </FormField>
 
         <FormField
-          label={isBreak ? '休憩開始' : '訪問日時'}
+          label={
+            isBreak
+              ? isPlanned
+                ? '休憩開始予定'
+                : '休憩開始'
+              : isPlanned
+                ? '到着予定'
+                : '訪問日時'
+          }
           htmlFor="spotVisitedAt"
         >
           <Input
@@ -175,19 +194,33 @@ export function SpotAddForm({
           />
         </FormField>
 
-        {isBreak && (
-          <FormField label="休憩終了（任意）" htmlFor="spotEndAt">
-            <Input
-              id="spotEndAt"
-              type="datetime-local"
-              value={formState.endAt}
-              onChange={(e) =>
-                setFormState((prev) => ({ ...prev, endAt: e.target.value }))
-              }
-              disabled={isSubmitting}
-            />
-          </FormField>
-        )}
+        <FormField
+          label={
+            isBreak
+              ? isPlanned
+                ? '休憩終了予定（任意）'
+                : '休憩終了（任意）'
+              : isPlanned
+                ? '出発予定（任意）'
+                : '出発時間（任意）'
+          }
+          htmlFor="spotEndAt"
+        >
+          <Input
+            id="spotEndAt"
+            type="datetime-local"
+            value={formState.endAt}
+            onChange={(e) =>
+              setFormState((prev) => ({ ...prev, endAt: e.target.value }))
+            }
+            disabled={isSubmitting}
+          />
+          {stayMinutes !== null && (
+            <p className="text-xs opacity-50 mt-1 text-right">
+              滞在: {stayMinutes}分
+            </p>
+          )}
+        </FormField>
 
         <FormField label="位置">
           <div className="flex items-center gap-2">

--- a/apps/web/components/spot/SpotAddForm.tsx
+++ b/apps/web/components/spot/SpotAddForm.tsx
@@ -15,6 +15,7 @@ type SpotAddFormProps = {
   bikeId: string
   touringId: string
   initialType?: 'SPOT' | 'BREAK'
+  initialLocation?: { lat: number; lng: number } | null
   onSuccess: () => void
 }
 
@@ -39,13 +40,14 @@ export function SpotAddForm({
   bikeId,
   touringId,
   initialType = 'SPOT',
+  initialLocation = null,
   onSuccess,
 }: SpotAddFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [isLocationModalOpen, setIsLocationModalOpen] = useState(false)
   const [location, setLocation] = useState<{ lat: number; lng: number } | null>(
-    null
+    initialLocation
   )
   const [formState, setFormState] = useState<SpotFormState>({
     type: initialType,

--- a/apps/web/components/spot/SpotAddForm.tsx
+++ b/apps/web/components/spot/SpotAddForm.tsx
@@ -55,7 +55,7 @@ export function SpotAddForm({
     type: initialType,
     name: '',
     memo: '',
-    visitedAt: getNowLocalString(),
+    visitedAt: touringStatus === 'PLANNED' ? '' : getNowLocalString(),
     endAt: '',
   })
 
@@ -80,6 +80,16 @@ export function SpotAddForm({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
+
+    if (!formState.visitedAt) {
+      setError(
+        isPlanned
+          ? '到着予定時間を入力してください'
+          : '訪問日時を入力してください'
+      )
+      return
+    }
+
     setIsSubmitting(true)
 
     try {

--- a/apps/web/components/spot/SpotAddForm.tsx
+++ b/apps/web/components/spot/SpotAddForm.tsx
@@ -17,6 +17,7 @@ type SpotAddFormProps = {
   initialType?: 'SPOT' | 'BREAK'
   initialLocation?: { lat: number; lng: number } | null
   touringStatus?: 'PLANNED' | 'STARTED' | 'COMPLETED'
+  prevSpotVisitedAt?: string
   onSuccess: () => void
 }
 
@@ -28,11 +29,12 @@ type SpotFormState = {
   endAt: string
 }
 
-const getNowLocalString = () => {
-  const now = new Date()
-  const pad = (n: number) => String(n).padStart(2, '0')
-  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}T${pad(now.getHours())}:${pad(now.getMinutes())}`
-}
+const pad = (n: number) => String(n).padStart(2, '0')
+
+const toLocalDateTimeString = (date: Date): string =>
+  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+
+const getNowLocalString = () => toLocalDateTimeString(new Date())
 
 /**
  * スポット・休憩追加フォーム
@@ -43,6 +45,7 @@ export function SpotAddForm({
   initialType = 'SPOT',
   initialLocation = null,
   touringStatus,
+  prevSpotVisitedAt,
   onSuccess,
 }: SpotAddFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -55,7 +58,12 @@ export function SpotAddForm({
     type: initialType,
     name: '',
     memo: '',
-    visitedAt: touringStatus === 'PLANNED' ? '' : getNowLocalString(),
+    visitedAt:
+      touringStatus === 'PLANNED'
+        ? prevSpotVisitedAt
+          ? toLocalDateTimeString(new Date(prevSpotVisitedAt))
+          : ''
+        : getNowLocalString(),
     endAt: '',
   })
 

--- a/apps/web/components/spot/SpotAddModal.tsx
+++ b/apps/web/components/spot/SpotAddModal.tsx
@@ -7,6 +7,7 @@ type SpotAddModalProps = {
   bikeId: string
   touringId: string
   initialType?: 'SPOT' | 'BREAK'
+  initialLocation?: { lat: number; lng: number } | null
   onClose: () => void
   onSuccess: () => void
 }
@@ -18,6 +19,7 @@ export function SpotAddModal({
   bikeId,
   touringId,
   initialType = 'SPOT',
+  initialLocation = null,
   onClose,
   onSuccess,
 }: SpotAddModalProps) {
@@ -29,6 +31,7 @@ export function SpotAddModal({
         bikeId={bikeId}
         touringId={touringId}
         initialType={initialType}
+        initialLocation={initialLocation}
         onSuccess={onSuccess}
       />
     </ModalBase>

--- a/apps/web/components/spot/SpotAddModal.tsx
+++ b/apps/web/components/spot/SpotAddModal.tsx
@@ -8,6 +8,7 @@ type SpotAddModalProps = {
   touringId: string
   initialType?: 'SPOT' | 'BREAK'
   initialLocation?: { lat: number; lng: number } | null
+  touringStatus?: 'PLANNED' | 'STARTED' | 'COMPLETED'
   onClose: () => void
   onSuccess: () => void
 }
@@ -20,6 +21,7 @@ export function SpotAddModal({
   touringId,
   initialType = 'SPOT',
   initialLocation = null,
+  touringStatus,
   onClose,
   onSuccess,
 }: SpotAddModalProps) {
@@ -32,6 +34,7 @@ export function SpotAddModal({
         touringId={touringId}
         initialType={initialType}
         initialLocation={initialLocation}
+        touringStatus={touringStatus}
         onSuccess={onSuccess}
       />
     </ModalBase>

--- a/apps/web/components/spot/SpotAddModal.tsx
+++ b/apps/web/components/spot/SpotAddModal.tsx
@@ -9,6 +9,7 @@ type SpotAddModalProps = {
   initialType?: 'SPOT' | 'BREAK'
   initialLocation?: { lat: number; lng: number } | null
   touringStatus?: 'PLANNED' | 'STARTED' | 'COMPLETED'
+  prevSpotVisitedAt?: string
   onClose: () => void
   onSuccess: () => void
 }
@@ -22,6 +23,7 @@ export function SpotAddModal({
   initialType = 'SPOT',
   initialLocation = null,
   touringStatus,
+  prevSpotVisitedAt,
   onClose,
   onSuccess,
 }: SpotAddModalProps) {
@@ -35,6 +37,7 @@ export function SpotAddModal({
         initialType={initialType}
         initialLocation={initialLocation}
         touringStatus={touringStatus}
+        prevSpotVisitedAt={prevSpotVisitedAt}
         onSuccess={onSuccess}
       />
     </ModalBase>

--- a/apps/web/components/spot/SpotEditForm.tsx
+++ b/apps/web/components/spot/SpotEditForm.tsx
@@ -146,8 +146,7 @@ export function SpotEditForm({
           name: formState.name !== '' ? formState.name : null,
           memo: formState.memo !== '' ? formState.memo : null,
           visitedAt: new Date(formState.visitedAt),
-          endAt:
-            formState.endAt !== '' ? new Date(formState.endAt) : null,
+          endAt: formState.endAt !== '' ? new Date(formState.endAt) : null,
         }
       )
 

--- a/apps/web/components/spot/SpotEditForm.tsx
+++ b/apps/web/components/spot/SpotEditForm.tsx
@@ -17,6 +17,7 @@ interface SpotEditFormProps {
   bikeId: string
   touringId: string
   spot: ApiResponseSpotDetail
+  touringStatus?: 'PLANNED' | 'STARTED' | 'COMPLETED'
   onSuccess: () => void
   onDelete?: () => void
 }
@@ -41,6 +42,7 @@ export function SpotEditForm({
   bikeId,
   touringId,
   spot,
+  touringStatus,
   onSuccess,
   onDelete,
 }: SpotEditFormProps) {
@@ -62,7 +64,18 @@ export function SpotEditForm({
   })
 
   const isBreak = spot.type === 'BREAK'
+  const isPlanned = touringStatus === 'PLANNED'
   const label = isBreak ? '休憩' : 'スポット'
+
+  const stayMinutes = (() => {
+    if (!formState.visitedAt || !formState.endAt) return null
+    const diff = Math.round(
+      (new Date(formState.endAt).getTime() -
+        new Date(formState.visitedAt).getTime()) /
+        60000
+    )
+    return diff > 0 ? diff : null
+  })()
 
   useEffect(() => {
     setFormState({
@@ -133,11 +146,8 @@ export function SpotEditForm({
           name: formState.name !== '' ? formState.name : null,
           memo: formState.memo !== '' ? formState.memo : null,
           visitedAt: new Date(formState.visitedAt),
-          endAt: isBreak
-            ? formState.endAt !== ''
-              ? new Date(formState.endAt)
-              : null
-            : undefined,
+          endAt:
+            formState.endAt !== '' ? new Date(formState.endAt) : null,
         }
       )
 
@@ -185,7 +195,15 @@ export function SpotEditForm({
         </FormField>
 
         <FormField
-          label={isBreak ? '休憩開始' : '訪問日時'}
+          label={
+            isBreak
+              ? isPlanned
+                ? '休憩開始予定'
+                : '休憩開始'
+              : isPlanned
+                ? '到着予定'
+                : '訪問日時'
+          }
           htmlFor="spotVisitedAt"
         >
           <Input
@@ -199,19 +217,33 @@ export function SpotEditForm({
           />
         </FormField>
 
-        {isBreak && (
-          <FormField label="休憩終了（任意）" htmlFor="spotEndAt">
-            <Input
-              id="spotEndAt"
-              type="datetime-local"
-              value={formState.endAt}
-              onChange={(e) =>
-                setFormState((prev) => ({ ...prev, endAt: e.target.value }))
-              }
-              disabled={isSubmitting}
-            />
-          </FormField>
-        )}
+        <FormField
+          label={
+            isBreak
+              ? isPlanned
+                ? '休憩終了予定（任意）'
+                : '休憩終了（任意）'
+              : isPlanned
+                ? '出発予定（任意）'
+                : '出発時間（任意）'
+          }
+          htmlFor="spotEndAt"
+        >
+          <Input
+            id="spotEndAt"
+            type="datetime-local"
+            value={formState.endAt}
+            onChange={(e) =>
+              setFormState((prev) => ({ ...prev, endAt: e.target.value }))
+            }
+            disabled={isSubmitting}
+          />
+          {stayMinutes !== null && (
+            <p className="text-xs opacity-50 mt-1 text-right">
+              滞在: {stayMinutes}分
+            </p>
+          )}
+        </FormField>
 
         <FormField label="位置">
           <div className="flex items-center gap-2">

--- a/apps/web/components/spot/SpotEditModal.tsx
+++ b/apps/web/components/spot/SpotEditModal.tsx
@@ -8,6 +8,7 @@ interface SpotEditModalProps {
   bikeId: string
   touringId: string
   spot: ApiResponseSpotDetail
+  touringStatus?: 'PLANNED' | 'STARTED' | 'COMPLETED'
   onClose: () => void
   onSuccess: () => void
   onDelete?: () => void
@@ -20,6 +21,7 @@ export function SpotEditModal({
   bikeId,
   touringId,
   spot,
+  touringStatus,
   onClose,
   onSuccess,
   onDelete,
@@ -32,6 +34,7 @@ export function SpotEditModal({
         bikeId={bikeId}
         touringId={touringId}
         spot={spot}
+        touringStatus={touringStatus}
         onSuccess={onSuccess}
         onDelete={onDelete}
       />

--- a/apps/web/components/touring/TouringEditForm.tsx
+++ b/apps/web/components/touring/TouringEditForm.tsx
@@ -76,18 +76,29 @@ export function TouringEditForm({
     setError('')
     setIsSubmitting(true)
 
+    const isPlan = formData.mode === 'plan'
+
     try {
       await apiPatch(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}`, {
         title: formData.title,
         startDate: new Date(
           `${formData.startDate}T${formData.startTime || '00:00'}`
         ),
-        endDate: new Date(`${formData.endDate}T${formData.endTime || '00:00'}`),
-        startMileage: formData.startMileage
-          ? Number(formData.startMileage)
-          : null,
-        endMileage: formData.endMileage ? Number(formData.endMileage) : null,
-        status: formData.mode === 'plan' ? 'PLANNED' : 'COMPLETED',
+        // プランの endDate はスポット追加で自動更新されるため編集時は送らない
+        ...(!isPlan && {
+          endDate: new Date(
+            `${formData.endDate}T${formData.endTime || '00:00'}`
+          ),
+        }),
+        startMileage:
+          formData.startMileage !== ''
+            ? Number(formData.startMileage)
+            : undefined,
+        endMileage:
+          !isPlan && formData.endMileage !== ''
+            ? Number(formData.endMileage)
+            : undefined,
+        status: isPlan ? 'PLANNED' : 'COMPLETED',
       })
 
       await mutate(

--- a/apps/web/components/touring/TouringEditForm.tsx
+++ b/apps/web/components/touring/TouringEditForm.tsx
@@ -6,12 +6,13 @@ import type {
   ApiResponseTouringDetail,
   SuccessResponse,
 } from '@repo/shared-types'
+import { Button } from '@repo/ui/button'
 import { toast } from '@repo/ui/sonner'
 import {
   TouringForm,
   type TouringFormData,
 } from '@/components/touring/TouringForm'
-import { authenticatedFetch, apiPatch } from '@/lib/api/client'
+import { authenticatedFetch, apiPatch, apiDelete } from '@/lib/api/client'
 import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
 
 interface TouringEditFormProps {
@@ -26,6 +27,8 @@ export function TouringEditForm({
   onSuccess,
 }: TouringEditFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [confirmingDelete, setConfirmingDelete] = useState(false)
   const [error, setError] = useState('')
   const [initialData, setInitialData] = useState<TouringFormData | undefined>()
 
@@ -57,6 +60,7 @@ export function TouringEditForm({
           endDate: endDateStr,
           startMileage: data.startMileage?.toString() ?? '',
           endMileage: data.endMileage?.toString() ?? '',
+          mode: data.status === 'PLANNED' ? 'plan' : 'history',
         })
       }
     }
@@ -75,19 +79,39 @@ export function TouringEditForm({
           ? Number(formData.startMileage)
           : null,
         endMileage: formData.endMileage ? Number(formData.endMileage) : null,
-        status: 'COMPLETED',
+        status: formData.mode === 'plan' ? 'PLANNED' : 'COMPLETED',
       })
 
       await mutate(
-        `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=end-date&sort-order=desc`
+        `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=start-date&sort-order=desc`
       )
       await mutate(detailUrl)
-      toast.success('ツーリング履歴を更新しました')
+      toast.success('更新しました')
       onSuccess('update')
     } catch (err) {
       setError(err instanceof ApiV1Error ? err.message : 'エラーが発生しました')
     } finally {
       setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    setIsDeleting(true)
+    try {
+      await apiDelete(`/api/v1/user-bike/bike/${bikeId}/tourings`, {
+        touringId,
+      })
+      await mutate(
+        `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=start-date&sort-order=desc`
+      )
+      onSuccess('delete')
+    } catch (err) {
+      toast.error(
+        err instanceof ApiV1Error ? err.message : '削除に失敗しました'
+      )
+      setConfirmingDelete(false)
+    } finally {
+      setIsDeleting(false)
     }
   }
 
@@ -102,12 +126,71 @@ export function TouringEditForm({
   if (!initialData) return null
 
   return (
-    <TouringForm
-      initialData={initialData}
-      onSubmit={handleFormSubmit}
-      isSubmitting={isSubmitting}
-      error={error}
-      isEdit
-    />
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 'var(--spacing-4)',
+      }}
+    >
+      <TouringForm
+        initialData={initialData}
+        onSubmit={handleFormSubmit}
+        isSubmitting={isSubmitting}
+        error={error}
+        isEdit
+      />
+
+      <hr style={{ borderColor: 'var(--color-cloud)', margin: '0' }} />
+
+      {confirmingDelete ? (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--spacing-2)',
+          }}
+        >
+          <p
+            style={{
+              fontSize: 'var(--font-size-sm)',
+              color: 'var(--color-ink)',
+            }}
+          >
+            このツーリングを削除しますか？この操作は取り消せません。
+          </p>
+          <div style={{ display: 'flex', gap: 'var(--spacing-2)' }}>
+            <Button
+              onClick={() => setConfirmingDelete(false)}
+              variant="cloud"
+              size="sm"
+              disabled={isDeleting}
+              fullWidth
+            >
+              キャンセル
+            </Button>
+            <Button
+              onClick={handleDelete}
+              variant="danger"
+              size="sm"
+              disabled={isDeleting}
+              loading={isDeleting}
+              fullWidth
+            >
+              {isDeleting ? '削除中...' : '削除する'}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button
+          onClick={() => setConfirmingDelete(true)}
+          variant="danger"
+          size="sm"
+          disabled={isSubmitting}
+        >
+          削除
+        </Button>
+      )}
+    </div>
   )
 }

--- a/apps/web/components/touring/TouringEditForm.tsx
+++ b/apps/web/components/touring/TouringEditForm.tsx
@@ -50,19 +50,25 @@ export function TouringEditForm({
 
   useEffect(() => {
     if (data) {
-      const startDateStr = new Date(data.startDate).toISOString().split('T')[0]
-      const endDateStr = new Date(data.endDate).toISOString().split('T')[0]
+      const pad = (n: number) => String(n).padStart(2, '0')
+      const toLocalDate = (d: Date) =>
+        `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+      const toLocalTime = (d: Date) =>
+        `${pad(d.getHours())}:${pad(d.getMinutes())}`
 
-      if (startDateStr && endDateStr) {
-        setInitialData({
-          title: data.title,
-          startDate: startDateStr,
-          endDate: endDateStr,
-          startMileage: data.startMileage?.toString() ?? '',
-          endMileage: data.endMileage?.toString() ?? '',
-          mode: data.status === 'PLANNED' ? 'plan' : 'history',
-        })
-      }
+      const start = new Date(data.startDate)
+      const end = new Date(data.endDate)
+
+      setInitialData({
+        title: data.title,
+        startDate: toLocalDate(start),
+        startTime: toLocalTime(start),
+        endDate: toLocalDate(end),
+        endTime: toLocalTime(end),
+        startMileage: data.startMileage?.toString() ?? '',
+        endMileage: data.endMileage?.toString() ?? '',
+        mode: data.status === 'PLANNED' ? 'plan' : 'history',
+      })
     }
   }, [data])
 
@@ -73,8 +79,10 @@ export function TouringEditForm({
     try {
       await apiPatch(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}`, {
         title: formData.title,
-        startDate: new Date(formData.startDate),
-        endDate: new Date(formData.endDate),
+        startDate: new Date(
+          `${formData.startDate}T${formData.startTime || '00:00'}`
+        ),
+        endDate: new Date(`${formData.endDate}T${formData.endTime || '00:00'}`),
         startMileage: formData.startMileage
           ? Number(formData.startMileage)
           : null,

--- a/apps/web/components/touring/TouringForm.tsx
+++ b/apps/web/components/touring/TouringForm.tsx
@@ -47,26 +47,42 @@ export const TouringForm = ({
   }
   const today = getTodayDateString()
 
+  const getCurrentTime = () => {
+    const now = new Date()
+    return `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
+  }
+
+  const getDefaultStartTime = (m: TouringMode) =>
+    m === 'plan' ? '09:00' : getCurrentTime()
+  const getDefaultEndTime = (m: TouringMode) =>
+    m === 'plan' ? '17:00' : getCurrentTime()
+
   const [mode, setMode] = useState<TouringMode>(initialData?.mode ?? 'history')
-  const [formData, setFormData] = useState<Omit<TouringFormData, 'mode'>>({
-    title: initialData?.title ?? '',
-    startDate: initialData?.startDate ?? today,
-    startTime: initialData?.startTime ?? '00:00',
-    endDate: initialData?.endDate ?? today,
-    endTime: initialData?.endTime ?? '00:00',
-    startMileage: initialData?.startMileage ?? '',
-    endMileage: initialData?.endMileage ?? '',
-  })
+  const [formData, setFormData] = useState<Omit<TouringFormData, 'mode'>>(
+    () => {
+      const initialMode = initialData?.mode ?? 'history'
+      return {
+        title: initialData?.title ?? '',
+        startDate: initialData?.startDate ?? today,
+        startTime: initialData?.startTime ?? getDefaultStartTime(initialMode),
+        endDate: initialData?.endDate ?? today,
+        endTime: initialData?.endTime ?? getDefaultEndTime(initialMode),
+        startMileage: initialData?.startMileage ?? '',
+        endMileage: initialData?.endMileage ?? '',
+      }
+    }
+  )
   const [validationError, setValidationError] = useState('')
 
   useEffect(() => {
     if (initialData) {
+      const updatedMode = initialData.mode ?? mode
       setFormData({
         title: initialData.title ?? '',
         startDate: initialData.startDate ?? today,
-        startTime: initialData.startTime ?? '00:00',
+        startTime: initialData.startTime ?? getDefaultStartTime(updatedMode),
         endDate: initialData.endDate ?? today,
-        endTime: initialData.endTime ?? '00:00',
+        endTime: initialData.endTime ?? getDefaultEndTime(updatedMode),
         startMileage: initialData.startMileage ?? '',
         endMileage: initialData.endMileage ?? '',
       })

--- a/apps/web/components/touring/TouringForm.tsx
+++ b/apps/web/components/touring/TouringForm.tsx
@@ -79,7 +79,7 @@ export const TouringForm = ({
   const validateForm = (): boolean => {
     setValidationError('')
 
-    if (formData.startDate && formData.endDate) {
+    if (!isPlan && formData.startDate && formData.endDate) {
       const start = new Date(
         `${formData.startDate}T${formData.startTime || '00:00'}`
       )
@@ -112,7 +112,12 @@ export const TouringForm = ({
     e.preventDefault()
     setValidationError('')
     if (!validateForm()) return
-    await onSubmit({ ...formData, mode })
+    await onSubmit({
+      ...formData,
+      endDate: isPlan ? formData.startDate : formData.endDate,
+      endTime: isPlan ? formData.startTime : formData.endTime,
+      mode,
+    })
   }
 
   return (
@@ -235,35 +240,33 @@ export const TouringForm = ({
         </div>
       </FormField>
 
-      <FormField
-        label={isPlan ? '帰着予定日時' : '終了日時'}
-        htmlFor="endDate"
-        required
-      >
-        <div style={{ display: 'flex', gap: 'var(--spacing-2)' }}>
-          <Input
-            id="endDate"
-            type="date"
-            value={formData.endDate}
-            min={formData.startDate}
-            onChange={(e) =>
-              setFormData((prev) => ({ ...prev, endDate: e.target.value }))
-            }
-            required
-            disabled={isSubmitting}
-          />
-          <Input
-            id="endTime"
-            type="time"
-            value={formData.endTime}
-            onChange={(e) =>
-              setFormData((prev) => ({ ...prev, endTime: e.target.value }))
-            }
-            disabled={isSubmitting}
-            style={{ width: '9rem', flexShrink: 0 }}
-          />
-        </div>
-      </FormField>
+      {!isPlan && (
+        <FormField label="終了日時" htmlFor="endDate" required>
+          <div style={{ display: 'flex', gap: 'var(--spacing-2)' }}>
+            <Input
+              id="endDate"
+              type="date"
+              value={formData.endDate}
+              min={formData.startDate}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, endDate: e.target.value }))
+              }
+              required
+              disabled={isSubmitting}
+            />
+            <Input
+              id="endTime"
+              type="time"
+              value={formData.endTime}
+              onChange={(e) =>
+                setFormData((prev) => ({ ...prev, endTime: e.target.value }))
+              }
+              disabled={isSubmitting}
+              style={{ width: '9rem', flexShrink: 0 }}
+            />
+          </div>
+        </FormField>
+      )}
 
       <FormField
         label={isPlan ? '出発時走行距離 (km)（任意）' : '開始時走行距離 (km)'}

--- a/apps/web/components/touring/TouringForm.tsx
+++ b/apps/web/components/touring/TouringForm.tsx
@@ -11,7 +11,9 @@ export type TouringMode = 'history' | 'plan'
 export interface TouringFormData {
   title: string
   startDate: string
+  startTime: string
   endDate: string
+  endTime: string
   startMileage: string
   endMileage: string
   mode: TouringMode
@@ -47,7 +49,9 @@ export const TouringForm = ({
   const [formData, setFormData] = useState<Omit<TouringFormData, 'mode'>>({
     title: initialData?.title ?? '',
     startDate: initialData?.startDate ?? today,
+    startTime: initialData?.startTime ?? '00:00',
     endDate: initialData?.endDate ?? today,
+    endTime: initialData?.endTime ?? '00:00',
     startMileage: initialData?.startMileage ?? '',
     endMileage: initialData?.endMileage ?? '',
   })
@@ -58,7 +62,9 @@ export const TouringForm = ({
       setFormData({
         title: initialData.title ?? '',
         startDate: initialData.startDate ?? today,
+        startTime: initialData.startTime ?? '00:00',
         endDate: initialData.endDate ?? today,
+        endTime: initialData.endTime ?? '00:00',
         startMileage: initialData.startMileage ?? '',
         endMileage: initialData.endMileage ?? '',
       })
@@ -74,13 +80,15 @@ export const TouringForm = ({
     setValidationError('')
 
     if (formData.startDate && formData.endDate) {
-      const start = new Date(formData.startDate)
-      const end = new Date(formData.endDate)
+      const start = new Date(
+        `${formData.startDate}T${formData.startTime || '00:00'}`
+      )
+      const end = new Date(`${formData.endDate}T${formData.endTime || '00:00'}`)
       if (start > end) {
         setValidationError(
           isPlan
-            ? '出発予定日は帰着予定日より前である必要があります'
-            : '開始日は終了日より前である必要があります'
+            ? '出発予定日時は帰着予定日時より前である必要があります'
+            : '開始日時は終了日時より前である必要があります'
         )
         return false
       }
@@ -191,46 +199,70 @@ export const TouringForm = ({
       </FormField>
 
       <FormField
-        label={isPlan ? '出発予定日' : '開始日'}
+        label={isPlan ? '出発予定日時' : '開始日時'}
         htmlFor="startDate"
         required
       >
-        <Input
-          id="startDate"
-          type="date"
-          value={formData.startDate}
-          onChange={(e) => {
-            const newStart = e.target.value
-            setFormData((prev) => ({
-              ...prev,
-              startDate: newStart,
-              endDate:
-                prev.endDate && newStart > prev.endDate
-                  ? newStart
-                  : prev.endDate,
-            }))
-          }}
-          required
-          disabled={isSubmitting}
-        />
+        <div style={{ display: 'flex', gap: 'var(--spacing-2)' }}>
+          <Input
+            id="startDate"
+            type="date"
+            value={formData.startDate}
+            onChange={(e) => {
+              const newStart = e.target.value
+              setFormData((prev) => ({
+                ...prev,
+                startDate: newStart,
+                endDate:
+                  prev.endDate && newStart > prev.endDate
+                    ? newStart
+                    : prev.endDate,
+              }))
+            }}
+            required
+            disabled={isSubmitting}
+          />
+          <Input
+            id="startTime"
+            type="time"
+            value={formData.startTime}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, startTime: e.target.value }))
+            }
+            disabled={isSubmitting}
+            style={{ width: '9rem', flexShrink: 0 }}
+          />
+        </div>
       </FormField>
 
       <FormField
-        label={isPlan ? '帰着予定日' : '終了日'}
+        label={isPlan ? '帰着予定日時' : '終了日時'}
         htmlFor="endDate"
         required
       >
-        <Input
-          id="endDate"
-          type="date"
-          value={formData.endDate}
-          min={formData.startDate}
-          onChange={(e) =>
-            setFormData((prev) => ({ ...prev, endDate: e.target.value }))
-          }
-          required
-          disabled={isSubmitting}
-        />
+        <div style={{ display: 'flex', gap: 'var(--spacing-2)' }}>
+          <Input
+            id="endDate"
+            type="date"
+            value={formData.endDate}
+            min={formData.startDate}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, endDate: e.target.value }))
+            }
+            required
+            disabled={isSubmitting}
+          />
+          <Input
+            id="endTime"
+            type="time"
+            value={formData.endTime}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, endTime: e.target.value }))
+            }
+            disabled={isSubmitting}
+            style={{ width: '9rem', flexShrink: 0 }}
+          />
+        </div>
       </FormField>
 
       <FormField

--- a/apps/web/components/touring/TouringForm.tsx
+++ b/apps/web/components/touring/TouringForm.tsx
@@ -6,20 +6,24 @@ import { ErrorMessage } from '@repo/ui/errorMessage'
 import { FormField } from '@repo/ui/formField'
 import { Input } from '@repo/ui/input'
 
+export type TouringMode = 'history' | 'plan'
+
 export interface TouringFormData {
   title: string
   startDate: string
   endDate: string
   startMileage: string
   endMileage: string
+  mode: TouringMode
 }
 
 export interface TouringFormProps {
-  initialData?: TouringFormData
+  initialData?: Partial<TouringFormData>
   onSubmit: (data: TouringFormData) => Promise<void>
   isSubmitting: boolean
   error: string
   isEdit?: boolean
+  hideModeSelector?: boolean
 }
 
 export const TouringForm = ({
@@ -28,6 +32,7 @@ export const TouringForm = ({
   isSubmitting,
   error,
   isEdit = false,
+  hideModeSelector = false,
 }: TouringFormProps) => {
   const getTodayDateString = () => {
     const today = new Date()
@@ -37,35 +42,50 @@ export const TouringForm = ({
     return `${year}-${month}-${day}`
   }
   const today = getTodayDateString()
-  const [formData, setFormData] = useState<TouringFormData>({
-    title: '',
-    startDate: today ?? '',
-    endDate: today ?? '',
-    startMileage: '',
-    endMileage: '',
+
+  const [mode, setMode] = useState<TouringMode>(initialData?.mode ?? 'history')
+  const [formData, setFormData] = useState<Omit<TouringFormData, 'mode'>>({
+    title: initialData?.title ?? '',
+    startDate: initialData?.startDate ?? today,
+    endDate: initialData?.endDate ?? today,
+    startMileage: initialData?.startMileage ?? '',
+    endMileage: initialData?.endMileage ?? '',
   })
   const [validationError, setValidationError] = useState('')
 
   useEffect(() => {
     if (initialData) {
-      setFormData(initialData)
+      setFormData({
+        title: initialData.title ?? '',
+        startDate: initialData.startDate ?? today,
+        endDate: initialData.endDate ?? today,
+        startMileage: initialData.startMileage ?? '',
+        endMileage: initialData.endMileage ?? '',
+      })
+      if (initialData.mode) {
+        setMode(initialData.mode)
+      }
     }
-  }, [initialData])
+  }, [initialData]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const isPlan = mode === 'plan'
 
   const validateForm = (): boolean => {
     setValidationError('')
 
-    // 日付の前後関係をチェック
     if (formData.startDate && formData.endDate) {
       const start = new Date(formData.startDate)
       const end = new Date(formData.endDate)
       if (start > end) {
-        setValidationError('開始日は終了日より前である必要があります')
+        setValidationError(
+          isPlan
+            ? '出発予定日は帰着予定日より前である必要があります'
+            : '開始日は終了日より前である必要があります'
+        )
         return false
       }
     }
 
-    // 走行距離の大小関係をチェック
     if (formData.startMileage && formData.endMileage) {
       const start = Number(formData.startMileage)
       const end = Number(formData.endMileage)
@@ -83,12 +103,8 @@ export const TouringForm = ({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setValidationError('')
-
-    if (!validateForm()) {
-      return
-    }
-
-    await onSubmit(formData)
+    if (!validateForm()) return
+    await onSubmit({ ...formData, mode })
   }
 
   return (
@@ -100,95 +116,162 @@ export const TouringForm = ({
         gap: 'var(--spacing-4)',
       }}
     >
+      {/* モード切り替え */}
+      {!hideModeSelector && !isEdit && (
+        <div
+          style={{
+            display: 'flex',
+            borderRadius: 'var(--radius-md)',
+            overflow: 'hidden',
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => setMode('history')}
+            disabled={isSubmitting}
+            style={{
+              flex: 1,
+              padding: 'var(--spacing-2)',
+              background:
+                mode === 'history'
+                  ? 'var(--color-product)'
+                  : 'var(--color-cloud)',
+              color: mode === 'history' ? 'white' : 'var(--color-ink)',
+              border: 'none',
+              cursor: isSubmitting ? 'not-allowed' : 'pointer',
+              fontWeight:
+                mode === 'history'
+                  ? 'var(--font-weight-semibold)'
+                  : 'var(--font-weight-normal)',
+              fontSize: 'var(--font-size-sm)',
+            }}
+          >
+            ツーリングを記録
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode('plan')}
+            disabled={isSubmitting}
+            style={{
+              flex: 1,
+              padding: 'var(--spacing-2)',
+              background:
+                mode === 'plan' ? 'var(--color-product)' : 'var(--color-cloud)',
+              color: mode === 'plan' ? 'white' : 'var(--color-ink)',
+              border: 'none',
+              borderLeft: '1px solid var(--color-cloudHover)',
+              cursor: isSubmitting ? 'not-allowed' : 'pointer',
+              fontWeight:
+                mode === 'plan'
+                  ? 'var(--font-weight-semibold)'
+                  : 'var(--font-weight-normal)',
+              fontSize: 'var(--font-size-sm)',
+            }}
+          >
+            プランを作成
+          </button>
+        </div>
+      )}
+
       <FormField label="タイトル" htmlFor="title" required>
         <Input
           id="title"
           type="text"
           value={formData.title}
           onChange={(e) =>
-            setFormData((prev) => ({
-              ...prev,
-              title: e.target.value,
-            }))
+            setFormData((prev) => ({ ...prev, title: e.target.value }))
           }
           maxLength={100}
           required
           disabled={isSubmitting}
-          placeholder="例: 北海道ツーリング"
+          placeholder={
+            isPlan ? '例: 夏の北海道ツーリング' : '例: 北海道ツーリング'
+          }
         />
       </FormField>
 
-      <FormField label="開始日" htmlFor="startDate" required>
+      <FormField
+        label={isPlan ? '出発予定日' : '開始日'}
+        htmlFor="startDate"
+        required
+      >
         <Input
           id="startDate"
           type="date"
           value={formData.startDate}
-          onChange={(e) =>
+          onChange={(e) => {
+            const newStart = e.target.value
             setFormData((prev) => ({
               ...prev,
-              startDate: e.target.value,
+              startDate: newStart,
+              endDate:
+                prev.endDate && newStart > prev.endDate
+                  ? newStart
+                  : prev.endDate,
             }))
-          }
+          }}
           required
           disabled={isSubmitting}
         />
       </FormField>
 
-      <FormField label="終了日" htmlFor="endDate" required>
+      <FormField
+        label={isPlan ? '帰着予定日' : '終了日'}
+        htmlFor="endDate"
+        required
+      >
         <Input
           id="endDate"
           type="date"
           value={formData.endDate}
+          min={formData.startDate}
           onChange={(e) =>
-            setFormData((prev) => ({
-              ...prev,
-              endDate: e.target.value,
-            }))
+            setFormData((prev) => ({ ...prev, endDate: e.target.value }))
           }
           required
           disabled={isSubmitting}
         />
       </FormField>
 
-      <FormField label="開始時走行距離 (km)" htmlFor="startMileage" required>
+      <FormField
+        label={isPlan ? '出発時走行距離 (km)（任意）' : '開始時走行距離 (km)'}
+        htmlFor="startMileage"
+        required={!isPlan}
+      >
         <Input
           id="startMileage"
           type="number"
           inputMode="numeric"
           value={formData.startMileage}
-          onChange={(e) => {
-            setFormData((prev) => ({
-              ...prev,
-              startMileage: e.target.value,
-            }))
-          }}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, startMileage: e.target.value }))
+          }
           min="0"
           step="1"
-          required
+          required={!isPlan}
           disabled={isSubmitting}
           placeholder="例: 5000"
         />
       </FormField>
 
-      <FormField label="終了時走行距離 (km)" htmlFor="endMileage" required>
-        <Input
-          id="endMileage"
-          type="number"
-          inputMode="numeric"
-          value={formData.endMileage}
-          onChange={(e) => {
-            setFormData((prev) => ({
-              ...prev,
-              endMileage: e.target.value,
-            }))
-          }}
-          min="0"
-          step="1"
-          required
-          disabled={isSubmitting}
-          placeholder="例: 5500"
-        />
-      </FormField>
+      {!isPlan && (
+        <FormField label="終了時走行距離 (km)" htmlFor="endMileage" required>
+          <Input
+            id="endMileage"
+            type="number"
+            inputMode="numeric"
+            value={formData.endMileage}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, endMileage: e.target.value }))
+            }
+            min="0"
+            step="1"
+            required
+            disabled={isSubmitting}
+            placeholder="例: 5500"
+          />
+        </FormField>
+      )}
 
       {validationError && <ErrorMessage>{validationError}</ErrorMessage>}
       {error && <ErrorMessage>{error}</ErrorMessage>}
@@ -202,10 +285,14 @@ export const TouringForm = ({
         {isSubmitting
           ? isEdit
             ? '更新中...'
-            : '登録中...'
+            : isPlan
+              ? '保存中...'
+              : '登録中...'
           : isEdit
             ? '更新する'
-            : '登録する'}
+            : isPlan
+              ? 'プランを保存'
+              : '登録する'}
       </Button>
     </form>
   )

--- a/apps/web/components/touring/TouringForm.tsx
+++ b/apps/web/components/touring/TouringForm.tsx
@@ -26,6 +26,7 @@ export interface TouringFormProps {
   error: string
   isEdit?: boolean
   hideModeSelector?: boolean
+  disablePlanMode?: boolean
 }
 
 export const TouringForm = ({
@@ -35,6 +36,7 @@ export const TouringForm = ({
   error,
   isEdit = false,
   hideModeSelector = false,
+  disablePlanMode = false,
 }: TouringFormProps) => {
   const getTodayDateString = () => {
     const today = new Date()
@@ -163,22 +165,33 @@ export const TouringForm = ({
           </button>
           <button
             type="button"
-            onClick={() => setMode('plan')}
-            disabled={isSubmitting}
+            onClick={() => !disablePlanMode && setMode('plan')}
+            disabled={isSubmitting || disablePlanMode}
+            title={
+              disablePlanMode
+                ? 'ゲストアカウントはプランを作成できません'
+                : undefined
+            }
             style={{
               flex: 1,
               padding: 'var(--spacing-2)',
               background:
                 mode === 'plan' ? 'var(--color-product)' : 'var(--color-cloud)',
-              color: mode === 'plan' ? 'white' : 'var(--color-ink)',
+              color: disablePlanMode
+                ? 'var(--color-muted-foreground)'
+                : mode === 'plan'
+                  ? 'white'
+                  : 'var(--color-ink)',
               border: 'none',
               borderLeft: '1px solid var(--color-cloudHover)',
-              cursor: isSubmitting ? 'not-allowed' : 'pointer',
+              cursor:
+                isSubmitting || disablePlanMode ? 'not-allowed' : 'pointer',
               fontWeight:
                 mode === 'plan'
                   ? 'var(--font-weight-semibold)'
                   : 'var(--font-weight-normal)',
               fontSize: 'var(--font-size-sm)',
+              opacity: disablePlanMode ? 0.5 : 1,
             }}
           >
             プランを作成

--- a/apps/web/components/touring/TouringListItem.module.css
+++ b/apps/web/components/touring/TouringListItem.module.css
@@ -9,6 +9,29 @@
   border-bottom: 1px solid var(--color-cloud);
 }
 
+.itemClickable {
+  cursor: pointer;
+  border-radius: var(--radius-md);
+  transition: background-color var(--transition-fast);
+  padding: var(--spacing-2) var(--spacing-2);
+  margin: 0 calc(-1 * var(--spacing-2));
+}
+
+.itemClickable:hover {
+  background-color: var(--color-cloudHover);
+}
+
+.itemClickable:active {
+  background-color: var(--color-cloudActive);
+}
+
+.chevron {
+  font-size: 1.25rem;
+  color: var(--color-inkLight);
+  flex-shrink: 0;
+  line-height: 1;
+}
+
 /* 行1: タイトル・ステータス・編集 */
 .mainRow {
   display: flex;
@@ -49,6 +72,16 @@
   background-color: var(--color-cloud);
   color: var(--color-ink);
   opacity: 0.7;
+}
+
+.statusBadgePlanned {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  white-space: nowrap;
+  background-color: #6366f1;
+  color: white;
 }
 
 /* 行2: 期間 */

--- a/apps/web/components/touring/TouringListItem.tsx
+++ b/apps/web/components/touring/TouringListItem.tsx
@@ -1,20 +1,16 @@
 'use client'
 
 import type { ApiResponseTouringDetail } from '@repo/shared-types'
-import { Button } from '@repo/ui/button'
 import styles from './TouringListItem.module.css'
-import { TrashIcon } from '@/components/icons/TrashIcon'
 
 export interface TouringListItemProps {
   touring: ApiResponseTouringDetail
   onDetail?: (touringId: string) => void
-  onDelete?: (touringId: string) => void
 }
 
 export const TouringListItem = ({
   touring,
   onDetail,
-  onDelete,
 }: TouringListItemProps) => {
   const formatDate = (dateString: string) => {
     try {
@@ -38,52 +34,51 @@ export const TouringListItem = ({
   const distance = calculateDistance()
 
   return (
-    <div className={styles.item}>
-      {/* 行1: タイトル・ステータス・編集 */}
+    <div
+      className={`${styles.item} ${onDetail ? styles.itemClickable : ''}`}
+      onClick={() => onDetail?.(touring.touringId)}
+      role={onDetail ? 'button' : undefined}
+      tabIndex={onDetail ? 0 : undefined}
+      onKeyDown={
+        onDetail
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                onDetail(touring.touringId)
+              }
+            }
+          : undefined
+      }
+    >
       <div className={styles.mainRow}>
         <div className={styles.titleSection}>
           <h3 className={styles.title}>{touring.title}</h3>
           <span
             className={
-              touring.status === 'STARTED'
-                ? styles.statusBadgeStarted
-                : styles.statusBadgeCompleted
+              touring.status === 'PLANNED'
+                ? styles.statusBadgePlanned
+                : touring.status === 'STARTED'
+                  ? styles.statusBadgeStarted
+                  : styles.statusBadgeCompleted
             }
           >
-            {touring.status === 'STARTED' ? '進行中' : '完了'}
+            {touring.status === 'PLANNED'
+              ? 'プラン'
+              : touring.status === 'STARTED'
+                ? '進行中'
+                : '完了'}
           </span>
         </div>
-
-        <div style={{ display: 'flex', gap: '0.5rem' }}>
-          {onDetail && (
-            <Button
-              onClick={() => onDetail(touring.touringId)}
-              variant="cloud"
-              size="sm"
-            >
-              詳細
-            </Button>
-          )}
-          {onDelete && (
-            <Button
-              onClick={() => onDelete(touring.touringId)}
-              variant="danger"
-              size="sm"
-            >
-              <TrashIcon />
-            </Button>
-          )}
-        </div>
+        <span className={styles.chevron}>›</span>
       </div>
 
-      {/* 行2: 期間 */}
       <div className={styles.periodRow}>
         <span>
+          {touring.status === 'PLANNED' ? '予定: ' : ''}
           {formatDate(touring.startDate)} 〜 {formatDate(touring.endDate)}
         </span>
       </div>
 
-      {/* 行3: 走行距離情報 */}
       {distance !== null && (
         <div className={styles.detailsRow}>
           <span>走行距離: {distance.toLocaleString()}km</span>

--- a/apps/web/components/touring/TouringListSection.tsx
+++ b/apps/web/components/touring/TouringListSection.tsx
@@ -7,40 +7,23 @@ import { TouringListItem } from './TouringListItem'
 import styles from './TouringListSection.module.css'
 
 export interface TouringListSectionProps {
-  /**
-   * 表示するツーリング履歴のリスト（ソート済み）
-   */
   tourings: ApiResponseTouringDetail[]
-
-  /**
-   * ツーリング履歴詳細表示時のコールバック
-   */
   onDetail?: (touringId: string) => void
-
-  /**
-   * ツーリング履歴削除時のコールバック
-   */
-  onDelete?: (touringId: string) => void
-
-  /**
-   * ツーリング履歴登録ボタンクリック時のコールバック
-   */
   onRegister: () => void
 }
 
 export const TouringListSection = ({
   tourings,
   onDetail,
-  onDelete,
   onRegister,
 }: TouringListSectionProps) => {
   return (
-    <BaseCard title="ツーリング履歴">
+    <BaseCard title="ツーリング">
       {tourings.length === 0 ? (
         <div className={styles.emptyState}>
-          <p>ツーリング履歴がまだありません</p>
+          <p>ツーリングの記録がまだありません</p>
           <Button onClick={onRegister} variant="primary">
-            最初のツーリング履歴を登録
+            最初のツーリングを登録
           </Button>
         </div>
       ) : (
@@ -50,7 +33,6 @@ export const TouringListSection = ({
               key={touring.touringId}
               touring={touring}
               onDetail={onDetail}
-              onDelete={onDelete}
             />
           ))}
         </div>

--- a/apps/web/components/touring/TouringRouteMap.tsx
+++ b/apps/web/components/touring/TouringRouteMap.tsx
@@ -6,6 +6,7 @@ export type { MapPoint }
 type Props = {
   points: MapPoint[]
   containerClassName: string | undefined
+  onMapClick?: (lat: number, lng: number) => void
 }
 
 const TouringRouteMapInner = dynamic(() => import('./TouringRouteMapInner'), {
@@ -27,11 +28,16 @@ const TouringRouteMapInner = dynamic(() => import('./TouringRouteMapInner'), {
   ),
 })
 
-export default function TouringRouteMap({ points, containerClassName }: Props) {
+export default function TouringRouteMap({
+  points,
+  containerClassName,
+  onMapClick,
+}: Props) {
   return (
     <TouringRouteMapInner
       points={points}
       containerClassName={containerClassName}
+      onMapClick={onMapClick}
     />
   )
 }

--- a/apps/web/components/touring/TouringRouteMapInner.tsx
+++ b/apps/web/components/touring/TouringRouteMapInner.tsx
@@ -4,6 +4,8 @@ import type L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 import { useEffect, useRef } from 'react'
 
+type Callback = (lat: number, lng: number) => void
+
 export type MapPoint = {
   lat: number
   lng: number
@@ -14,6 +16,7 @@ export type MapPoint = {
 type Props = {
   points: MapPoint[]
   containerClassName: string | undefined
+  onMapClick?: (lat: number, lng: number) => void
 }
 
 const COLORS: Record<MapPoint['type'], string> = {
@@ -26,12 +29,15 @@ const COLORS: Record<MapPoint['type'], string> = {
 export default function TouringRouteMapInner({
   points,
   containerClassName,
+  onMapClick,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
   const mapRef = useRef<L.Map | null>(null)
+  const onMapClickRef = useRef<Callback | undefined>(onMapClick)
+  onMapClickRef.current = onMapClick
 
   useEffect(() => {
-    if (!containerRef.current || points.length === 0) return
+    if (!containerRef.current) return
 
     const initMap = async () => {
       const L = (await import('leaflet')).default
@@ -50,37 +56,49 @@ export default function TouringRouteMapInner({
         maxZoom: 18,
       }).addTo(map)
 
-      const latLngs: L.LatLngExpression[] = points.map((p) => [p.lat, p.lng])
+      if (points.length > 0) {
+        const latLngs: L.LatLngExpression[] = points.map((p) => [p.lat, p.lng])
 
-      if (latLngs.length > 1) {
-        L.polyline(latLngs, {
-          color: '#6366f1',
-          weight: 3,
-          opacity: 0.7,
-        }).addTo(map)
+        if (latLngs.length > 1) {
+          L.polyline(latLngs, {
+            color: '#6366f1',
+            weight: 3,
+            opacity: 0.7,
+          }).addTo(map)
+        }
+
+        points.forEach((point) => {
+          const color = COLORS[point.type]
+          const radius = point.type === 'spot' ? 7 : 9
+          const marker = L.circleMarker([point.lat, point.lng], {
+            radius,
+            fillColor: color,
+            color: '#fff',
+            weight: 2,
+            opacity: 1,
+            fillOpacity: 0.9,
+          }).addTo(map)
+
+          marker.bindTooltip(point.label, {
+            permanent: false,
+            direction: 'top',
+            offset: [0, -8],
+          })
+        })
+
+        const bounds = L.latLngBounds(latLngs)
+        map.fitBounds(bounds, { padding: [32, 32] })
+      } else {
+        // ポイントなし: 日本全体を表示
+        map.setView([36.0, 138.0], 5)
       }
 
-      points.forEach((point) => {
-        const color = COLORS[point.type]
-        const radius = point.type === 'spot' ? 7 : 9
-        const marker = L.circleMarker([point.lat, point.lng], {
-          radius,
-          fillColor: color,
-          color: '#fff',
-          weight: 2,
-          opacity: 1,
-          fillOpacity: 0.9,
-        }).addTo(map)
-
-        marker.bindTooltip(point.label, {
-          permanent: false,
-          direction: 'top',
-          offset: [0, -8],
+      if (onMapClickRef.current) {
+        map.getContainer().style.cursor = 'crosshair'
+        map.on('click', (e: L.LeafletMouseEvent) => {
+          onMapClickRef.current?.(e.latlng.lat, e.latlng.lng)
         })
-      })
-
-      const bounds = L.latLngBounds(latLngs)
-      map.fitBounds(bounds, { padding: [32, 32] })
+      }
     }
 
     initMap()

--- a/apps/web/lib/api/server/interfaces/IHistoryRepository.ts
+++ b/apps/web/lib/api/server/interfaces/IHistoryRepository.ts
@@ -42,7 +42,7 @@ export type PublicHistoryDetail = {
     endDate: Date
     startMileage: number | null
     endMileage: number | null
-    status: 'STARTED' | 'COMPLETED'
+    status: 'PLANNED' | 'STARTED' | 'COMPLETED'
   } | null
 }
 

--- a/apps/web/lib/api/server/interfaces/ITouringRepository.ts
+++ b/apps/web/lib/api/server/interfaces/ITouringRepository.ts
@@ -1,4 +1,4 @@
-import { MyUserBikeId, TouringId } from '@repo/shared-types'
+import { MyUserBikeId, TouringId, TouringStatus } from '@repo/shared-types'
 import { TouringEntity } from '../entities/TouringEntity'
 import { TouringSearchParams } from '../valueObjects/TouringSearchParams'
 
@@ -17,7 +17,7 @@ export interface ITouringRepository {
   updateTouringStatus(
     touringId: TouringId,
     myUserBikeId: MyUserBikeId,
-    status: 'STARTED' | 'COMPLETED'
+    status: TouringStatus
   ): Promise<TouringEntity>
   deleteTouring(touringId: TouringId, myUserBikeId: MyUserBikeId): Promise<void>
   countTourings(myUserBikeId: MyUserBikeId): Promise<number>

--- a/apps/web/lib/api/server/repositories/PrismaTouringRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaTouringRepository.ts
@@ -3,6 +3,7 @@ import {
   createTouringId,
   MyUserBikeId,
   TouringId,
+  TouringStatus,
 } from '@repo/shared-types'
 import { TouringEntity } from '../entities/TouringEntity'
 import { ITouringRepository } from '../interfaces/ITouringRepository'
@@ -36,7 +37,7 @@ type TouringRow = {
   startLongitude: number | null
   endLatitude: number | null
   endLongitude: number | null
-  status: 'STARTED' | 'COMPLETED'
+  status: TouringStatus
 }
 
 const toTouringEntity = (row: TouringRow): TouringEntity =>
@@ -121,6 +122,9 @@ export class PrismaTouringRepository
     const tourings = await this.connection.tUserMyBikeTouring.findMany({
       where: {
         userMyBikeId: myUserBikeId,
+        ...(searchParams.status !== undefined
+          ? { status: searchParams.status }
+          : {}),
       },
       select: touringSelect,
       orderBy,
@@ -169,7 +173,7 @@ export class PrismaTouringRepository
   async updateTouringStatus(
     touringId: TouringId,
     myUserBikeId: MyUserBikeId,
-    status: 'STARTED' | 'COMPLETED'
+    status: TouringStatus
   ): Promise<TouringEntity> {
     const updated = await this.connection.tUserMyBikeTouring.update({
       where: {

--- a/apps/web/lib/api/server/services/SpotService.ts
+++ b/apps/web/lib/api/server/services/SpotService.ts
@@ -8,6 +8,7 @@ import {
 } from '@repo/shared-types'
 import type { SpotReorderRequest } from '@repo/shared-types'
 import { SpotEntity } from '../entities/SpotEntity'
+import { TouringEntity } from '../entities/TouringEntity'
 import { ApiV1Error } from '../errors/ApiV1Error'
 import { IMyUserBikeRepository } from '../interfaces/IMyUserBikeRepository'
 import { ISpotRepository } from '../interfaces/ISpotRepository'
@@ -79,7 +80,9 @@ export class SpotService {
         sortOrder: 0, // createSpot でカウントして末尾に設定される
       })
 
-      return await this.spotRepository.createSpot(spot)
+      const created = await this.spotRepository.createSpot(spot)
+      await this._syncPlanEndDate(params.touringId, touring)
+      return created
     } catch (error) {
       if (error instanceof Error) {
         throw new ApiV1Error('INVALID_REQUEST', error.message)
@@ -162,7 +165,9 @@ export class SpotService {
         sortOrder: existingSpot.sortOrder,
       })
 
-      return await this.spotRepository.updateSpot(updatedSpot)
+      const updated = await this.spotRepository.updateSpot(updatedSpot)
+      await this._syncPlanEndDate(params.touringId, touring)
+      return updated
     } catch (error) {
       if (error instanceof Error) {
         throw new ApiV1Error('INVALID_REQUEST', error.message)
@@ -205,6 +210,7 @@ export class SpotService {
     }
 
     await this.spotRepository.deleteSpot(spotId, touringId)
+    await this._syncPlanEndDate(touringId, touring)
   }
 
   public async reorderSpots(
@@ -234,6 +240,25 @@ export class SpotService {
     await this.spotRepository.reorderSpots(
       spotIds.map((id) => createSpotId(id)),
       touringId
+    )
+  }
+
+  private async _syncPlanEndDate(
+    touringId: TouringId,
+    touring: TouringEntity
+  ): Promise<void> {
+    if (touring.status !== 'PLANNED') return
+
+    const spots = await this.spotRepository.findSpotsByTouringId(touringId)
+    const newEndDate =
+      spots.length > 0
+        ? new Date(Math.max(...spots.map((s) => s.visitedAt.getTime())))
+        : touring.startDate
+
+    if (newEndDate.getTime() === touring.endDate.getTime()) return
+
+    await this.touringRepository.updateTouring(
+      new TouringEntity({ ...touring.toJson(), endDate: newEndDate })
     )
   }
 }

--- a/apps/web/lib/api/server/services/TouringService.ts
+++ b/apps/web/lib/api/server/services/TouringService.ts
@@ -32,6 +32,7 @@ type StartTouringParams = {
   myUserBikeId: MyUserBikeId
   userId: UserId
   role: 'USER' | 'ADMIN' | 'GUEST'
+  touringPlanId?: string
   title?: string
   startDate?: Date
   startMileage?: number
@@ -103,7 +104,7 @@ export class TouringService {
 
     const status = params.status ?? 'COMPLETED'
 
-    // STARTEDで登録する場合は、既に進行中のツーリングがないかチェック
+    // STARTEDで登録する場合は、既に進行中のツーリングがないかチェック（PLANNEDは複数登録可能）
     if (status === 'STARTED') {
       const ongoingTouring = await this.touringRepository.findOngoingTouring(
         params.myUserBikeId
@@ -191,6 +192,44 @@ export class TouringService {
         }
 
         const startDate = params.startDate ?? new Date()
+
+        // プランから開始する場合は既存の PLANNED ツーリングを STARTED に更新
+        if (params.touringPlanId !== undefined) {
+          const plan = await this.touringRepository.findTouringById(
+            createTouringId(params.touringPlanId),
+            params.myUserBikeId
+          )
+          if (!plan) {
+            throw new ApiV1Error(
+              'NOT_FOUND',
+              '指定されたツーリングプランが見つかりません'
+            )
+          }
+          if (plan.status !== 'PLANNED') {
+            throw new ApiV1Error(
+              'INVALID_REQUEST',
+              '指定されたツーリングはプラン状態ではありません'
+            )
+          }
+
+          const updatedPlan = new TouringEntity({
+            touringId: plan.id,
+            myUserBikeId: plan.myUserBikeId,
+            title: params.title ?? plan.title,
+            startDate,
+            endDate: startDate,
+            startMileage: startMileage ?? plan.startMileage,
+            endMileage: null,
+            startLatitude: params.startLatitude ?? plan.startLatitude,
+            startLongitude: params.startLongitude ?? plan.startLongitude,
+            endLatitude: null,
+            endLongitude: null,
+            status: 'STARTED',
+          })
+
+          return await this.touringRepository.updateTouring(updatedPlan)
+        }
+
         const title = params.title ?? 'ツーリング'
         const touring = new TouringEntity({
           touringId: createTouringId(''),
@@ -322,7 +361,7 @@ export class TouringService {
       throw new ApiV1Error('NOT_FOUND', '指定されたツーリングが見つかりません')
     }
 
-    // ステータスをSTARTEDに変更する場合、既に進行中のツーリングがないかチェック
+    // ステータスをSTARTEDに変更する場合、既に進行中のツーリングがないかチェック（PLANNEDからの遷移も含む）
     const newStatus = params.status ?? existingTouring.status
     if (newStatus === 'STARTED' && existingTouring.status !== 'STARTED') {
       const ongoingTouring = await this.touringRepository.findOngoingTouring(

--- a/apps/web/lib/api/server/services/TouringService.ts
+++ b/apps/web/lib/api/server/services/TouringService.ts
@@ -89,6 +89,14 @@ export class TouringService {
       throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
     }
 
+    // ゲストアカウントのプランモード制限
+    if (params.role === 'GUEST' && params.status === 'PLANNED') {
+      throw new ApiV1Error(
+        'INVALID_REQUEST',
+        'ゲストアカウントはツーリングプランを使用できません'
+      )
+    }
+
     // ゲストアカウントのツーリング登録数チェック
     if (params.role === 'GUEST') {
       const count = await this.touringRepository.countTourings(
@@ -156,8 +164,8 @@ export class TouringService {
 
     try {
       if (params.action === 'start') {
-        // ゲストアカウントのツーリング登録数チェック
-        if (params.role === 'GUEST') {
+        // ゲストアカウントのツーリング登録数チェック（プランから開始する場合は新規作成ではないためスキップ）
+        if (params.role === 'GUEST' && params.touringPlanId === undefined) {
           const count = await this.touringRepository.countTourings(
             params.myUserBikeId
           )

--- a/apps/web/lib/api/server/services/TouringService.ts
+++ b/apps/web/lib/api/server/services/TouringService.ts
@@ -217,7 +217,7 @@ export class TouringService {
             myUserBikeId: plan.myUserBikeId,
             title: params.title ?? plan.title,
             startDate,
-            endDate: startDate,
+            endDate: plan.endDate,
             startMileage: startMileage ?? plan.startMileage,
             endMileage: null,
             startLatitude: params.startLatitude ?? plan.startLatitude,

--- a/apps/web/lib/api/server/v1/userBike/tourings.ts
+++ b/apps/web/lib/api/server/v1/userBike/tourings.ts
@@ -48,6 +48,7 @@ userBikeTourings.get(
     const searchParams = new TouringSearchParams({
       sortBy: query['sort-by'] === 'end-date' ? 'endDate' : 'startDate',
       sortOrder: query['sort-order'],
+      status: query['status'],
     })
 
     const touringRepo = new PrismaTouringRepository(prisma)
@@ -115,16 +116,20 @@ userBikeTourings.post(
         endDate: body.endDate,
         startMileage: body.startMileage,
         endMileage: body.endMileage,
+        status: body.status,
       })
 
-      const historyRepo = new PrismaHistoryRepository(t)
-      await historyRepo.createHistory({
-        userId: createUserId(userId),
-        userMyBikeId: createMyUserBikeId(myUserBikeId),
-        type: 'TOURING',
-        occurredAt: touring.endDate,
-        touringId: touring.id,
-      })
+      // PLANNEDのときはまだツーリングが完了していないので履歴を作成しない
+      if (touring.status !== 'PLANNED') {
+        const historyRepo = new PrismaHistoryRepository(t)
+        await historyRepo.createHistory({
+          userId: createUserId(userId),
+          userMyBikeId: createMyUserBikeId(myUserBikeId),
+          type: 'TOURING',
+          occurredAt: touring.endDate,
+          touringId: touring.id,
+        })
+      }
 
       return touring
     })
@@ -215,6 +220,7 @@ userBikeTourings.post(
           myUserBikeId: createMyUserBikeId(myUserBikeId),
           userId: createUserId(userId),
           role,
+          touringPlanId: body.touringPlanId,
           title: body.title,
           startDate: body.startDate,
           startMileage: body.startMileage,

--- a/apps/web/lib/api/server/valueObjects/TouringSearchParams.ts
+++ b/apps/web/lib/api/server/valueObjects/TouringSearchParams.ts
@@ -1,16 +1,21 @@
+import { TouringStatus } from '@repo/shared-types'
+
 /**
  * ツーリング検索パラメータを表すバリューオブジェクト
  */
 export class TouringSearchParams {
   private readonly _sortBy: 'startDate' | 'endDate'
   private readonly _sortOrder: 'asc' | 'desc'
+  private readonly _status: TouringStatus | undefined
 
   constructor(params: {
     sortBy?: 'startDate' | 'endDate'
     sortOrder?: 'asc' | 'desc'
+    status?: TouringStatus
   }) {
     this._sortBy = params.sortBy || 'startDate'
     this._sortOrder = params.sortOrder || 'desc'
+    this._status = params.status
   }
 
   get sortBy(): 'startDate' | 'endDate' {
@@ -19,5 +24,9 @@ export class TouringSearchParams {
 
   get sortOrder(): 'asc' | 'desc' {
     return this._sortOrder
+  }
+
+  get status(): TouringStatus | undefined {
+    return this._status
   }
 }

--- a/apps/web/lib/utils/googleMaps.ts
+++ b/apps/web/lib/utils/googleMaps.ts
@@ -1,0 +1,33 @@
+type GeoPoint = { lat: number; lng: number }
+
+/**
+ * 複数地点を経由するGoogleマップ経路URLを生成する。
+ * 地点が1つのみの場合は場所検索URLを返す。
+ */
+export function buildGoogleMapsRouteUrl(points: GeoPoint[]): string | null {
+  const first = points[0]
+  const last = points[points.length - 1]
+  if (!first) return null
+  if (points.length === 1) {
+    return `https://www.google.com/maps/search/?api=1&query=${first.lat},${first.lng}`
+  }
+  if (!last) return null
+  const origin = `${first.lat},${first.lng}`
+  const destination = `${last.lat},${last.lng}`
+  const waypoints = points
+    .slice(1, -1)
+    .map((p) => `${p.lat},${p.lng}`)
+    .join('|')
+  const base = `https://www.google.com/maps/dir/?api=1&origin=${origin}&destination=${destination}`
+  return waypoints ? `${base}&waypoints=${encodeURIComponent(waypoints)}` : base
+}
+
+/**
+ * 2地点間のGoogleマップ経路URLを生成する。
+ */
+export function buildGoogleMapsTwoPointUrl(
+  from: GeoPoint,
+  to: GeoPoint
+): string {
+  return `https://www.google.com/maps/dir/?api=1&origin=${from.lat},${from.lng}&destination=${to.lat},${to.lng}`
+}

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -1020,6 +1020,15 @@ paths:
               - desc
             default: desc
             description: ソート順序
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum:
+              - PLANNED
+              - STARTED
+              - COMPLETED
+          description: ステータスでフィルタリング
       responses:
         '200':
           description: ツーリング一覧取得成功
@@ -1087,6 +1096,50 @@ paths:
                   message:
                     type: string
                     example: ツーリング登録成功
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '403':
+          $ref: '#/components/responses/Error403'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '500':
+          $ref: '#/components/responses/Error500'
+    delete:
+      summary: ユーザー所有バイクのツーリング削除
+      tags:
+        - user-bikes
+      parameters:
+        - in: path
+          name: my-user-bike-id
+          required: true
+          schema:
+            type: string
+          description: ユーザー所有バイクID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MyUserBikeTouringDeleteDetail'
+      responses:
+        '200':
+          description: ツーリング削除成功
+          headers:
+            Authorization:
+              $ref: '#/components/headers/Authorization'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  message:
+                    type: string
+                    example: ツーリング削除成功
         '400':
           $ref: '#/components/responses/Error400'
         '401':
@@ -1253,6 +1306,270 @@ paths:
                   message:
                     type: string
                     example: ツーリング更新成功
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '403':
+          $ref: '#/components/responses/Error403'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '500':
+          $ref: '#/components/responses/Error500'
+
+  /api/v1/user-bike/bike/{my-user-bike-id}/tourings/{touring-id}/spots:
+    get:
+      summary: ツーリングのスポット一覧取得
+      tags:
+        - user-bikes
+      parameters:
+        - in: path
+          name: my-user-bike-id
+          required: true
+          schema:
+            type: string
+          description: ユーザー所有バイクID
+        - in: path
+          name: touring-id
+          required: true
+          schema:
+            type: string
+          description: ツーリングID
+      responses:
+        '200':
+          description: スポット一覧取得成功
+          headers:
+            Authorization:
+              $ref: '#/components/headers/Authorization'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/MyUserBikeTouringSpotDetail'
+                  message:
+                    type: string
+                    example: スポット一覧取得成功
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '403':
+          $ref: '#/components/responses/Error403'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '500':
+          $ref: '#/components/responses/Error500'
+    post:
+      summary: ツーリングのスポット登録
+      tags:
+        - user-bikes
+      parameters:
+        - in: path
+          name: my-user-bike-id
+          required: true
+          schema:
+            type: string
+          description: ユーザー所有バイクID
+        - in: path
+          name: touring-id
+          required: true
+          schema:
+            type: string
+          description: ツーリングID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MyUserBikeTouringSpotRegisterDetail'
+      responses:
+        '201':
+          description: スポット登録成功
+          headers:
+            Authorization:
+              $ref: '#/components/headers/Authorization'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  data:
+                    $ref: '#/components/schemas/MyUserBikeTouringSpotDetail'
+                  message:
+                    type: string
+                    example: スポット登録成功
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '403':
+          $ref: '#/components/responses/Error403'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '500':
+          $ref: '#/components/responses/Error500'
+
+  /api/v1/user-bike/bike/{my-user-bike-id}/tourings/{touring-id}/spots/reorder:
+    patch:
+      summary: ツーリングのスポット並び替え
+      tags:
+        - user-bikes
+      parameters:
+        - in: path
+          name: my-user-bike-id
+          required: true
+          schema:
+            type: string
+          description: ユーザー所有バイクID
+        - in: path
+          name: touring-id
+          required: true
+          schema:
+            type: string
+          description: ツーリングID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MyUserBikeTouringSpotReorderDetail'
+      responses:
+        '200':
+          description: スポット並び替え成功
+          headers:
+            Authorization:
+              $ref: '#/components/headers/Authorization'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  message:
+                    type: string
+                    example: スポット並び替え成功
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '403':
+          $ref: '#/components/responses/Error403'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '500':
+          $ref: '#/components/responses/Error500'
+
+  /api/v1/user-bike/bike/{my-user-bike-id}/tourings/{touring-id}/spots/{spot-id}:
+    patch:
+      summary: ツーリングのスポット更新
+      tags:
+        - user-bikes
+      parameters:
+        - in: path
+          name: my-user-bike-id
+          required: true
+          schema:
+            type: string
+          description: ユーザー所有バイクID
+        - in: path
+          name: touring-id
+          required: true
+          schema:
+            type: string
+          description: ツーリングID
+        - in: path
+          name: spot-id
+          required: true
+          schema:
+            type: string
+          description: スポットID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MyUserBikeTouringSpotUpdateDetail'
+      responses:
+        '200':
+          description: スポット更新成功
+          headers:
+            Authorization:
+              $ref: '#/components/headers/Authorization'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  data:
+                    $ref: '#/components/schemas/MyUserBikeTouringSpotDetail'
+                  message:
+                    type: string
+                    example: スポット更新成功
+        '400':
+          $ref: '#/components/responses/Error400'
+        '401':
+          $ref: '#/components/responses/Error401'
+        '403':
+          $ref: '#/components/responses/Error403'
+        '404':
+          $ref: '#/components/responses/Error404'
+        '500':
+          $ref: '#/components/responses/Error500'
+    delete:
+      summary: ツーリングのスポット削除
+      tags:
+        - user-bikes
+      parameters:
+        - in: path
+          name: my-user-bike-id
+          required: true
+          schema:
+            type: string
+          description: ユーザー所有バイクID
+        - in: path
+          name: touring-id
+          required: true
+          schema:
+            type: string
+          description: ツーリングID
+        - in: path
+          name: spot-id
+          required: true
+          schema:
+            type: string
+          description: スポットID
+      responses:
+        '200':
+          description: スポット削除成功
+          headers:
+            Authorization:
+              $ref: '#/components/headers/Authorization'
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: success
+                  message:
+                    type: string
+                    example: スポット削除成功
         '400':
           $ref: '#/components/responses/Error400'
         '401':
@@ -1731,6 +2048,38 @@ components:
           type: integer
           nullable: true
           description: 終了時の総走行距離（km）
+        startLatitude:
+          type: number
+          format: float
+          nullable: true
+          description: 開始地点の緯度
+        startLongitude:
+          type: number
+          format: float
+          nullable: true
+          description: 開始地点の経度
+        endLatitude:
+          type: number
+          format: float
+          nullable: true
+          description: 終了地点の緯度
+        endLongitude:
+          type: number
+          format: float
+          nullable: true
+          description: 終了地点の経度
+        status:
+          type: string
+          enum:
+            - PLANNED
+            - STARTED
+            - COMPLETED
+          description: ステータス
+        fuelLogIds:
+          type: array
+          items:
+            type: string
+          description: 紐づく給油履歴IDの一覧
     MyUserBikeTouringRegisterDetail:
       type: object
       required:
@@ -1756,9 +2105,18 @@ components:
           type: integer
           nullable: true
           description: 終了時の総走行距離（km）
+        status:
+          type: string
+          enum:
+            - PLANNED
+            - STARTED
+            - COMPLETED
+          default: COMPLETED
+          description: ステータス（省略時はCOMPLETED）
 
     MyUserBikeTouringUpdateDetail:
       type: object
+      description: いずれかのフィールドの指定が必須
       properties:
         title:
           type: string
@@ -1778,8 +2136,55 @@ components:
           type: integer
           nullable: true
           description: 終了時の総走行距離（km）
+        status:
+          type: string
+          enum:
+            - PLANNED
+            - STARTED
+            - COMPLETED
+          description: ステータス
+        fuelLogIds:
+          type: array
+          items:
+            type: string
+          description: 紐づける給油履歴IDの一覧
+        startLatitude:
+          type: number
+          format: float
+          minimum: -90
+          maximum: 90
+          nullable: true
+          description: 開始地点の緯度
+        startLongitude:
+          type: number
+          format: float
+          minimum: -180
+          maximum: 180
+          nullable: true
+          description: 開始地点の経度
+        endLatitude:
+          type: number
+          format: float
+          minimum: -90
+          maximum: 90
+          nullable: true
+          description: 終了地点の緯度
+        endLongitude:
+          type: number
+          format: float
+          minimum: -180
+          maximum: 180
+          nullable: true
+          description: 終了地点の経度
 
     MyUserBikeTouringStartEndDetail:
+      oneOf:
+        - $ref: '#/components/schemas/MyUserBikeTouringStartDetail'
+        - $ref: '#/components/schemas/MyUserBikeTouringEndDetail'
+      discriminator:
+        propertyName: action
+
+    MyUserBikeTouringStartDetail:
       type: object
       required:
         - action
@@ -1788,30 +2193,66 @@ components:
           type: string
           enum:
             - start
-            - end
-          description: 操作種別
-        touringId:
+          description: 操作種別（開始）
+        touringPlanId:
           type: string
-          description: ツーリングID（終了時に必須）
+          description: プランから開始する場合のツーリングプランID（任意）
         title:
           type: string
           minLength: 1
           maxLength: 100
-          description: タイトル（開始時の任意）
+          description: タイトル（任意）
         startDate:
           type: string
-          description: 開始日（ISO 8601形式）
-        endDate:
-          type: string
-          description: 終了日（ISO 8601形式）
+          description: 開始日（ISO 8601形式、任意）
         startMileage:
           type: integer
-          nullable: true
-          description: 開始時の総走行距離（km）
+          description: 開始時の総走行距離（km、任意）
+        startLatitude:
+          type: number
+          format: float
+          minimum: -90
+          maximum: 90
+          description: 開始地点の緯度（任意）
+        startLongitude:
+          type: number
+          format: float
+          minimum: -180
+          maximum: 180
+          description: 開始地点の経度（任意）
+
+    MyUserBikeTouringEndDetail:
+      type: object
+      required:
+        - action
+        - touringId
+      properties:
+        action:
+          type: string
+          enum:
+            - end
+          description: 操作種別（終了）
+        touringId:
+          type: string
+          description: ツーリングID（終了時に必須）
+        endDate:
+          type: string
+          description: 終了日（ISO 8601形式、任意）
         endMileage:
           type: integer
-          nullable: true
-          description: 終了時の総走行距離（km）
+          description: 終了時の総走行距離（km、任意）
+        endLatitude:
+          type: number
+          format: float
+          minimum: -90
+          maximum: 90
+          description: 終了地点の緯度（任意）
+        endLongitude:
+          type: number
+          format: float
+          minimum: -180
+          maximum: 180
+          description: 終了地点の経度（任意）
 
     MyUserBikeFuelInsightDetail:
       type: object
@@ -1862,13 +2303,153 @@ components:
           nullable: true
           description: 詳細情報（任意）
 
+    MyUserBikeTouringDeleteDetail:
+      type: object
+      required:
+        - touringId
+      properties:
+        touringId:
+          type: string
+          description: ツーリングID
+
+    MyUserBikeTouringSpotDetail:
+      type: object
+      properties:
+        spotId:
+          type: string
+        touringId:
+          type: string
+        type:
+          type: string
+          enum:
+            - SPOT
+            - BREAK
+          description: スポット種別（SPOT=観光地など、BREAK=休憩）
+        name:
+          type: string
+          nullable: true
+          maxLength: 100
+          description: スポット名
+        memo:
+          type: string
+          nullable: true
+          maxLength: 500
+          description: メモ
+        latitude:
+          type: number
+          format: float
+          nullable: true
+          description: 緯度
+        longitude:
+          type: number
+          format: float
+          nullable: true
+          description: 経度
+        visitedAt:
+          type: string
+          description: 訪問日時（ISO 8601形式）
+        endAt:
+          type: string
+          nullable: true
+          description: 終了日時（ISO 8601形式）
+        sortOrder:
+          type: integer
+          description: 並び順
+
+    MyUserBikeTouringSpotRegisterDetail:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - SPOT
+            - BREAK
+          default: SPOT
+          description: スポット種別
+        name:
+          type: string
+          maxLength: 100
+          description: スポット名
+        memo:
+          type: string
+          maxLength: 500
+          description: メモ
+        latitude:
+          type: number
+          format: float
+          minimum: -90
+          maximum: 90
+          description: 緯度
+        longitude:
+          type: number
+          format: float
+          minimum: -180
+          maximum: 180
+          description: 経度
+        visitedAt:
+          type: string
+          description: 訪問日時（ISO 8601形式）
+        endAt:
+          type: string
+          description: 終了日時（ISO 8601形式）
+
+    MyUserBikeTouringSpotUpdateDetail:
+      type: object
+      description: いずれかのフィールドの指定が必須
+      properties:
+        name:
+          type: string
+          maxLength: 100
+          nullable: true
+          description: スポット名
+        memo:
+          type: string
+          maxLength: 500
+          nullable: true
+          description: メモ
+        latitude:
+          type: number
+          format: float
+          minimum: -90
+          maximum: 90
+          nullable: true
+          description: 緯度
+        longitude:
+          type: number
+          format: float
+          minimum: -180
+          maximum: 180
+          nullable: true
+          description: 経度
+        visitedAt:
+          type: string
+          description: 訪問日時（ISO 8601形式）
+        endAt:
+          type: string
+          nullable: true
+          description: 終了日時（ISO 8601形式）
+
+    MyUserBikeTouringSpotReorderDetail:
+      type: object
+      required:
+        - spotIds
+      properties:
+        spotIds:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: 並び替え後のスポットIDの順序
+
     ErrorCode:
       type: string
       enum:
         - INVALID_REQUEST
         - VALIDATION_ERROR
         - AUTH_FAILED
+        - FORBIDDEN
         - USER_NOT_REGISTERED
+        - GUEST_EXPIRED
         - NOT_FOUND
         - SERVER_ERROR
 

--- a/packages/database/prisma/migrations/20260605000000_add_planned_to_touring_status/migration.sql
+++ b/packages/database/prisma/migrations/20260605000000_add_planned_to_touring_status/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "TouringStatus" ADD VALUE 'PLANNED';

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -429,6 +429,7 @@ enum UserQuitStatus {
 }
 
 enum TouringStatus {
+  PLANNED
   STARTED
   COMPLETED
 }

--- a/packages/shared-types/src/common/ApiIO.ts
+++ b/packages/shared-types/src/common/ApiIO.ts
@@ -238,7 +238,7 @@ export type ApiResponseTouringDetail = {
   startLongitude: number | null
   endLatitude: number | null
   endLongitude: number | null
-  status: 'STARTED' | 'COMPLETED'
+  status: 'PLANNED' | 'STARTED' | 'COMPLETED'
   fuelLogIds: string[]
 }
 
@@ -252,7 +252,7 @@ export type ApiResponsePublicTouringList = {
     endDate: string
     startMileage: number | null
     endMileage: number | null
-    status: 'STARTED' | 'COMPLETED'
+    status: 'PLANNED' | 'STARTED' | 'COMPLETED'
   }[]
 }
 

--- a/packages/shared-types/src/domain/touring.ts
+++ b/packages/shared-types/src/domain/touring.ts
@@ -3,7 +3,7 @@ import { MyUserBikeId } from './bike'
 export type TouringId = string & { readonly __brand: unique symbol }
 export const createTouringId = (id: string): TouringId => id as TouringId
 
-export type TouringStatus = 'STARTED' | 'COMPLETED'
+export type TouringStatus = 'PLANNED' | 'STARTED' | 'COMPLETED'
 
 export type Touring = {
   touringId: TouringId

--- a/packages/shared-types/src/schemas/touringSchema.ts
+++ b/packages/shared-types/src/schemas/touringSchema.ts
@@ -36,9 +36,9 @@ export const TouringRegisterRequestSchema = z
       .nonnegative('終了時の総走行距離は0以上で指定してください')
       .optional(),
     status: z
-      .enum(['STARTED', 'COMPLETED'], {
+      .enum(['PLANNED', 'STARTED', 'COMPLETED'], {
         invalid_type_error:
-          'ステータスはSTARTEDまたはCOMPLETEDで指定してください',
+          'ステータスはPLANNED、STARTEDまたはCOMPLETEDで指定してください',
       })
       .default('COMPLETED')
       .optional(),
@@ -100,9 +100,9 @@ export const TouringUpdateRequestSchema = z
       .nonnegative('終了時の総走行距離は0以上で指定してください')
       .optional(),
     status: z
-      .enum(['STARTED', 'COMPLETED'], {
+      .enum(['PLANNED', 'STARTED', 'COMPLETED'], {
         invalid_type_error:
-          'ステータスはSTARTEDまたはCOMPLETEDで指定してください',
+          'ステータスはPLANNED、STARTEDまたはCOMPLETEDで指定してください',
       })
       .optional(),
     fuelLogIds: z
@@ -194,6 +194,12 @@ const TouringStartRequestSchema = z.object({
   action: z.literal('start', {
     required_error: '操作は必須です',
   }),
+  touringPlanId: z
+    .string({
+      invalid_type_error: 'ツーリングプランIDは文字列で指定してください',
+    })
+    .min(1, 'ツーリングプランIDは1文字以上で指定してください')
+    .optional(),
   title: z
     .string({
       invalid_type_error: 'タイトルは文字列で指定してください',
@@ -283,6 +289,7 @@ export type TouringStartEndRequest = z.infer<
 export const TouringListQuerySchema = z.object({
   'sort-by': z.enum(['start-date', 'end-date']).optional(),
   'sort-order': z.enum(['asc', 'desc']).default('desc').optional(),
+  status: z.enum(['PLANNED', 'STARTED', 'COMPLETED']).optional(),
 })
 
 export type TouringListQuery = z.infer<typeof TouringListQuerySchema>
@@ -291,9 +298,10 @@ export type TouringListQuery = z.infer<typeof TouringListQuerySchema>
  * ツーリングステータス更新リクエストのバリデーションスキーマ
  */
 export const TouringStatusUpdateRequestSchema = z.object({
-  status: z.enum(['STARTED', 'COMPLETED'], {
+  status: z.enum(['PLANNED', 'STARTED', 'COMPLETED'], {
     required_error: 'ステータスは必須です',
-    invalid_type_error: 'ステータスはSTARTEDまたはCOMPLETEDで指定してください',
+    invalid_type_error:
+      'ステータスはPLANNED、STARTEDまたはCOMPLETEDで指定してください',
   }),
 })
 


### PR DESCRIPTION
## 概要

ツーリングの事前プランニング機能を追加します。プランモードでツーリング情報・スポット・
終着地を登録し、当日「ツーリングを開始する」ボタンで STARTED に移行するフローを実装
しました。ゲストアカウントはプランモードを利用できない制限も含みます。

## 変更内容

### ツーリングプラン機能（コア）
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `lib/api/server/services/TouringService.ts` | 修正 | PLANNED ステータスの登録・開始・制限ロジック追加 |
| `lib/api/server/v1/userBike/tourings.ts` | 修正 | status=PLANNED の受け付けと start-end アクション対応 |
| `lib/api/server/valueObjects/TouringSearchParams.ts` | 追加 | ステータスフィルタリング用バリューオブジェクト |
| `packages/shared-types/src/schemas/touringSchema.ts` | 修正 | PLANNED ステータスのスキーマ追加 |
| `packages/shared-types/src/domain/touring.ts` | 修正 | TouringStatus に PLANNED を追加 |
| `packages/database/prisma/schema.prisma` | 修正 | TouringStatus enum に PLANNED を追加 |

### UI・フォーム
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `components/touring/TouringForm.tsx` | 修正 | プラン／履歴モード切り替え UI・プランモード時の入力項目制御 |
| `components/touring/TouringEditForm.tsx` | 修正 | プラン編集対応・ゲスト制限の表示 |
| `components/touring/TouringListItem.tsx` | 修正 | プランバッジ・ステータス別表示 |
| `components/touring/TouringListSection.tsx` | 修正 | プランと履歴を同一リストで表示 |
| `components/spot/SpotAddForm.tsx` | 修正 | PLANNED 時の入力ラベル・初期値制御 |
| `components/spot/SpotEditForm.tsx` | 修正 | PLANNED 時の編集対応 |
| `lib/utils/googleMaps.ts` | 追加 | スポット間 Google マップ経路 URL 生成ユーティリティ |

### ツーリング詳細ページ
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx` | 修正 | 「ツーリングを開始する」ボタン・PLANNED での終着地登録・スポット間ルートリンク |
| `app/(protected)/my-bike/[id]/tourings/page.tsx` | 修正 | プラン一覧表示 |
| `app/(protected)/my-bike/[id]/tourings/register/page.tsx` | 修正 | プラン登録フロー |

### ナビゲーション UI 改善
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `components/Navigation/DesktopHeader.tsx` | 追加 | デスクトップ用ヘッダーコンポーネント |
| `components/Navigation/BreadcrumbNav.tsx` | 修正 | パンくずナビの表示改善 |
| `components/notification/BellButton.tsx` | 修正 | 共通 Button コンポーネントへ統一 |

### テスト
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `apps/e2e/tests/touring/touringPlan.spec.ts` | 追加 | プラン作成・開始・削除の E2E テスト |
| `apps/e2e/tests/touring/touringPlanDestination.spec.ts` | 追加 | PLANNED での終着地登録 E2E テスト |
| `apps/web/__tests__/api/v1/userBike.test.ts` | 修正 | プラン関連の API ユニットテスト追加 |

## 影響範囲
- ツーリング登録・一覧・詳細ページ全体
- スポット追加・編集フォーム
- ゲストアカウントの制限ロジック
- ナビゲーションヘッダー・パンくず

## テストプラン
- [x] プランモードでツーリングを登録できる
- [ ] プラン詳細ページで「ツーリングを開始する」ボタンが表示される
- [ ] 「開始する」をタップすると STARTED に移行してホームへ遷移する
- [ ] プランに出発地・終着地・スポットを登録できる
- [ ] ゲストアカウントでプランモードが無効化されている
- [ ] 記録モード（COMPLETED）の既存フローが壊れていない

Closes #391