### PR TITLE
✨ ツーリングプラン作成件数の上限制限を実装する

### DIFF
--- a/apps/web/app/(public)/pricing/page.module.css
+++ b/apps/web/app/(public)/pricing/page.module.css
@@ -16,7 +16,7 @@
 .description {
   font-size: 18px;
   line-height: 1.7;
-  color: rgba(23, 23, 23, 0.7);
+  color: var(--color-inkLight);
 }
 
 .pricingGrid {
@@ -34,34 +34,34 @@
 
 .comparisonTitle {
   font-size: 28px;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   margin-bottom: 32px;
   text-align: center;
 }
 
 .tableWrapper {
   overflow-x: auto;
-  border-radius: 16px;
-  border: 1px solid rgba(23, 23, 23, 0.1);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--color-ink) 10%, transparent);
 }
 
 .comparisonTable {
   width: 100%;
   border-collapse: collapse;
-  font-size: 15px;
+  font-size: var(--font-size-sm);
 }
 
 .comparisonTable th,
 .comparisonTable td {
   padding: 14px 20px;
   text-align: center;
-  border-bottom: 1px solid rgba(23, 23, 23, 0.08);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-ink) 8%, transparent);
 }
 
 .comparisonTable thead th {
-  font-weight: 700;
-  font-size: 14px;
-  background: rgba(23, 23, 23, 0.04);
+  font-weight: var(--font-weight-bold);
+  font-size: var(--font-size-xs);
+  background: color-mix(in srgb, var(--color-ink) 4%, transparent);
 }
 
 .comparisonTable tbody tr:last-child td {
@@ -69,7 +69,7 @@
 }
 
 .comparisonTable tbody tr:hover {
-  background: rgba(23, 23, 23, 0.02);
+  background: color-mix(in srgb, var(--color-ink) 3%, transparent);
 }
 
 .featureCol {
@@ -79,21 +79,21 @@
 
 .comparisonTable td:first-child {
   text-align: left;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .premiumCol {
-  color: rgba(23, 23, 23, 0.5);
+  color: var(--color-inkLight);
 }
 
 .comingSoon {
-  color: rgba(23, 23, 23, 0.4);
+  color: var(--color-inkLight);
   font-style: italic;
 }
 
 .comparisonNote {
-  font-size: 13px;
-  color: rgba(23, 23, 23, 0.5);
+  font-size: var(--font-size-xs);
+  color: var(--color-inkLight);
   margin-top: 12px;
   text-align: center;
 }
@@ -102,12 +102,12 @@
   max-width: 1200px;
   margin: 0 auto;
   padding-top: 48px;
-  border-top: 1px solid rgba(23, 23, 23, 0.1);
+  border-top: 1px solid color-mix(in srgb, var(--color-ink) 10%, transparent);
 }
 
 .faqTitle {
   font-size: 28px;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   margin-bottom: 32px;
   text-align: center;
 }
@@ -119,8 +119,8 @@
 }
 
 .faqItem {
-  background: rgba(23, 23, 23, 0.04);
-  border-radius: 16px;
+  background: color-mix(in srgb, var(--color-ink) 4%, transparent);
+  border-radius: var(--radius-lg);
   padding: 24px;
   display: flex;
   flex-direction: column;
@@ -128,14 +128,14 @@
 }
 
 .faqItem h3 {
-  font-size: 18px;
-  font-weight: 600;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
 }
 
 .faqItem p {
-  font-size: 15px;
-  line-height: 1.6;
-  color: rgba(23, 23, 23, 0.7);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-inkLight);
 }
 
 @media (max-width: 900px) {
@@ -161,7 +161,7 @@
   .comparisonTable th,
   .comparisonTable td {
     padding: 10px 12px;
-    font-size: 13px;
+    font-size: var(--font-size-xs);
   }
 
   .featureCol {
@@ -183,52 +183,10 @@
   }
 
   .faqItem h3 {
-    font-size: 16px;
+    font-size: var(--font-size-md);
   }
 
   .faqItem p {
-    font-size: 14px;
+    font-size: var(--font-size-sm);
   }
-}
-
-html[data-theme-mode='dark'] .description,
-html[data-theme-mode='dark'] .faqItem p {
-  color: rgba(237, 237, 237, 0.7);
-}
-
-html[data-theme-mode='dark'] .faqSection {
-  border-top-color: rgba(255, 255, 255, 0.1);
-}
-
-html[data-theme-mode='dark'] .faqItem {
-  background: rgba(255, 255, 255, 0.04);
-}
-
-html[data-theme-mode='dark'] .tableWrapper {
-  border-color: rgba(255, 255, 255, 0.1);
-}
-
-html[data-theme-mode='dark'] .comparisonTable th,
-html[data-theme-mode='dark'] .comparisonTable td {
-  border-bottom-color: rgba(255, 255, 255, 0.06);
-}
-
-html[data-theme-mode='dark'] .comparisonTable thead th {
-  background: rgba(255, 255, 255, 0.04);
-}
-
-html[data-theme-mode='dark'] .comparisonTable tbody tr:hover {
-  background: rgba(255, 255, 255, 0.03);
-}
-
-html[data-theme-mode='dark'] .premiumCol {
-  color: rgba(237, 237, 237, 0.4);
-}
-
-html[data-theme-mode='dark'] .comingSoon {
-  color: rgba(237, 237, 237, 0.3);
-}
-
-html[data-theme-mode='dark'] .comparisonNote {
-  color: rgba(237, 237, 237, 0.4);
 }

