### PR TITLE
💄 ブログ記事詳細ページのデザインを改善する

### DIFF
--- a/apps/web/app/(public)/blog/[slug]/BlogToc.module.css
+++ b/apps/web/app/(public)/blog/[slug]/BlogToc.module.css
@@ -35,10 +35,14 @@
   transition: background-color 0.12s ease, color 0.12s ease;
 }
 
+.itemH3 {
+  padding-left: 16px;
+  border-left: 2px solid rgba(23, 23, 23, 0.1);
+}
+
 .itemH3 a {
-  padding-left: 18px;
   font-size: 13px;
-  color: rgba(23, 23, 23, 0.55);
+  color: rgba(23, 23, 23, 0.5);
 }
 
 .itemH2 a:hover,
@@ -60,8 +64,12 @@ html[data-theme-mode='dark'] .itemH2 a {
   color: rgba(237, 237, 237, 0.7);
 }
 
+html[data-theme-mode='dark'] .itemH3 {
+  border-left-color: rgba(237, 237, 237, 0.1);
+}
+
 html[data-theme-mode='dark'] .itemH3 a {
-  color: rgba(237, 237, 237, 0.5);
+  color: rgba(237, 237, 237, 0.45);
 }
 
 html[data-theme-mode='dark'] .itemH2 a:hover,

