### PR TITLE
✨ ツーリング詳細でスポットのスキップ時刻(skippedAt)を表示する

### DIFF
--- a/apps/e2e/tests/touring/touringSpotStatus.spec.ts
+++ b/apps/e2e/tests/touring/touringSpotStatus.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '../../helpers/touringPlanHelper'
 
 test.describe('ツーリング詳細 - スポットのスキップ表示', () => {
-  test('スキップしたスポットは「スキップ」バッジと「実績 未設定」で区別表示される', async ({
+  test('スキップしたスポットは「スキップ」バッジとスキップ時刻で区別表示される', async ({
     authenticatedPage: page,
     authToken,
   }) => {
@@ -34,7 +34,7 @@ test.describe('ツーリング詳細 - スポットのスキップ表示', () =>
       timeout: 10_000,
     })
     await expect(page.getByText('スキップ', { exact: true })).toBeVisible()
-    await expect(page.getByText('実績 未設定')).toBeVisible()
+    await expect(page.getByText(/スキップ \d{2}:\d{2}/)).toBeVisible()
   })
 })
 

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -408,7 +408,9 @@ function TouringDetailPage() {
         latitude: spot.latitude,
         longitude: spot.longitude,
         primaryTime: { label: '予定', value: spot.plannedArrivalAt },
-        secondaryTime: { label: '実績', value: spot.arrivedAt },
+        secondaryTime: spot.isSkipped
+          ? { label: 'スキップ', value: spot.skippedAt }
+          : { label: '実績', value: spot.arrivedAt },
         isSkipped: spot.isSkipped,
         travelLink: travelLinks.get(spot.spotId) ?? null,
         onEdit: () => setEditingSpot(spot),


### PR DESCRIPTION
## 概要
ツーリング詳細画面のスポットタイムラインで、スキップしたスポットの時刻スロットに「スキップ HH:mm」を表示するよう修正しました。
DBに記録されている `skippedAt` 情報をフロントエンドの画面に活用し、いつスポットをスキップしたかを確認できるようになります。

## 変更内容

### スキップ時刻の表示対応

| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `apps/web/.../tourings/[touringId]/page.tsx` | 修正 | `secondaryTime` スロットを `isSkipped` に応じて切り替え。`true` のとき `{ label: 'スキップ', value: skippedAt }` を、`false` のとき `{ label: '実績', value: arrivedAt }` を返すよう変更 |
| `apps/e2e/tests/touring/touringSpotStatus.spec.ts` | 修正 | スキップ表示テストのアサーションを `'実績 未設定'` から `/スキップ \d{2}:\d{2}/` に更新。テスト名も表示内容に合わせて修正 |

## 影響範囲
- ツーリング詳細ページのスポット・タイムライン表示（`RouteTimeline` の `secondaryTime` スロット）
- スキップしていないスポットの表示は変更なし

## テストプラン
- [ ] スキップ済みスポットのタイムラインに「スキップ HH:mm」が表示される
- [ ] スキップしていないスポットは引き続き「実績 HH:mm」が表示される
- [ ] E2Eテスト `touringSpotStatus.spec.ts` がパスする

Closes #415