--- a/apps/web/app/(public)/pricing/page.module.css
+++ b/apps/web/app/(public)/pricing/page.module.css
@@ -27,6 +27,77 @@
   margin: 0 auto 96px;
 }
 
+.comparisonSection {
+  max-width: 1200px;
+  margin: 0 auto 96px;
+}
+
+.comparisonTitle {
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 32px;
+  text-align: center;
+}
+
+.tableWrapper {
+  overflow-x: auto;
+  border-radius: 16px;
+  border: 1px solid rgba(23, 23, 23, 0.1);
+}
+
+.comparisonTable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 15px;
+}
+
+.comparisonTable th,
+.comparisonTable td {
+  padding: 14px 20px;
+  text-align: center;
+  border-bottom: 1px solid rgba(23, 23, 23, 0.08);
+}
+
+.comparisonTable thead th {
+  font-weight: 700;
+  font-size: 14px;
+  background: rgba(23, 23, 23, 0.04);
+}
+
+.comparisonTable tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.comparisonTable tbody tr:hover {
+  background: rgba(23, 23, 23, 0.02);
+}
+
+.featureCol {
+  text-align: left !important;
+  width: 220px;
+}
+
+.comparisonTable td:first-child {
+  text-align: left;
+  font-weight: 500;
+}
+
+.premiumCol {
+  color: rgba(23, 23, 23, 0.5);
+}
+
+.comingSoon {
+  color: rgba(23, 23, 23, 0.4);
+  font-style: italic;
+}
+
+.comparisonNote {
+  font-size: 13px;
+  color: rgba(23, 23, 23, 0.5);
+  margin-top: 12px;
+  text-align: center;
+}
+
 .faqSection {
   max-width: 1200px;
   margin: 0 auto;
@@ -78,6 +149,25 @@
     margin-bottom: 72px;
   }
 
