### PR TITLE
♻️ ロール別制限値をAccountLimitsValueバリューオブジェクトに集約し、ゲストのメンテナンス履歴制限を実装

### DIFF
--- a/apps/web/__tests__/api/v1/userBike.test.ts
+++ b/apps/web/__tests__/api/v1/userBike.test.ts
@@ -284,7 +284,7 @@ describe('UserBike API Endpoints', () => {
       expect(json3).toEqual({
         status: 'error',
         errorCode: 'INVALID_REQUEST',
-        message: '無料プランでは2台まで登録可能です',
+        message: '無料ユーザーはバイクを2台まで登録できます',
       })
     })
   })

--- a/apps/web/__tests__/unit/services/TouringPlanService.test.ts
+++ b/apps/web/__tests__/unit/services/TouringPlanService.test.ts
@@ -17,6 +17,7 @@ import { ITouringPlanRepository } from '@/lib/api/server/interfaces/ITouringPlan
 import { ITouringPlanSpotRepository } from '@/lib/api/server/interfaces/ITouringPlanSpotRepository'
 import { ITouringRepository } from '@/lib/api/server/interfaces/ITouringRepository'
 import { TouringPlanService } from '@/lib/api/server/services/TouringPlanService'
+import { AccountLimitsValue } from '@/lib/api/server/valueObjects/AccountLimitsValue'
 
 const myUserBikeId = createMyUserBikeId('bike-1')
 const userId = createUserId('user-1')