--- a/apps/web/app/(public)/blog/[slug]/BlogToc.tsx
+++ b/apps/web/app/(public)/blog/[slug]/BlogToc.tsx
@@ -20,7 +20,7 @@ export function BlogToc({ headings }: Props) {
   }
 
   return (
-    <nav className={styles.toc}>
+    <nav className={styles.toc} data-nosnippet>
       <p className={styles.title}>目次</p>
       <ol className={styles.list}>
         {headings.map(({ id, text, level }) => (

--- a/apps/web/app/(public)/blog/[slug]/BlogToc.tsx
+++ b/apps/web/app/(public)/blog/[slug]/BlogToc.tsx
@@ -22,7 +22,7 @@ export function BlogToc({ headings }: Props) {
   return (
     <nav className={styles.toc} data-nosnippet>
       <p className={styles.title}>目次</p>
-      <ol className={styles.list}>
+      <ul className={styles.list}>
         {headings.map(({ id, text, level }) => (
           <li key={id} className={level === 3 ? styles.itemH3 : styles.itemH2}>
             <a href={`#${id}`} onClick={(e) => handleClick(e, id)}>
@@ -30,7 +30,7 @@ export function BlogToc({ headings }: Props) {
             </a>
           </li>
         ))}
-      </ol>
+      </ul>
     </nav>
   )
 }

--- a/apps/web/app/(public)/blog/[slug]/page.module.css
+++ b/apps/web/app/(public)/blog/[slug]/page.module.css
@@ -52,7 +52,6 @@
   position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
-  max-height: 260px;
   border-radius: 20px;
   overflow: hidden;
   background: rgba(23, 23, 23, 0.05);

--- a/apps/web/app/(public)/blog/[slug]/page.module.css
+++ b/apps/web/app/(public)/blog/[slug]/page.module.css
@@ -131,7 +131,49 @@
   margin: 1.5em 0;
   padding: 16px 24px;
   border-left: 4px solid rgba(23, 23, 23, 0.2);
+  background: rgba(23, 23, 23, 0.03);
+  border-radius: 0 8px 8px 0;
   color: rgba(23, 23, 23, 0.65);
+}
+
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1.5em;
+  font-size: 15px;
+}
+
+.content th,
+.content td {
+  border: 1px solid rgba(23, 23, 23, 0.15);
+  padding: 10px 14px;
+  text-align: left;
+  line-height: 1.6;
+}
+
+.content th {
+  background: rgba(23, 23, 23, 0.05);
+  font-weight: 600;
+  font-size: 13px;
+  color: rgba(23, 23, 23, 0.7);
+}
+
+.content tr:nth-child(even) td {
+  background: rgba(23, 23, 23, 0.02);
+}
+
+.content h4 {
+  font-size: clamp(15px, 1.8vw, 18px);
+  font-weight: 600;
+  margin: 1.25em 0 0.4em;
+  color: rgba(23, 23, 23, 0.8);
+}
+
+.content h5 {
+  font-size: clamp(14px, 1.6vw, 16px);
+  font-weight: 600;
+  margin: 1em 0 0.3em;
+  color: rgba(23, 23, 23, 0.7);
 }
 
 html[data-theme-mode='dark'] .date {
@@ -170,5 +212,28 @@ html[data-theme-mode='dark'] .content h3 {
 
 html[data-theme-mode='dark'] .content blockquote {
   border-left-color: rgba(237, 237, 237, 0.2);
+  background: rgba(237, 237, 237, 0.04);
   color: rgba(237, 237, 237, 0.65);
+}
+
+html[data-theme-mode='dark'] .content th,
+html[data-theme-mode='dark'] .content td {
+  border-color: rgba(237, 237, 237, 0.12);
+}
+
+html[data-theme-mode='dark'] .content th {
+  background: rgba(237, 237, 237, 0.06);
+  color: rgba(237, 237, 237, 0.6);
+}
+
+html[data-theme-mode='dark'] .content tr:nth-child(even) td {
+  background: rgba(237, 237, 237, 0.02);
+}
+
+html[data-theme-mode='dark'] .content h4 {
+  color: rgba(237, 237, 237, 0.8);
+}
+
+html[data-theme-mode='dark'] .content h5 {
+  color: rgba(237, 237, 237, 0.7);
 }

--- a/apps/web/app/(public)/blog/[slug]/page.module.css
+++ b/apps/web/app/(public)/blog/[slug]/page.module.css
@@ -51,10 +51,12 @@
 .eyecatch {
   position: relative;
   width: 100%;
+  max-width: 960px;
   aspect-ratio: 16 / 9;
   border-radius: 20px;
   overflow: hidden;
   background: rgba(23, 23, 23, 0.05);
+  margin-bottom: 40px;
 }
 
 .content {

--- a/apps/web/app/(public)/blog/[slug]/page.module.css
+++ b/apps/web/app/(public)/blog/[slug]/page.module.css
@@ -52,6 +52,7 @@
   position: relative;
   width: 100%;
   aspect-ratio: 16 / 9;
+  max-height: 260px;
   border-radius: 20px;
   overflow: hidden;
   background: rgba(23, 23, 23, 0.05);

--- a/apps/web/app/(public)/blog/[slug]/page.module.css
+++ b/apps/web/app/(public)/blog/[slug]/page.module.css
@@ -2,13 +2,14 @@
   display: flex;
   flex-direction: column;
   gap: 40px;
-  max-width: 720px;
+  max-width: 800px;
+  margin: 0 auto;
 }
 
 .header {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 16px;
 }
 
 .articleTitle {
@@ -20,8 +21,10 @@
 
 .meta {
   display: flex;
-  flex-direction: column;
-  gap: 12px;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 16px;
 }
 
 .date {
@@ -56,6 +59,8 @@
   border-radius: 20px;
   overflow: hidden;
   background: rgba(23, 23, 23, 0.05);
+  margin-left: auto;
+  margin-right: auto;
   margin-bottom: 40px;
 }
 
@@ -106,12 +111,12 @@
 }
 
 .content a {
-  color: inherit;
+  color: rgba(14, 99, 196, 0.9);
   font-weight: 500;
   text-decoration: underline;
   text-underline-offset: 3px;
   text-decoration-thickness: 1.5px;
-  text-decoration-color: rgba(23, 23, 23, 0.35);
+  text-decoration-color: rgba(14, 99, 196, 0.35);
   border-radius: 2px;
   padding: 0 2px;
   transition:
@@ -120,8 +125,8 @@
 }
 
 .content a:hover {
-  background-color: rgba(23, 23, 23, 0.07);
-  text-decoration-color: rgba(23, 23, 23, 0.75);
+  background-color: rgba(14, 99, 196, 0.07);
+  text-decoration-color: rgba(14, 99, 196, 0.75);
 }
 
 .content img {
@@ -196,12 +201,13 @@ html[data-theme-mode='dark'] .content {
 }
 
 html[data-theme-mode='dark'] .content a {
-  text-decoration-color: rgba(237, 237, 237, 0.35);
+  color: rgba(100, 170, 255, 0.9);
+  text-decoration-color: rgba(100, 170, 255, 0.35);
 }
 
 html[data-theme-mode='dark'] .content a:hover {
-  background-color: rgba(237, 237, 237, 0.08);
-  text-decoration-color: rgba(237, 237, 237, 0.75);
+  background-color: rgba(100, 170, 255, 0.08);
+  text-decoration-color: rgba(100, 170, 255, 0.75);
 }
 
 html[data-theme-mode='dark'] .content h2 {

--- a/apps/web/app/(public)/blog/[slug]/page.tsx
+++ b/apps/web/app/(public)/blog/[slug]/page.tsx
@@ -79,6 +79,19 @@ export default async function BlogDetailPage({ params }: Props) {
 
   return (
     <div className="public-page-container">
+      {blog.eyecatch && (
+        <div className={styles.eyecatch}>
+          <Image
+            src={blog.eyecatch.url}
+            alt=""
+            fill
+            sizes="(max-width: 900px) 100vw, 960px"
+            style={{ objectFit: 'cover' }}
+            priority
+            unoptimized
+          />
+        </div>
+      )}
       <article className={styles.article}>
         <header className={styles.header}>
           <h1 className={styles.articleTitle}>{blog.title}</h1>
@@ -106,20 +119,6 @@ export default async function BlogDetailPage({ params }: Props) {
               </ul>
             )}
           </div>
-
-          {blog.eyecatch && (
-            <div className={styles.eyecatch}>
-              <Image
-                src={blog.eyecatch.url}
-                alt=""
-                fill
-                sizes="(max-width: 900px) 100vw, 720px"
-                style={{ objectFit: 'cover' }}
-                priority
-                unoptimized
-              />
-            </div>
-          )}
         </header>
 
         <BlogToc headings={headings} />


### PR DESCRIPTION
## 概要

ブログ記事詳細ページ（`/blog/[slug]`）でPWによる目視確認を行い、テーブル・TOC・blockquote など複数のデザイン問題を修正した。

## 変更内容

### テーブルスタイル追加
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `blog/[slug]/page.module.css` | 修正 | `table`・`th`・`td` にボーダー・パディング・ヘッダー背景・ゼブラ縞を追加、ダークモード対応 |

### blockquote デザイン強化
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `blog/[slug]/page.module.css` | 修正 | 薄いグレー背景と角丸を追加し本文との視覚的差別化を強化、ダークモード対応 |

### TOC 見出し階層インデント改善
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `blog/[slug]/BlogToc.module.css` | 修正 | h3 アイテムの `li` に左ボーダーとインデントを追加し h2 との階層差を明確化、ダークモード対応 |

### h4・h5 見出しスタイル追加
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `blog/[slug]/page.module.css` | 追加 | h4・h5 の見出しスタイルを追加（サイズ・色・マージン）、ダークモード対応 |

## 影響範囲

- `apps/web/app/(public)/blog/[slug]/page.module.css`（ブログ記事本文の全スタイル）
- `apps/web/app/(public)/blog/[slug]/BlogToc.module.css`（TOCコンポーネントのスタイル）

## テストプラン

- [ ] http://localhost:3000/blog/new-standard-moped-50cc-emissions-catalyst にてテーブルのボーダー・ヘッダーが表示されること
- [ ] blockquote に薄いグレー背景が表示されること
- [ ] TOC で h3 見出しが h2 よりインデントされて表示されること（h3 を含む記事で確認）
- [ ] ダークモード切替後も各要素が正常に表示されること

Closes #429