+  .comparisonSection {
+    margin-bottom: 72px;
+  }
+
+  .comparisonTitle {
+    font-size: 24px;
+    margin-bottom: 24px;
+  }
+
+  .comparisonTable th,
+  .comparisonTable td {
+    padding: 10px 12px;
+    font-size: 13px;
+  }
+
+  .featureCol {
+    width: 140px;
+  }
+
   .faqTitle {
     font-size: 24px;
     margin-bottom: 24px;
@@ -112,4 +202,33 @@ html[data-theme-mode='dark'] .faqSection {
 
 html[data-theme-mode='dark'] .faqItem {
   background: rgba(255, 255, 255, 0.04);
+}
+
+html[data-theme-mode='dark'] .tableWrapper {
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+html[data-theme-mode='dark'] .comparisonTable th,
+html[data-theme-mode='dark'] .comparisonTable td {
+  border-bottom-color: rgba(255, 255, 255, 0.06);
+}
+
+html[data-theme-mode='dark'] .comparisonTable thead th {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+html[data-theme-mode='dark'] .comparisonTable tbody tr:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+html[data-theme-mode='dark'] .premiumCol {
+  color: rgba(237, 237, 237, 0.4);
+}
+
+html[data-theme-mode='dark'] .comingSoon {
+  color: rgba(237, 237, 237, 0.3);
+}
+
+html[data-theme-mode='dark'] .comparisonNote {
+  color: rgba(237, 237, 237, 0.4);
 }

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -2,7 +2,12 @@ import type { Metadata } from 'next'
 import styles from './page.module.css'
 import { PRICING_PLANS } from './pricingData'
 import { PricingCard } from '@/components/docs/pricing/PricingCard'
-import { APP_NAME, SITE_URL } from '@/lib/statics'
+import {
+  APP_NAME,
+  FREE_USER_LIMITS,
+  GUEST_ACCOUNT_LIMITS,
+  SITE_URL,
+} from '@/lib/statics'
 
 export const metadata: Metadata = {
   title: `料金プラン`,
@@ -53,6 +58,75 @@ export default function PricingPage() {
           />
         ))}
       </div>
+
+      <section className={styles.comparisonSection}>
+        <h2 className={styles.comparisonTitle}>機能・制限一覧</h2>
+        <div className={styles.tableWrapper}>
+          <table className={styles.comparisonTable}>
+            <thead>
+              <tr>
+                <th className={styles.featureCol}>機能</th>
+                <th>ゲストアカウント</th>
+                <th>無料プラン</th>
+                <th className={styles.premiumCol}>プレミアムプラン</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>バイク登録</td>
+                <td>{GUEST_ACCOUNT_LIMITS.BIKE}台まで</td>
+                <td>2台まで</td>
+                <td className={styles.comingSoon}>無制限（予定）</td>
+              </tr>
+              <tr>
+                <td>給油履歴</td>
+                <td>{GUEST_ACCOUNT_LIMITS.FUEL_LOG}件まで / 台</td>
+                <td>無制限</td>
+                <td className={styles.comingSoon}>無制限（予定）</td>
+              </tr>
+              <tr>
+                <td>ツーリング記録</td>
+                <td>{GUEST_ACCOUNT_LIMITS.TOURING}件まで / 台</td>
+                <td>無制限</td>
+                <td className={styles.comingSoon}>無制限（予定）</td>
+              </tr>
+              <tr>
+                <td>ツーリングプラン</td>
+                <td>{GUEST_ACCOUNT_LIMITS.TOURING_PLAN}件まで / 台</td>
+                <td>{FREE_USER_LIMITS.TOURING_PLAN}件まで / 台</td>
+                <td className={styles.comingSoon}>無制限（予定）</td>
+              </tr>
+              <tr>
+                <td>メンテナンス記録</td>
+                <td>2件まで / 台</td>
+                <td>無制限</td>
+                <td className={styles.comingSoon}>無制限（予定）</td>
+              </tr>
+              <tr>
+                <td>メンテナンス通知</td>
+                <td>-</td>
+                <td>○</td>
+                <td className={styles.comingSoon}>○（予定）</td>
+              </tr>
+              <tr>
+                <td>データ自動バックアップ</td>
+                <td>○</td>
+                <td>○</td>
+                <td className={styles.comingSoon}>○（予定）</td>
+              </tr>
+              <tr>
+                <td>マルチデバイス同期</td>
+                <td>○</td>
+                <td>○</td>
+                <td className={styles.comingSoon}>○（予定）</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p className={styles.comparisonNote}>
+          ※ゲストアカウントは登録から7日間有効です。
+        </p>
+      </section>
 
       <section className={styles.faqSection}>
         <h2 className={styles.faqTitle}>プランに関する質問</h2>

--- a/apps/web/lib/api/server/interfaces/ITouringPlanRepository.ts
+++ b/apps/web/lib/api/server/interfaces/ITouringPlanRepository.ts
@@ -13,4 +13,5 @@ export interface ITouringPlanRepository {
     myUserBikeId: MyUserBikeId
   ): Promise<TouringPlanEntity | null>
   deletePlan(planId: TouringPlanId, myUserBikeId: MyUserBikeId): Promise<void>
+  countPlans(myUserBikeId: MyUserBikeId): Promise<number>
 }

--- a/apps/web/lib/api/server/repositories/PrismaTouringPlanRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaTouringPlanRepository.ts
@@ -96,4 +96,10 @@ export class PrismaTouringPlanRepository
       where: { id: planId, userMyBikeId: myUserBikeId },
     })
   }
+
+  async countPlans(myUserBikeId: MyUserBikeId): Promise<number> {
+    return this.connection.tUserMyBikeTouringPlan.count({
+      where: { userMyBikeId: myUserBikeId },
+    })
+  }
 }

--- a/apps/web/lib/api/server/services/TouringPlanService.ts
+++ b/apps/web/lib/api/server/services/TouringPlanService.ts
@@ -7,6 +7,7 @@ import {
   TouringPlanRouteType,
   UserId,
 } from '@repo/shared-types'
+import { FREE_USER_LIMITS, GUEST_ACCOUNT_LIMITS } from '../../../statics'
 import { TouringEntity } from '../entities/TouringEntity'
 import { TouringPlanEntity } from '../entities/TouringPlanEntity'
 import { TouringPlanSpotEntity } from '../entities/TouringPlanSpotEntity'
