### PR TITLE
💄 位置情報の精度が低い場合に警告メッセージを表示する

### DIFF
--- a/apps/web/components/touring/TouringModeView.module.css
+++ b/apps/web/components/touring/TouringModeView.module.css
@@ -386,6 +386,13 @@ html[data-theme-mode='dark'] .container {
   padding: var(--spacing-4);
 }
 
+.spotMapAccuracyHint {
+  font-size: var(--font-size-xs);
+  color: var(--color-inkLight);
+  margin-top: calc(var(--spacing-1) * -1);
+  margin-bottom: var(--spacing-3);
+}
+
 .spotModalActions {
   display: flex;
   gap: var(--spacing-3);

--- a/apps/web/components/touring/TouringModeView.tsx
+++ b/apps/web/components/touring/TouringModeView.tsx
@@ -56,6 +56,7 @@ export const TouringModeView = ({
   const [geoPosition, setGeoPosition] = useState<{
     lat: number
     lng: number
+    accuracy: number
   } | null>(null)
   const [geoStatus, setGeoStatus] = useState<
     'loading' | 'success' | 'denied' | 'error'
@@ -150,7 +151,11 @@ export const TouringModeView = ({
 
     const { position, denied } = await getCurrentPosition()
     if (position) {
-      setGeoPosition({ lat: position.latitude, lng: position.longitude })
+      setGeoPosition({
+        lat: position.latitude,
+        lng: position.longitude,
+        accuracy: position.accuracy,
+      })
       setGeoStatus('success')
     } else if (denied) {
       setGeoStatus('denied')
@@ -546,6 +551,14 @@ export const TouringModeView = ({
                 />
               )}
             </div>
+            {geoStatus === 'success' &&
+              geoPosition &&
+              geoPosition.accuracy > 100 && (
+                <p className={styles.spotMapAccuracyHint}>
+                  位置精度が低い可能性があります（誤差 約
+                  {Math.round(geoPosition.accuracy)}m）
+                </p>
+              )}
 
             <div className={styles.spotModalActions}>
               <Button

--- a/apps/web/lib/hooks/useGeolocation.ts
+++ b/apps/web/lib/hooks/useGeolocation.ts
@@ -3,6 +3,7 @@
 type GeoPosition = {
   latitude: number
   longitude: number
+  accuracy: number
 }
 
 type GeoResult = {
@@ -32,6 +33,7 @@ export const useGeolocation = () => {
             position: {
               latitude: pos.coords.latitude,
               longitude: pos.coords.longitude,
+              accuracy: pos.coords.accuracy,
             },
             denied: false,
           })


### PR DESCRIPTION
## 概要

スポット記録モーダルで位置情報を取得した際、精度が低い（誤差100m超）場合にマップ下部へ薄いグレーのテキストで警告メッセージを表示する機能を追加しました。`useGeolocation` フックに `accuracy` フィールドを追加し、UI側でその値を利用して精度状態をユーザーへ通知します。

## 変更内容

### 位置情報の精度通知

| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `lib/hooks/useGeolocation.ts` | 修正 | `GeoPosition` 型に `accuracy: number` を追加し、`pos.coords.accuracy` を返却するよう変更 |
| `components/touring/TouringModeView.tsx` | 修正 | `geoPosition` state に `accuracy` を追加。精度が100m超の場合にマップ下部へ警告テキストを表示 |
| `components/touring/TouringModeView.module.css` | 修正 | `.spotMapAccuracyHint` スタイルを追加（`--color-inkLight` の薄いグレー、`xs` サイズ） |

## 影響範囲

- スポット記録モーダルの表示（`TouringModeView`）
- `useGeolocation` フックの返却型（`accuracy` フィールド追加、後方互換あり）

## テストプラン

- [ ] ツーリングを開始し「スポットを記録」ボタンをタップする
- [ ] GPS精度が良好（屋外）な場合、警告メッセージが表示されないことを確認
- [ ] GPS精度が低い（室内・起動直後）場合、「位置精度が低い可能性があります（誤差 約XXXm）」がマップ下部に薄いグレーで表示されることを確認

Closes #394