@@ -76,6 +77,7 @@ describe('TouringPlanService', () => {
       findPlans: vi.fn(),
       findPlanById: vi.fn(),
       deletePlan: vi.fn(),
+      countPlans: vi.fn().mockResolvedValue(0),
     }
     touringPlanSpotRepository = {
       createPlanSpot: vi.fn(),
@@ -129,6 +131,7 @@ describe('TouringPlanService', () => {
         service.registerPlan({
           myUserBikeId,
           userId,
+          limits: AccountLimitsValue.from('USER'),
           title: 'プラン',
         })
       ).rejects.toThrow(ApiV1Error)
@@ -141,6 +144,7 @@ describe('TouringPlanService', () => {
       const result = await service.registerPlan({
         myUserBikeId,
         userId,
+        limits: AccountLimitsValue.from('USER'),
         title: '日帰り箱根ツーリング',
       })
 
@@ -176,6 +180,7 @@ describe('TouringPlanService', () => {
       const result = await service.registerPlan({
         myUserBikeId,
         userId,
+        limits: AccountLimitsValue.from('USER'),
         title: '日帰り箱根ツーリング',
         startLocation: { latitude: 35.6812, longitude: 139.7671 },
         destinationLocation: {

--- a/apps/web/__tests__/unit/services/TouringService.test.ts
+++ b/apps/web/__tests__/unit/services/TouringService.test.ts
@@ -20,6 +20,7 @@ import { ITouringPlanRepository } from '@/lib/api/server/interfaces/ITouringPlan
 import { ITouringPlanSpotRepository } from '@/lib/api/server/interfaces/ITouringPlanSpotRepository'
 import { ITouringRepository } from '@/lib/api/server/interfaces/ITouringRepository'
 import { TouringService } from '@/lib/api/server/services/TouringService'
+import { AccountLimitsValue } from '@/lib/api/server/valueObjects/AccountLimitsValue'
 
 const myUserBikeId = createMyUserBikeId('bike-1')
 const userId = createUserId('user-1')
@@ -160,7 +161,7 @@ describe('TouringService', () => {
       const result = await service.registerTouring({
         myUserBikeId,
         userId,
-        role: 'USER',
+        limits: AccountLimitsValue.from('USER'),
         title: 'ツーリング',
         startDate: new Date('2026-07-01T08:00:00.000Z'),
         endDate: new Date('2026-07-01T18:00:00.000Z'),
@@ -179,7 +180,7 @@ describe('TouringService', () => {
         service.registerTouring({
           myUserBikeId,
           userId,
-          role: 'USER',
+          limits: AccountLimitsValue.from('USER'),
           title: 'ツーリング',
           startDate: new Date('2026-07-01T08:00:00.000Z'),
           endDate: new Date('2026-07-01T18:00:00.000Z'),
@@ -195,7 +196,7 @@ describe('TouringService', () => {
         service.registerTouring({
           myUserBikeId,
           userId,
-          role: 'GUEST',
+          limits: AccountLimitsValue.from('GUEST'),
           title: 'ツーリング',
           startDate: new Date('2026-07-01T08:00:00.000Z'),
           endDate: new Date('2026-07-01T18:00:00.000Z'),
@@ -215,7 +216,7 @@ describe('TouringService', () => {
           action: 'start',
           myUserBikeId,
           userId,
-          role: 'USER',
+          limits: AccountLimitsValue.from('USER'),
         })
       ).rejects.toThrow(ApiV1Error)
     })
@@ -225,7 +226,7 @@ describe('TouringService', () => {
         action: 'start',
         myUserBikeId,
         userId,
-        role: 'USER',
+        limits: AccountLimitsValue.from('USER'),
       })
 
       expect(result.title).toBe('ツーリング')
@@ -242,7 +243,7 @@ describe('TouringService', () => {
         action: 'start',
         myUserBikeId,
         userId,
-        role: 'USER',
+        limits: AccountLimitsValue.from('USER'),
       })
 
       expect(result.startMileage).toBe(12345)
@@ -265,7 +266,7 @@ describe('TouringService', () => {
         action: 'start',
         myUserBikeId,
         userId,
-        role: 'USER',
+        limits: AccountLimitsValue.from('USER'),
         touringPlanId: 'plan-1',
       })
 
@@ -290,7 +291,7 @@ describe('TouringService', () => {
         action: 'start',
         myUserBikeId,
         userId,
-        role: 'USER',
+        limits: AccountLimitsValue.from('USER'),
         touringPlanId: 'plan-1',
         title: '個別タイトル',
       })
@@ -329,7 +330,7 @@ describe('TouringService', () => {
         action: 'start',
         myUserBikeId,
         userId,
-        role: 'USER',
+        limits: AccountLimitsValue.from('USER'),
         touringPlanId: 'plan-1',
       })
 
@@ -382,7 +383,7 @@ describe('TouringService', () => {
         action: 'start',
         myUserBikeId,
         userId,
-        role: 'USER',
+        limits: AccountLimitsValue.from('USER'),
         touringPlanId: 'plan-1',
         startDate,
       })
@@ -425,7 +426,7 @@ describe('TouringService', () => {
           action: 'start',
           myUserBikeId,
           userId,
-          role: 'USER',
+          limits: AccountLimitsValue.from('USER'),
           touringPlanId: 'plan-unknown',
         })
       ).rejects.toThrow(ApiV1Error)

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -75,7 +75,7 @@ export default function PricingPage() {
               <tr>
                 <td>バイク登録</td>
                 <td>{GUEST_ACCOUNT_LIMITS.BIKE}台まで</td>
-                <td>2台まで</td>
+                <td>{FREE_USER_LIMITS.BIKE}台まで</td>
                 <td className={styles.comingSoon}>無制限（予定）</td>
               </tr>
               <tr>

--- a/apps/web/app/(public)/pricing/page.tsx
+++ b/apps/web/app/(public)/pricing/page.tsx
@@ -98,7 +98,7 @@ export default function PricingPage() {
               </tr>
               <tr>
                 <td>メンテナンス記録</td>
-                <td>2件まで / 台</td>
+                <td>{GUEST_ACCOUNT_LIMITS.MAINTENANCE_LOG}件まで / 台</td>
                 <td>無制限</td>
                 <td className={styles.comingSoon}>無制限（予定）</td>
               </tr>

--- a/apps/web/lib/api/server/entities/UserEntity.ts
+++ b/apps/web/lib/api/server/entities/UserEntity.ts
@@ -1,4 +1,5 @@
 import { User, UserId } from '@repo/shared-types'
+import { AccountLimitsValue } from '../valueObjects/AccountLimitsValue'
 
 export class UserEntity {
   private _value: User
@@ -17,6 +18,10 @@ export class UserEntity {
 
   public get role(): string {
     return this._value.role
+  }
+
+  public get limits(): AccountLimitsValue {
+    return AccountLimitsValue.from(this._value.role)
   }
 
   public get status(): string {

--- a/apps/web/lib/api/server/interfaces/IMaintenanceLogRepository.ts
+++ b/apps/web/lib/api/server/interfaces/IMaintenanceLogRepository.ts
@@ -22,4 +22,5 @@ export interface IMaintenanceLogRepository {
   updateMaintenanceLog(
     maintenanceLog: MaintenanceLogEntity
   ): Promise<MaintenanceLogEntity>
+  countMaintenanceLogs(myUserBikeId: MyUserBikeId): Promise<number>
 }

--- a/apps/web/lib/api/server/repositories/PrismaMaintenanceLogRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaMaintenanceLogRepository.ts
@@ -135,6 +135,12 @@ export class PrismaMaintenanceLogRepository
     return logs.map(mapToEntity)
   }
 
+  async countMaintenanceLogs(myUserBikeId: MyUserBikeId): Promise<number> {
+    return this.connection.tUserMyBikeMaintenance.count({
+      where: { userMyBikeId: myUserBikeId },
+    })
+  }
+
   async updateMaintenanceLog(
     maintenanceLog: MaintenanceLogEntity
   ): Promise<MaintenanceLogEntity> {

--- a/apps/web/lib/api/server/services/FuelLogService.ts
+++ b/apps/web/lib/api/server/services/FuelLogService.ts
@@ -5,19 +5,19 @@ import {
   TouringId,
   UserId,
 } from '@repo/shared-types'
-import { GUEST_ACCOUNT_LIMITS } from '../../../statics'
 import { FuelLogEntity } from '../entities/FuelLogEntity'
 import { ApiV1Error } from '../errors/ApiV1Error'
 import { IFuelLogRepository } from '../interfaces/IFuelLogRepository'
 import { IMyUserBikeRepository } from '../interfaces/IMyUserBikeRepository'
 import { ITouringRepository } from '../interfaces/ITouringRepository'
 import { IUserBikeRepository } from '../interfaces/IUserBikeRepository'
+import { AccountLimitsValue } from '../valueObjects/AccountLimitsValue'
 import { FuelLogSearchParams } from '../valueObjects/FuelLogSearchParams'
 
 type RegisterFuelLogParams = {
   myUserBikeId: MyUserBikeId
   userId: UserId
-  role: 'USER' | 'ADMIN' | 'GUEST'
+  limits: AccountLimitsValue
   refueledAt: Date
   mileage: number
   previousMileage: number
@@ -66,15 +66,14 @@ export class FuelLogService {
       throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
     }
 
-    // ゲストアカウントの給油履歴登録数チェック
-    if (params.role === 'GUEST') {
+    if (params.limits.fuelLog !== null) {
       const count = await this.fuelLogRepository.countFuelLogs(
         params.myUserBikeId
       )
-      if (count >= GUEST_ACCOUNT_LIMITS.FUEL_LOG) {
+      if (params.limits.isOver('fuelLog', count)) {
         throw new ApiV1Error(
           'INVALID_REQUEST',
-          'ゲストアカウントは給油履歴を5件まで登録できます'
+          params.limits.limitMessage('fuelLog')
         )
       }
     }

--- a/apps/web/lib/api/server/services/MaintenanceLogService.ts
+++ b/apps/web/lib/api/server/services/MaintenanceLogService.ts
@@ -80,10 +80,9 @@ export class MaintenanceLogService {
     }
 
     if (params.limits.maintenanceLog !== null) {
-      const count =
-        await this.maintenanceLogRepository.countMaintenanceLogs(
-          params.myUserBikeId
-        )
+      const count = await this.maintenanceLogRepository.countMaintenanceLogs(
+        params.myUserBikeId
+      )
       if (params.limits.isOver('maintenanceLog', count)) {
         throw new ApiV1Error(
           'INVALID_REQUEST',

--- a/apps/web/lib/api/server/services/MaintenanceLogService.ts
+++ b/apps/web/lib/api/server/services/MaintenanceLogService.ts
@@ -9,6 +9,7 @@ import { MaintenanceLogEntity } from '../entities/MaintenanceLogEntity'
 import { ApiV1Error } from '../errors/ApiV1Error'
 import { IMaintenanceLogRepository } from '../interfaces/IMaintenanceLogRepository'
 import { IMyUserBikeRepository } from '../interfaces/IMyUserBikeRepository'
+import { AccountLimitsValue } from '../valueObjects/AccountLimitsValue'
 
 type GetMaintenanceLogsParams = {
   myUserBikeId: MyUserBikeId
@@ -21,6 +22,7 @@ type GetMaintenanceLogsParams = {
 type RegisterMaintenanceLogParams = {
   myUserBikeId: MyUserBikeId
   userId: UserId
+  limits: AccountLimitsValue
   performedAt: Date
   mileage: number
   memo?: string | null
@@ -75,6 +77,19 @@ export class MaintenanceLogService {
 
     if (!myUserBike) {
       throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
+    }
+
+    if (params.limits.maintenanceLog !== null) {
+      const count =
+        await this.maintenanceLogRepository.countMaintenanceLogs(
+          params.myUserBikeId
+        )
+      if (params.limits.isOver('maintenanceLog', count)) {
+        throw new ApiV1Error(
+          'INVALID_REQUEST',
+          params.limits.limitMessage('maintenanceLog')
+        )
+      }
     }
 
     const maintenanceLog = new MaintenanceLogEntity({

--- a/apps/web/lib/api/server/services/TouringPlanService.ts
+++ b/apps/web/lib/api/server/services/TouringPlanService.ts
@@ -7,7 +7,6 @@ import {
   TouringPlanRouteType,
   UserId,
 } from '@repo/shared-types'
-import { FREE_USER_LIMITS, GUEST_ACCOUNT_LIMITS } from '../../../statics'
 import { TouringEntity } from '../entities/TouringEntity'
 import { TouringPlanEntity } from '../entities/TouringPlanEntity'
 import { TouringPlanSpotEntity } from '../entities/TouringPlanSpotEntity'
@@ -16,6 +15,7 @@ import { IMyUserBikeRepository } from '../interfaces/IMyUserBikeRepository'
 import { ITouringPlanRepository } from '../interfaces/ITouringPlanRepository'
 import { ITouringPlanSpotRepository } from '../interfaces/ITouringPlanSpotRepository'
 import { ITouringRepository } from '../interfaces/ITouringRepository'
+import { AccountLimitsValue } from '../valueObjects/AccountLimitsValue'
 import {
   computeTouringPlanSpotTimes,
   TouringPlanSpotWithTimes,
@@ -31,7 +31,7 @@ type LocationParams = {
 type RegisterPlanParams = {
   myUserBikeId: MyUserBikeId
   userId: UserId
-  role: 'USER' | 'ADMIN' | 'GUEST'
+  limits: AccountLimitsValue
   title: string
   startLocation?: LocationParams | null
   destinationLocation?:
@@ -89,26 +89,14 @@ export class TouringPlanService {
       throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
     }
 
-    if (params.role === 'GUEST') {
+    if (params.limits.touringPlan !== null) {
       const count = await this.touringPlanRepository.countPlans(
         params.myUserBikeId
       )
-      if (count >= GUEST_ACCOUNT_LIMITS.TOURING_PLAN) {
+      if (params.limits.isOver('touringPlan', count)) {
         throw new ApiV1Error(
           'INVALID_REQUEST',
-          'ゲストアカウントはツーリングプランを2件まで登録できます'
-        )
-      }
-    }
-
-    if (params.role === 'USER') {
-      const count = await this.touringPlanRepository.countPlans(
-        params.myUserBikeId
-      )
-      if (count >= FREE_USER_LIMITS.TOURING_PLAN) {
-        throw new ApiV1Error(
-          'INVALID_REQUEST',
-          '無料ユーザーはツーリングプランを10件まで登録できます'
+          params.limits.limitMessage('touringPlan')
         )
       }
     }

--- a/apps/web/lib/api/server/services/TouringService.ts
+++ b/apps/web/lib/api/server/services/TouringService.ts
@@ -8,7 +8,6 @@ import {
   TouringStatus,
   UserId,
 } from '@repo/shared-types'
-import { GUEST_ACCOUNT_LIMITS } from '../../../statics'
 import { getCurrentDate } from '../../../utils/dateUtils'
 import { SpotEntity } from '../entities/SpotEntity'
 import { TouringEntity } from '../entities/TouringEntity'
@@ -19,6 +18,7 @@ import { ISpotRepository } from '../interfaces/ISpotRepository'
 import { ITouringPlanRepository } from '../interfaces/ITouringPlanRepository'
 import { ITouringPlanSpotRepository } from '../interfaces/ITouringPlanSpotRepository'
 import { ITouringRepository } from '../interfaces/ITouringRepository'
+import { AccountLimitsValue } from '../valueObjects/AccountLimitsValue'
 import { FuelLogSearchParams } from '../valueObjects/FuelLogSearchParams'
 import { TouringSearchParams } from '../valueObjects/TouringSearchParams'
 import { computeTouringPlanSpotTimes } from './computeTouringPlanSpotTimes'
@@ -26,7 +26,7 @@ import { computeTouringPlanSpotTimes } from './computeTouringPlanSpotTimes'
 type RegisterTouringParams = {
   myUserBikeId: MyUserBikeId
   userId: UserId
-  role: 'USER' | 'ADMIN' | 'GUEST'
+  limits: AccountLimitsValue
   title: string
   startDate: Date
   endDate: Date
@@ -39,7 +39,7 @@ type StartTouringParams = {
   action: 'start'
   myUserBikeId: MyUserBikeId
   userId: UserId
-  role: 'USER' | 'ADMIN' | 'GUEST'
+  limits: AccountLimitsValue
   touringPlanId?: string
   title?: string
   startDate?: Date
@@ -100,15 +100,14 @@ export class TouringService {
       throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
     }
 
-    // ゲストアカウントのツーリング登録数チェック
-    if (params.role === 'GUEST') {
+    if (params.limits.touring !== null) {
       const count = await this.touringRepository.countTourings(
         params.myUserBikeId
       )
-      if (count >= GUEST_ACCOUNT_LIMITS.TOURING) {
+      if (params.limits.isOver('touring', count)) {
         throw new ApiV1Error(
           'INVALID_REQUEST',
-          'ゲストアカウントはツーリング履歴を2件まで登録できます'
+          params.limits.limitMessage('touring')
         )
       }
     }
@@ -168,15 +167,14 @@ export class TouringService {
 
     try {
       if (params.action === 'start') {
-        // ゲストアカウントのツーリング登録数チェック
-        if (params.role === 'GUEST') {
+        if (params.limits.touring !== null) {
           const count = await this.touringRepository.countTourings(
             params.myUserBikeId
           )
-          if (count >= GUEST_ACCOUNT_LIMITS.TOURING) {
+          if (params.limits.isOver('touring', count)) {
             throw new ApiV1Error(
               'INVALID_REQUEST',
-              'ゲストアカウントはツーリング履歴を2件まで登録できます'
+              params.limits.limitMessage('touring')
             )
           }
         }

--- a/apps/web/lib/api/server/services/UserBikeService.ts
+++ b/apps/web/lib/api/server/services/UserBikeService.ts
@@ -4,7 +4,6 @@ import {
   createUserBikeId,
   UserId,
 } from '@repo/shared-types'
-import { GUEST_ACCOUNT_LIMITS } from '../../../statics'
 import { getCurrentDate } from '../../../utils/dateUtils'
 import { BikeEntity } from '../entities/BikeEntity'
 import { MyUserBikeEntity } from '../entities/MyUserBikeEntity'
@@ -13,16 +12,14 @@ import { ApiV1Error } from '../errors/ApiV1Error'
 import { IBikeRepository } from '../interfaces/IBikeRepository'
 import { IMyUserBikeRepository } from '../interfaces/IMyUserBikeRepository'
 import { IUserBikeRepository } from '../interfaces/IUserBikeRepository'
-
-// 無料プランのバイク登録上限
-const FREE_PLAN_BIKE_LIMIT = 2
+import { AccountLimitsValue } from '../valueObjects/AccountLimitsValue'
 
 type RegisterUserBikeParams = {
   bikeId?: BikeId | null
   displacement?: number
   serialNumber?: string | null
   userId: UserId
-  role: 'USER' | 'ADMIN' | 'GUEST'
+  limits: AccountLimitsValue
   nickname?: string
   purchaseDate?: Date
   purchasePrice?: number
@@ -33,7 +30,6 @@ type RegisterUserBikeParams = {
 type UpdateMyUserBikeParams = {
   myUserBikeId: ReturnType<typeof createMyUserBikeId>
   userId: UserId
-  role: 'USER' | 'ADMIN' | 'GUEST'
   nickname?: string | null
   purchaseDate?: Date | null
   purchasePrice?: number | null
@@ -49,31 +45,18 @@ export class UserBikeService {
     private bikeRepository: IBikeRepository
   ) {}
 
-  /**
-   * バイク登録数の制限をチェック
-   * ゲストは1台、無料プランは2台まで登録可能
-   */
-  private async validateBikeRegistrationLimit(
-    userId: UserId,
-    role: 'USER' | 'ADMIN' | 'GUEST'
-  ): Promise<void> {
-    const currentCount = await this.myUserBikeRepository.countOwnedBikes(userId)
-    const limit =
-      role === 'GUEST' ? GUEST_ACCOUNT_LIMITS.BIKE : FREE_PLAN_BIKE_LIMIT
-
-    if (currentCount >= limit) {
-      throw new ApiV1Error(
-        'INVALID_REQUEST',
-        role === 'GUEST'
-          ? 'ゲストアカウントはバイクを1台まで登録できます'
-          : '無料プランでは2台まで登録可能です'
-      )
-    }
-  }
-
   public async registerUserBike(params: RegisterUserBikeParams) {
-    // バイク登録数制限チェック
-    await this.validateBikeRegistrationLimit(params.userId, params.role)
+    if (params.limits.bike !== null) {
+      const currentCount = await this.myUserBikeRepository.countOwnedBikes(
+        params.userId
+      )
+      if (params.limits.isOver('bike', currentCount)) {
+        throw new ApiV1Error(
+          'INVALID_REQUEST',
+          params.limits.limitMessage('bike')
+        )
+      }
+    }
 
     let bike: BikeEntity | null = null
     if (params.bikeId) {

--- a/apps/web/lib/api/server/v1/userBike.ts
+++ b/apps/web/lib/api/server/v1/userBike.ts
@@ -31,6 +31,7 @@ import { PrismaUserBikeRepository } from '../repositories/PrismaUserBikeReposito
 import { FuelInsightService } from '../services/FuelInsightService'
 import { TouringService } from '../services/TouringService'
 import { UserBikeService } from '../services/UserBikeService'
+import { AccountLimitsValue } from '../valueObjects/AccountLimitsValue'
 import { FuelInsightSearchParams } from '../valueObjects/FuelInsightSearchParams'
 import { FuelLogSearchParams } from '../valueObjects/FuelLogSearchParams'
 import { TouringSearchParams } from '../valueObjects/TouringSearchParams'
@@ -86,7 +87,7 @@ userBike.post(
         displacement: body.displacement,
         serialNumber: body.serialNumber,
         userId,
-        role,
+        limits: AccountLimitsValue.from(role),
         nickname: body.nickname,
         purchaseDate: body.purchaseDate,
         purchasePrice: body.purchasePrice,
@@ -249,7 +250,7 @@ userBike.patch(
   honoAuthMiddleware,
   zodValidateJson(UserBikeUpdateRequestSchema),
   async (c) => {
-    const { userId, role } = c.var.user!
+    const { userId } = c.var.user!
     const body = c.req.valid('json')
 
     const detail = await prisma.$transaction((t) => {
@@ -265,7 +266,6 @@ userBike.patch(
       return service.updateMyUserBike({
         myUserBikeId: createMyUserBikeId(c.req.param('myUserBikeId')),
         userId: createUserId(userId),
-        role,
         nickname: body.nickname,
         purchaseDate: body.purchaseDate,
         purchasePrice: body.purchasePrice,

--- a/apps/web/lib/api/server/v1/userBike/fuelLogs.ts
+++ b/apps/web/lib/api/server/v1/userBike/fuelLogs.ts
@@ -25,6 +25,7 @@ import { PrismaMyUserBikeRepository } from '../../repositories/PrismaMyUserBikeR
 import { PrismaTouringRepository } from '../../repositories/PrismaTouringRepository'
 import { PrismaUserBikeRepository } from '../../repositories/PrismaUserBikeRepository'
 import { FuelLogService } from '../../services/FuelLogService'
+import { AccountLimitsValue } from '../../valueObjects/AccountLimitsValue'
 import { FuelLogSearchParams } from '../../valueObjects/FuelLogSearchParams'
 
 const userBikeFuelLogs = new Hono().basePath('/bike/:myUserBikeId/fuel-logs')
@@ -159,7 +160,7 @@ userBikeFuelLogs.post(
       const fuelLog = await service.registerFuelLog({
         myUserBikeId: createMyUserBikeId(myUserBikeId),
         userId: createUserId(userId),
-        role,
+        limits: AccountLimitsValue.from(role),
         refueledAt: body.refueledAt,
         mileage: body.mileage,
         previousMileage: body.previousMileage,

--- a/apps/web/lib/api/server/v1/userBike/maintenanceLogs.ts
+++ b/apps/web/lib/api/server/v1/userBike/maintenanceLogs.ts
@@ -19,6 +19,7 @@ import {
 import { PrismaMaintenanceLogRepository } from '../../repositories/PrismaMaintenanceLogRepository'
 import { PrismaMyUserBikeRepository } from '../../repositories/PrismaMyUserBikeRepository'
 import { MaintenanceLogService } from '../../services/MaintenanceLogService'
+import { AccountLimitsValue } from '../../valueObjects/AccountLimitsValue'
 
 const userBikeMaintenanceLogs = new Hono().basePath(
   '/bike/:myUserBikeId/maintenance-logs'
@@ -70,7 +71,7 @@ userBikeMaintenanceLogs.post(
   honoAuthMiddleware,
   zodValidateJson(MaintenanceLogRegisterRequestSchema),
   async (c) => {
-    const { userId } = c.var.user!
+    const { userId, role } = c.var.user!
     const myUserBikeId = c.req.param('myUserBikeId')
     const body = c.req.valid('json')
 
@@ -85,6 +86,7 @@ userBikeMaintenanceLogs.post(
       return service.registerMaintenanceLog({
         myUserBikeId: createMyUserBikeId(myUserBikeId),
         userId: createUserId(userId),
+        limits: AccountLimitsValue.from(role),
         performedAt: body.performedAt,
         mileage: body.mileage,
         memo: body.memo,

--- a/apps/web/lib/api/server/v1/userBike/touringPlans.ts
+++ b/apps/web/lib/api/server/v1/userBike/touringPlans.ts
@@ -31,6 +31,7 @@ import {
 } from '../../services/computeTouringPlanSpotTimes'
 import { TouringPlanService } from '../../services/TouringPlanService'
 import { TouringPlanSpotService } from '../../services/TouringPlanSpotService'
+import { AccountLimitsValue } from '../../valueObjects/AccountLimitsValue'
 
 const userBikeTouringPlans = new Hono().basePath(
   '/bike/:myUserBikeId/touring-plans'
@@ -151,7 +152,7 @@ userBikeTouringPlans.post(
       return service.registerPlan({
         myUserBikeId: createMyUserBikeId(myUserBikeId),
         userId: createUserId(userId),
-        role,
+        limits: AccountLimitsValue.from(role),
         title: body.title,
         startLocation: body.startLocation,
         destinationLocation: body.destinationLocation

--- a/apps/web/lib/api/server/v1/userBike/tourings.ts
+++ b/apps/web/lib/api/server/v1/userBike/tourings.ts
@@ -34,6 +34,7 @@ import { PrismaTouringPlanSpotRepository } from '../../repositories/PrismaTourin
 import { PrismaTouringRepository } from '../../repositories/PrismaTouringRepository'
 import { SpotService } from '../../services/SpotService'
 import { TouringService } from '../../services/TouringService'
+import { AccountLimitsValue } from '../../valueObjects/AccountLimitsValue'
 import { TouringSearchParams } from '../../valueObjects/TouringSearchParams'
 
 const userBikeTourings = new Hono().basePath('/bike/:myUserBikeId/tourings')
@@ -113,7 +114,7 @@ userBikeTourings.post(
       const touring = await service.registerTouring({
         myUserBikeId: createMyUserBikeId(myUserBikeId),
         userId: createUserId(userId),
-        role,
+        limits: AccountLimitsValue.from(role),
         title: body.title,
         startDate: body.startDate,
         endDate: body.endDate,
@@ -229,7 +230,7 @@ userBikeTourings.post(
           action: 'start',
           myUserBikeId: createMyUserBikeId(myUserBikeId),
           userId: createUserId(userId),
-          role,
+          limits: AccountLimitsValue.from(role),
           touringPlanId: body.touringPlanId,
           title: body.title,
           startDate: body.startDate,

--- a/apps/web/lib/api/server/valueObjects/AccountLimitsValue.ts
+++ b/apps/web/lib/api/server/valueObjects/AccountLimitsValue.ts
@@ -1,0 +1,71 @@
+import { User } from '@repo/shared-types'
+
+type Role = User['role']
+
+/** 制限件数チェックの対象種別 */
+export type LimitKey =
+  | 'bike'
+  | 'fuelLog'
+  | 'touring'
+  | 'touringPlan'
+  | 'maintenanceLog'
+
+type LimitMessages = Partial<Record<LimitKey, string>>
+
+const LIMIT_MESSAGES: Partial<Record<Role, LimitMessages>> = {
+  GUEST: {
+    bike: 'ゲストアカウントはバイクを1台まで登録できます',
+    fuelLog: 'ゲストアカウントは給油履歴を5件まで登録できます',
+    touring: 'ゲストアカウントはツーリング履歴を2件まで登録できます',
+    touringPlan: 'ゲストアカウントはツーリングプランを2件まで登録できます',
+    maintenanceLog: 'ゲストアカウントはメンテナンス履歴を2件まで登録できます',
+  },
+  USER: {
+    bike: '無料ユーザーはバイクを2台まで登録できます',
+    touringPlan: '無料ユーザーはツーリングプランを10件まで登録できます',
+  },
+}
+
+/**
+ * ユーザーロールに対応する登録件数制限を保持するバリューオブジェクト。
+ * null は制限なし（無制限）を表す。
+ */
+export class AccountLimitsValue {
+  private constructor(
+    private readonly _role: Role,
+    readonly bike: number | null,
+    readonly fuelLog: number | null,
+    readonly touring: number | null,
+    readonly touringPlan: number | null,
+    readonly maintenanceLog: number | null
+  ) {}
+
+  /**
+   * ロールから制限値オブジェクトを生成する
+   */
+  static from(role: Role): AccountLimitsValue {
+    if (role === 'GUEST') {
+      return new AccountLimitsValue(role, 1, 5, 2, 2, 2)
+    }
+    if (role === 'USER') {
+      return new AccountLimitsValue(role, 2, null, null, 10, null)
+    }
+    // ADMIN: 全て無制限
+    return new AccountLimitsValue(role, null, null, null, null, null)
+  }
+
+  /**
+   * 現在の件数が上限を超えているか返す
+   */
+  isOver(type: LimitKey, count: number): boolean {
+    const limit = this[type]
+    return limit !== null && count >= limit
+  }
+
+  /**
+   * 上限超過時のエラーメッセージを返す
+   */
+  limitMessage(type: LimitKey): string {
+    return LIMIT_MESSAGES[this._role]?.[type] ?? '登録件数の上限に達しました'
+  }
+}

--- a/apps/web/lib/api/server/valueObjects/AccountLimitsValue.ts
+++ b/apps/web/lib/api/server/valueObjects/AccountLimitsValue.ts
@@ -1,4 +1,5 @@
 import { User } from '@repo/shared-types'
+import { FREE_USER_LIMITS, GUEST_ACCOUNT_LIMITS } from '../../../statics'
 
 type Role = User['role']
 
@@ -14,15 +15,15 @@ type LimitMessages = Partial<Record<LimitKey, string>>
 
 const LIMIT_MESSAGES: Partial<Record<Role, LimitMessages>> = {
   GUEST: {
-    bike: 'ゲストアカウントはバイクを1台まで登録できます',
-    fuelLog: 'ゲストアカウントは給油履歴を5件まで登録できます',
-    touring: 'ゲストアカウントはツーリング履歴を2件まで登録できます',
-    touringPlan: 'ゲストアカウントはツーリングプランを2件まで登録できます',
-    maintenanceLog: 'ゲストアカウントはメンテナンス履歴を2件まで登録できます',
+    bike: `ゲストアカウントはバイクを${GUEST_ACCOUNT_LIMITS.BIKE}台まで登録できます`,
+    fuelLog: `ゲストアカウントは給油履歴を${GUEST_ACCOUNT_LIMITS.FUEL_LOG}件まで登録できます`,
+    touring: `ゲストアカウントはツーリング履歴を${GUEST_ACCOUNT_LIMITS.TOURING}件まで登録できます`,
+    touringPlan: `ゲストアカウントはツーリングプランを${GUEST_ACCOUNT_LIMITS.TOURING_PLAN}件まで登録できます`,
+    maintenanceLog: `ゲストアカウントはメンテナンス履歴を${GUEST_ACCOUNT_LIMITS.MAINTENANCE_LOG}件まで登録できます`,
   },
   USER: {
-    bike: '無料ユーザーはバイクを2台まで登録できます',
-    touringPlan: '無料ユーザーはツーリングプランを10件まで登録できます',
+    bike: `無料ユーザーはバイクを${FREE_USER_LIMITS.BIKE}台まで登録できます`,
+    touringPlan: `無料ユーザーはツーリングプランを${FREE_USER_LIMITS.TOURING_PLAN}件まで登録できます`,
   },
 }
 
@@ -45,10 +46,24 @@ export class AccountLimitsValue {
    */
   static from(role: Role): AccountLimitsValue {
     if (role === 'GUEST') {
-      return new AccountLimitsValue(role, 1, 5, 2, 2, 2)
+      return new AccountLimitsValue(
+        role,
+        GUEST_ACCOUNT_LIMITS.BIKE,
+        GUEST_ACCOUNT_LIMITS.FUEL_LOG,
+        GUEST_ACCOUNT_LIMITS.TOURING,
+        GUEST_ACCOUNT_LIMITS.TOURING_PLAN,
+        GUEST_ACCOUNT_LIMITS.MAINTENANCE_LOG
+      )
     }
     if (role === 'USER') {
-      return new AccountLimitsValue(role, 2, null, null, 10, null)
+      return new AccountLimitsValue(
+        role,
+        FREE_USER_LIMITS.BIKE,
+        null,
+        null,
+        FREE_USER_LIMITS.TOURING_PLAN,
+        null
+      )
     }
     // ADMIN: 全て無制限
     return new AccountLimitsValue(role, null, null, null, null, null)

--- a/apps/web/lib/statics.ts
+++ b/apps/web/lib/statics.ts
@@ -40,6 +40,8 @@ export const GUEST_ACCOUNT_LIMITS = {
  * 無料ユーザー（USERロール）の各種制限値
  */
 export const FREE_USER_LIMITS = {
+  /** バイク登録上限 */
+  BIKE: 2,
   /** ツーリングプラン登録上限 */
   TOURING_PLAN: 10,
 } as const

--- a/apps/web/lib/statics.ts
+++ b/apps/web/lib/statics.ts
@@ -30,6 +30,8 @@ export const GUEST_ACCOUNT_LIMITS = {
   TOURING: 2,
   /** ツーリングプラン登録上限 */
   TOURING_PLAN: 2,
+  /** メンテナンス履歴登録上限 */
+  MAINTENANCE_LOG: 2,
   /** アカウント有効期間（ミリ秒） */
   TTL_MS: 7 * 24 * 60 * 60 * 1000,
 } as const


### PR DESCRIPTION
## 概要

ロール別の登録件数制限ロジックが各サービスに散在していたため、`AccountLimitsValue` バリューオブジェクトに集約するリファクタリングを実施した。あわせて Issue #423 のゲストアカウントのメンテナンス履歴登録件数制限（2件まで）をバックエンドに実装した。

## 変更内容

### AccountLimitsValue バリューオブジェクトの新規追加

| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `valueObjects/AccountLimitsValue.ts` | 追加 | ロール別制限値・エラーメッセージを集約するVO。`from(role)` で生成、`isOver(type, count)` で超過判定、`limitMessage(type)` でエラーメッセージを返す |
| `entities/UserEntity.ts` | 修正 | `limits` getter を追加し、エンティティからロール別制限値を取得可能に |

### サービス層のリファクタリング（`role` → `limits: AccountLimitsValue`）

| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `services/FuelLogService.ts` | 修正 | `RegisterFuelLogParams` の `role` を `limits` に変更、`GUEST_ACCOUNT_LIMITS` 直参照を削除 |
| `services/TouringService.ts` | 修正 | `RegisterTouringParams` / `StartTouringParams` の `role` を `limits` に変更 |
| `services/TouringPlanService.ts` | 修正 | `RegisterPlanParams` の `role` を `limits` に変更、GUEST/USER の二重チェックを統一 |
| `services/UserBikeService.ts` | 修正 | `RegisterUserBikeParams` の `role` を `limits` に変更、ローカル定数 `FREE_PLAN_BIKE_LIMIT` と `validateBikeRegistrationLimit` メソッドを削除 |
| `services/MaintenanceLogService.ts` | 修正 | `RegisterMaintenanceLogParams` に `limits` を追加、件数上限チェックロジックを実装（Issue #423） |

### APIルートの更新

| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `v1/userBike.ts` | 修正 | `registerUserBike` で `AccountLimitsValue.from(role)` を生成して渡すよう変更。`updateMyUserBike` の未使用 `role` 変数を削除 |
| `v1/userBike/fuelLogs.ts` | 修正 | POST ハンドラで `limits` を渡すよう変更 |
| `v1/userBike/tourings.ts` | 修正 | registerTouring・handleTouringAction start で `limits` を渡すよう変更 |
| `v1/userBike/touringPlans.ts` | 修正 | registerPlan で `limits` を渡すよう変更 |
| `v1/userBike/maintenanceLogs.ts` | 修正 | POST ハンドラで `role` を取得し `limits` を渡すよう変更（Issue #423） |

### リポジトリへのカウントメソッド追加（Issue #423）

| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `interfaces/IMaintenanceLogRepository.ts` | 修正 | `countMaintenanceLogs` メソッドを追加 |
| `repositories/PrismaMaintenanceLogRepository.ts` | 修正 | `countMaintenanceLogs` の Prisma 実装を追加 |

### 定数・UI の更新

| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `lib/statics.ts` | 修正 | `GUEST_ACCOUNT_LIMITS.MAINTENANCE_LOG: 2` と `FREE_USER_LIMITS.BIKE: 2` を追加 |
| `app/(public)/pricing/page.tsx` | 修正 | メンテナンス記録・バイク登録の無料プラン表示をハードコーディングから定数参照に変更 |

## 影響範囲

- ゲスト・無料ユーザーの登録件数制限がかかる全 API エンドポイント（バイク・給油履歴・ツーリング・ツーリングプラン・メンテナンス履歴）
- 料金プランページの機能一覧表示

## テストプラン

- [ ] ゲストアカウントでメンテナンス履歴を2件登録後、3件目の登録がエラーになること
- [ ] 無料ユーザーでメンテナンス履歴が制限なく登録できること
- [ ] 既存の給油履歴・ツーリング・ツーリングプラン・バイク登録の件数制限が従来通り動作すること
- [ ] 料金プランページのゲスト列・無料プラン列の数値が正しく表示されること
- [ ] `pnpm lint` / `NODE_ENV=production pnpm build` が通ること

Closes #423