@@ -30,6 +31,7 @@ type LocationParams = {
 type RegisterPlanParams = {
   myUserBikeId: MyUserBikeId
   userId: UserId
+  role: 'USER' | 'ADMIN' | 'GUEST'
   title: string
   startLocation?: LocationParams | null
   destinationLocation?:
@@ -85,6 +87,30 @@ export class TouringPlanService {
 
     if (!myUserBike) {
       throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
+    }
+
+    if (params.role === 'GUEST') {
+      const count = await this.touringPlanRepository.countPlans(
+        params.myUserBikeId
+      )
+      if (count >= GUEST_ACCOUNT_LIMITS.TOURING_PLAN) {
+        throw new ApiV1Error(
+          'INVALID_REQUEST',
+          'ゲストアカウントはツーリングプランを2件まで登録できます'
+        )
+      }
+    }
+
+    if (params.role === 'USER') {
+      const count = await this.touringPlanRepository.countPlans(
+        params.myUserBikeId
+      )
+      if (count >= FREE_USER_LIMITS.TOURING_PLAN) {
+        throw new ApiV1Error(
+          'INVALID_REQUEST',
+          '無料ユーザーはツーリングプランを10件まで登録できます'
+        )
+      }
     }
 
     try {

--- a/apps/web/lib/api/server/v1/userBike/touringPlans.ts
+++ b/apps/web/lib/api/server/v1/userBike/touringPlans.ts
@@ -132,7 +132,7 @@ userBikeTouringPlans.post(
   honoAuthMiddleware,
   zodValidateJson(TouringPlanRegisterRequestSchema),
   async (c) => {
-    const { userId } = c.var.user!
+    const { userId, role } = c.var.user!
     const myUserBikeId = c.req.param('myUserBikeId')
     const body = c.req.valid('json')
 
@@ -151,6 +151,7 @@ userBikeTouringPlans.post(
       return service.registerPlan({
         myUserBikeId: createMyUserBikeId(myUserBikeId),
         userId: createUserId(userId),
+        role,
         title: body.title,
         startLocation: body.startLocation,
         destinationLocation: body.destinationLocation

--- a/apps/web/lib/statics.ts
+++ b/apps/web/lib/statics.ts
@@ -28,6 +28,16 @@ export const GUEST_ACCOUNT_LIMITS = {
   FUEL_LOG: 5,
   /** ツーリング履歴登録上限 */
   TOURING: 2,
+  /** ツーリングプラン登録上限 */
+  TOURING_PLAN: 2,
   /** アカウント有効期間（ミリ秒） */
   TTL_MS: 7 * 24 * 60 * 60 * 1000,
+} as const
+
+/**
+ * 無料ユーザー（USERロール）の各種制限値
+ */
+export const FREE_USER_LIMITS = {
+  /** ツーリングプラン登録上限 */
+  TOURING_PLAN: 10,
 } as const


### PR DESCRIPTION
## 概要
ツーリングプランの作成件数にユーザーロール別の上限を追加した。
ゲストアカウントは2件まで、無料ユーザー（USERロール）は10件までに制限される。
あわせて料金ページに機能・制限一覧テーブルを新設した。

## 変更内容

### ツーリングプラン件数制限（バックエンド）
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `lib/statics.ts` | 修正 | `GUEST_ACCOUNT_LIMITS` に `TOURING_PLAN: 2` を追加、`FREE_USER_LIMITS` を新規定義 |
| `interfaces/ITouringPlanRepository.ts` | 修正 | `countPlans()` メソッドを追加 |
| `repositories/PrismaTouringPlanRepository.ts` | 修正 | `countPlans()` を実装 |
| `services/TouringPlanService.ts` | 修正 | `role` パラメータを追加し、GUEST/USER別の件数チェックを実装 |
| `v1/userBike/touringPlans.ts` | 修正 | POST ハンドラーで `role` を取得して `registerPlan` に渡すよう変更 |

### 料金ページの機能・制限一覧テーブル
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `pricing/page.tsx` | 修正 | `GUEST_ACCOUNT_LIMITS`・`FREE_USER_LIMITS` を参照した制限一覧テーブルを追加 |
| `pricing/page.module.css` | 修正 | テーブル用スタイル（ライト/ダークモード・レスポンシブ対応）を追加 |

## 影響範囲
- `POST /api/v1/bike/:myUserBikeId/touring-plans` — ロール別件数上限に達した場合に `400` を返すようになる
- 料金ページ `/pricing` — 機能・制限一覧テーブルが表示される

## テストプラン
- [ ] ゲストアカウントでツーリングプランを3件登録しようとすると、3件目でエラーになること
- [ ] 無料ユーザー（USERロール）でツーリングプランを11件登録しようとすると、11件目でエラーになること
- [ ] 制限件数未満では正常に `201 Created` が返ること
- [ ] 料金ページに制限一覧テーブルが正しく表示されること（ライト/ダークモード・モバイル）

Closes #417