### PR TITLE
✨ リリースノートの個別ページ作成 (Issue #436)

### DIFF
--- a/apps/web/app/(public)/blog/[slug]/page.tsx
+++ b/apps/web/app/(public)/blog/[slug]/page.tsx
@@ -4,34 +4,13 @@ import { notFound } from 'next/navigation'
 import { BlogToc } from './BlogToc'
 import styles from './page.module.css'
 import { parseHeadings } from '@/lib/blog/toc'
-import { microCMSClient } from '@/lib/microcms/config'
-import type { Blog } from '@/lib/microcms/types'
+import { getBlogBySlug } from '@/lib/microcms/blog'
 import { APP_NAME, SITE_URL } from '@/lib/statics'
 
 export const revalidate = 300
 
 type Props = {
   params: Promise<{ slug: string }>
-}
-
-async function getBlogBySlug(slug: string): Promise<Blog | null> {
-  try {
-    if (!microCMSClient) return null
-    const data = await microCMSClient.getList<Blog>({
-      endpoint: 'motoreco-blogs',
-      queries: {
-        filters: `slug[equals]${slug}${
-          process.env.NODE_ENV !== 'development'
-            ? '[and]status[contains]published'
-            : ''
-        }`,
-        limit: 1,
-      },
-    })
-    return data.contents[0] ?? null
-  } catch {
-    return null
-  }
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/apps/web/app/(public)/blog/page.tsx
+++ b/apps/web/app/(public)/blog/page.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from 'next'
 import Image from 'next/image'
 import Link from 'next/link'
 import styles from './page.module.css'
-import { microCMSClient } from '@/lib/microcms/config'
-import type { Blog } from '@/lib/microcms/types'
+import { getBlogs } from '@/lib/microcms/blog'
 import { APP_NAME, SITE_URL } from '@/lib/statics'
 
 export const revalidate = 300
@@ -26,26 +25,6 @@ export const metadata: Metadata = {
   alternates: {
     canonical: '/blog',
   },
-}
-
-async function getBlogs(): Promise<Blog[]> {
-  try {
-    if (!microCMSClient) return []
-    const data = await microCMSClient.getList<Blog>({
-      endpoint: 'motoreco-blogs',
-      queries: {
-        orders: '-publishedAt',
-        limit: 100,
-        filters:
-          process.env.NODE_ENV !== 'development'
-            ? 'status[contains]published'
-            : undefined,
-      },
-    })
-    return data.contents
-  } catch {
-    return []
-  }
 }
 
 export default async function BlogPage() {

--- a/apps/web/app/(public)/release-note/[version]/page.module.css
+++ b/apps/web/app/(public)/release-note/[version]/page.module.css
@@ -1,0 +1,130 @@
+.article {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.itemHeader {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.version {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 600;
+  background: #ea580c;
+  color: #ffffff;
+}
+
+.date {
+  font-size: 14px;
+  color: rgba(23, 23, 23, 0.5);
+}
+
+.articleTitle {
+  font-size: clamp(24px, 3vw, 36px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
+}
+
+.content {
+  font-size: 16px;
+  line-height: 1.9;
+  color: rgba(23, 23, 23, 0.85);
+}
+
+.content p {
+  margin: 0 0 1.25em;
+}
+
+.content ul,
+.content ol {
+  padding-left: 1.5em;
+  margin-bottom: 1.25em;
+}
+
+.content ul {
+  list-style-type: disc;
+}
+
+.content ol {
+  list-style-type: decimal;
+}
+
+.content li {
+  margin-bottom: 6px;
+}
+
+.pager {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 16px;
+  padding-top: 24px;
+  border-top: 1px solid rgba(23, 23, 23, 0.1);
+}
+
+.pagerLink {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  text-decoration: none;
+  color: inherit;
+  transition: background-color 0.15s ease;
+}
+
+.pagerLink:hover {
+  background-color: rgba(23, 23, 23, 0.04);
+}
+
+.pagerLinkNext {
+  margin-left: auto;
+  align-items: flex-end;
+  text-align: right;
+}
+
+.pagerLabel {
+  font-size: 13px;
+  color: rgba(23, 23, 23, 0.5);
+}
+
+.pagerVersion {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+html[data-theme-mode='dark'] .date {
+  color: rgba(237, 237, 237, 0.5);
+}
+
+html[data-theme-mode='dark'] .content {
+  color: rgba(237, 237, 237, 0.85);
+}
+
+html[data-theme-mode='dark'] .pager {
+  border-top-color: rgba(255, 255, 255, 0.1);
+}
+
+html[data-theme-mode='dark'] .pagerLink:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+html[data-theme-mode='dark'] .pagerLabel {
+  color: rgba(237, 237, 237, 0.5);
+}

--- a/apps/web/app/(public)/release-note/[version]/page.tsx
+++ b/apps/web/app/(public)/release-note/[version]/page.tsx
@@ -2,69 +2,16 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import styles from './page.module.css'
-import { microCMSClient } from '@/lib/microcms/config'
-import type { ReleaseNote } from '@/lib/microcms/types'
+import {
+  getAdjacentReleaseNotes,
+  getReleaseNoteByVersion,
+} from '@/lib/microcms/releaseNote'
 import { APP_NAME, SITE_URL } from '@/lib/statics'
 
 export const revalidate = 300
 
 type Props = {
   params: Promise<{ version: string }>
-}
-
-type ReleaseNoteSummary = Pick<ReleaseNote, 'version' | 'title'>
-
-async function getReleaseNoteByVersion(
-  version: string
-): Promise<ReleaseNote | null> {
-  try {
-    if (!microCMSClient) return null
-    const data = await microCMSClient.getList<ReleaseNote>({
-      endpoint: 'motoreco-releases',
-      queries: {
-        filters: `version[equals]${version}${
-          process.env.NODE_ENV !== 'development'
-            ? '[and]status[contains]published'
-            : ''
-        }`,
-        limit: 1,
-      },
-    })
-    return data.contents[0] ?? null
-  } catch {
-    return null
-  }
-}
-
-async function getAdjacentReleaseNotes(version: string): Promise<{
-  prev: ReleaseNoteSummary | null
-  next: ReleaseNoteSummary | null
-}> {
-  try {
-    if (!microCMSClient) return { prev: null, next: null }
-    const data = await microCMSClient.getList<ReleaseNoteSummary>({
-      endpoint: 'motoreco-releases',
-      queries: {
-        orders: '-publishedAt',
-        limit: 100,
-        fields: 'version,title',
-        filters:
-          process.env.NODE_ENV !== 'development'
-            ? 'status[contains]published'
-            : undefined,
-      },
-    })
-    const notes = data.contents
-    const index = notes.findIndex((note) => note.version === version)
-    if (index === -1) return { prev: null, next: null }
-
-    return {
-      prev: notes[index + 1] ?? null,
-      next: index > 0 ? (notes[index - 1] ?? null) : null,
-    }
-  } catch {
-    return { prev: null, next: null }
-  }
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/apps/web/app/(public)/release-note/[version]/page.tsx
+++ b/apps/web/app/(public)/release-note/[version]/page.tsx
@@ -1,0 +1,168 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import styles from './page.module.css'
+import { microCMSClient } from '@/lib/microcms/config'
+import type { ReleaseNote } from '@/lib/microcms/types'
+import { APP_NAME, SITE_URL } from '@/lib/statics'
+
+export const revalidate = 300
+
+type Props = {
+  params: Promise<{ version: string }>
+}
+
+type ReleaseNoteSummary = Pick<ReleaseNote, 'version' | 'title'>
+
+async function getReleaseNoteByVersion(
+  version: string
+): Promise<ReleaseNote | null> {
+  try {
+    if (!microCMSClient) return null
+    const data = await microCMSClient.getList<ReleaseNote>({
+      endpoint: 'motoreco-releases',
+      queries: {
+        filters: `version[equals]${version}${
+          process.env.NODE_ENV !== 'development'
+            ? '[and]status[contains]published'
+            : ''
+        }`,
+        limit: 1,
+      },
+    })
+    return data.contents[0] ?? null
+  } catch {
+    return null
+  }
+}
+
+async function getAdjacentReleaseNotes(version: string): Promise<{
+  prev: ReleaseNoteSummary | null
+  next: ReleaseNoteSummary | null
+}> {
+  try {
+    if (!microCMSClient) return { prev: null, next: null }
+    const data = await microCMSClient.getList<ReleaseNoteSummary>({
+      endpoint: 'motoreco-releases',
+      queries: {
+        orders: '-publishedAt',
+        limit: 100,
+        fields: 'version,title',
+        filters:
+          process.env.NODE_ENV !== 'development'
+            ? 'status[contains]published'
+            : undefined,
+      },
+    })
+    const notes = data.contents
+    const index = notes.findIndex((note) => note.version === version)
+    if (index === -1) return { prev: null, next: null }
+
+    return {
+      prev: notes[index + 1] ?? null,
+      next: index > 0 ? (notes[index - 1] ?? null) : null,
+    }
+  } catch {
+    return { prev: null, next: null }
+  }
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { version } = await params
+  const releaseNote = await getReleaseNoteByVersion(version)
+
+  if (!releaseNote) {
+    return { title: 'リリースノートが見つかりません' }
+  }
+
+  const title = `v${releaseNote.version} ${releaseNote.title}`
+  const description = `${APP_NAME} v${releaseNote.version} のリリースノートです。`
+
+  return {
+    title,
+    description,
+    openGraph: {
+      url: `${SITE_URL}/release-note/${version}`,
+      title: `${title} | ${APP_NAME}`,
+      description,
+      images: ['/top_image_1.png'],
+    },
+    twitter: {
+      title: `${title} | ${APP_NAME}`,
+      description,
+      images: ['/top_image_1.png'],
+    },
+    metadataBase: new URL(SITE_URL),
+    alternates: {
+      canonical: `/release-note/${version}`,
+    },
+  }
+}
+
+export default async function ReleaseNoteDetailPage({ params }: Props) {
+  const { version } = await params
+  const releaseNote = await getReleaseNoteByVersion(version)
+
+  if (!releaseNote) {
+    notFound()
+  }
+
+  const { prev, next } = await getAdjacentReleaseNotes(version)
+
+  return (
+    <div className="public-page-container">
+      <article className={styles.article}>
+        <header className={styles.header}>
+          <div className={styles.itemHeader}>
+            <span className={styles.version}>v{releaseNote.version}</span>
+            <time
+              className={styles.date}
+              dateTime={releaseNote.releaseDate ?? releaseNote.createdAt}
+            >
+              {new Date(
+                releaseNote.releaseDate ?? releaseNote.createdAt
+              ).toLocaleDateString('ja-JP', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </time>
+          </div>
+          <h1 className={styles.articleTitle}>{releaseNote.title}</h1>
+        </header>
+
+        <div
+          className={styles.content}
+          dangerouslySetInnerHTML={{ __html: releaseNote.content }}
+        />
+
+        {(prev || next) && (
+          <nav className={styles.pager}>
+            {prev ? (
+              <Link
+                href={`/release-note/${prev.version}`}
+                className={styles.pagerLink}
+              >
+                <span className={styles.pagerLabel}>← 前のバージョン</span>
+                <span className={styles.pagerVersion}>v{prev.version}</span>
+              </Link>
+            ) : (
+              <span />
+            )}
+            {next ? (
+              <Link
+                href={`/release-note/${next.version}`}
+                className={`${styles.pagerLink} ${styles.pagerLinkNext}`}
+              >
+                <span className={styles.pagerLabel}>次のバージョン →</span>
+                <span className={styles.pagerVersion}>v{next.version}</span>
+              </Link>
+            ) : (
+              <span />
+            )}
+          </nav>
+        )}
+      </article>
+    </div>
+  )
+}

--- a/apps/web/app/(public)/release-note/page.module.css
+++ b/apps/web/app/(public)/release-note/page.module.css
@@ -37,6 +37,18 @@
   padding: 32px;
   border-radius: 20px;
   box-shadow: inset 0 0 0 1px rgba(23, 23, 23, 0.1);
+  text-decoration: none;
+  color: inherit;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
+}
+
+.item:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    inset 0 0 0 1px rgba(234, 88, 12, 0.3),
+    0 8px 24px rgba(23, 23, 23, 0.08);
 }
 
 .itemHeader {
@@ -98,6 +110,12 @@ html[data-theme-mode='dark'] .empty {
 
 html[data-theme-mode='dark'] .item {
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+html[data-theme-mode='dark'] .item:hover {
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.1),
+    0 8px 24px rgba(0, 0, 0, 0.3);
 }
 
 html[data-theme-mode='dark'] .version {

--- a/apps/web/app/(public)/release-note/page.module.css
+++ b/apps/web/app/(public)/release-note/page.module.css
@@ -78,20 +78,29 @@
   letter-spacing: -0.01em;
 }
 
-.content {
+.excerpt {
   font-size: 15px;
   line-height: 1.8;
   color: rgba(23, 23, 23, 0.75);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
-.content ul,
-.content ol {
-  padding-left: 1.5em;
-  list-style-type: circle;
+.readMore {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #ea580c;
+  margin-top: 4px;
+  transition: gap 0.2s ease;
 }
 
-.content li {
-  margin-bottom: 4px;
+.item:hover .readMore {
+  gap: 8px;
 }
 
 @media (max-width: 900px) {
@@ -127,6 +136,6 @@ html[data-theme-mode='dark'] .date {
   color: rgba(237, 237, 237, 0.5);
 }
 
-html[data-theme-mode='dark'] .content {
+html[data-theme-mode='dark'] .excerpt {
   color: rgba(237, 237, 237, 0.75);
 }

--- a/apps/web/app/(public)/release-note/page.tsx
+++ b/apps/web/app/(public)/release-note/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import styles from './page.module.css'
 import { microCMSClient } from '@/lib/microcms/config'
 import type { ReleaseNote } from '@/lib/microcms/types'
@@ -65,7 +66,11 @@ export default async function ReleaseNotePage() {
       ) : (
         <div className={styles.list}>
           {releaseNotes.map((note) => (
-            <article key={note.id} className={styles.item}>
+            <Link
+              key={note.id}
+              href={`/release-note/${note.version}`}
+              className={styles.item}
+            >
               <div className={styles.itemHeader}>
                 <span className={styles.version}>v{note.version}</span>
                 <time
@@ -86,7 +91,7 @@ export default async function ReleaseNotePage() {
                 className={styles.content}
                 dangerouslySetInnerHTML={{ __html: note.content }}
               />
-            </article>
+            </Link>
           ))}
         </div>
       )}

--- a/apps/web/app/(public)/release-note/page.tsx
+++ b/apps/web/app/(public)/release-note/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import styles from './page.module.css'
 import { getReleaseNotes } from '@/lib/microcms/releaseNote'
 import { APP_NAME, SITE_URL } from '@/lib/statics'
+import { stripHtmlToText } from '@/lib/utils/html'
 
 export const revalidate = 300
 
@@ -66,10 +67,8 @@ export default async function ReleaseNotePage() {
                 </time>
               </div>
               <h2 className={styles.itemTitle}>{note.title}</h2>
-              <div
-                className={styles.content}
-                dangerouslySetInnerHTML={{ __html: note.content }}
-              />
+              <p className={styles.excerpt}>{stripHtmlToText(note.content)}</p>
+              <span className={styles.readMore}>詳細を見る →</span>
             </Link>
           ))}
         </div>

--- a/apps/web/app/(public)/release-note/page.tsx
+++ b/apps/web/app/(public)/release-note/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import styles from './page.module.css'
-import { microCMSClient } from '@/lib/microcms/config'
-import type { ReleaseNote } from '@/lib/microcms/types'
+import { getReleaseNotes } from '@/lib/microcms/releaseNote'
 import { APP_NAME, SITE_URL } from '@/lib/statics'
 
 export const revalidate = 300
@@ -25,26 +24,6 @@ export const metadata: Metadata = {
   alternates: {
     canonical: '/release-note',
   },
-}
-
-async function getReleaseNotes(): Promise<ReleaseNote[]> {
-  try {
-    if (!microCMSClient) return []
-    const data = await microCMSClient.getList<ReleaseNote>({
-      endpoint: 'motoreco-releases',
-      queries: {
-        orders: '-publishedAt',
-        limit: 100,
-        filters:
-          process.env.NODE_ENV !== 'development'
-            ? 'status[contains]published'
-            : undefined,
-      },
-    })
-    return data.contents
-  } catch {
-    return []
-  }
 }
 
 export default async function ReleaseNotePage() {

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next'
 import { getCurrentDate } from '@repo/shared-utils'
-import { microCMSClient } from '@/lib/microcms/config'
-import type { Blog, ReleaseNote } from '@/lib/microcms/types'
+import { getBlogSitemapEntries } from '@/lib/microcms/blog'
+import { getReleaseNoteSitemapEntries } from '@/lib/microcms/releaseNote'
 import { SITE_URL } from '@/lib/statics'
 
 export const revalidate = 300
@@ -53,74 +53,26 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ]
 
-  const [blogPages, releaseNotePages] = await Promise.all([
-    fetchBlogPages(),
-    fetchReleaseNotePages(),
+  const [blogEntries, releaseNoteEntries] = await Promise.all([
+    getBlogSitemapEntries(),
+    getReleaseNoteSitemapEntries(),
   ])
 
-  return [...staticPages, ...blogPages, ...releaseNotePages]
-}
+  const blogPages: MetadataRoute.Sitemap = blogEntries.map((blog) => ({
+    url: `${SITE_URL}/blog/${blog.slug}`,
+    lastModified: new Date(blog.updatedAt),
+    changeFrequency: 'weekly',
+    priority: 0.7,
+  }))
 
-async function fetchBlogPages() {
-  try {
-    if (!microCMSClient) return []
-    const data = await microCMSClient.getList<Blog>({
-      endpoint: 'motoreco-blogs',
-      queries: {
-        orders: '-publishedAt',
-        limit: 100,
-        fields: 'slug,updatedAt',
-        filters:
-          process.env.NODE_ENV !== 'development'
-            ? 'status[contains]published'
-            : undefined,
-      },
-    })
-    console.log(`[sitemap] ブログ記事取得: ${data.contents.length}件`)
-
-    return data.contents.map((blog): MetadataRoute.Sitemap[number] => ({
-      url: `${SITE_URL}/blog/${blog.slug}`,
-      lastModified: new Date(blog.updatedAt),
-      changeFrequency: 'weekly',
-      priority: 0.7,
-    }))
-  } catch (error) {
-    console.error('[sitemap] ブログ記事取得失敗', {
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-    })
-    return []
-  }
-}
-
-async function fetchReleaseNotePages() {
-  try {
-    if (!microCMSClient) return []
-    const data = await microCMSClient.getList<ReleaseNote>({
-      endpoint: 'motoreco-releases',
-      queries: {
-        orders: '-publishedAt',
-        limit: 100,
-        fields: 'version,updatedAt',
-        filters:
-          process.env.NODE_ENV !== 'development'
-            ? 'status[contains]published'
-            : undefined,
-      },
-    })
-    console.log(`[sitemap] リリースノート取得: ${data.contents.length}件`)
-
-    return data.contents.map((note): MetadataRoute.Sitemap[number] => ({
+  const releaseNotePages: MetadataRoute.Sitemap = releaseNoteEntries.map(
+    (note) => ({
       url: `${SITE_URL}/release-note/${note.version}`,
       lastModified: new Date(note.updatedAt),
       changeFrequency: 'monthly',
       priority: 0.5,
-    }))
-  } catch (error) {
-    console.error('[sitemap] リリースノート取得失敗', {
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
     })
-    return []
-  }
+  )
+
+  return [...staticPages, ...blogPages, ...releaseNotePages]
 }

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next'
 import { getCurrentDate } from '@repo/shared-utils'
 import { microCMSClient } from '@/lib/microcms/config'
-import type { Blog } from '@/lib/microcms/types'
+import type { Blog, ReleaseNote } from '@/lib/microcms/types'
 import { SITE_URL } from '@/lib/statics'
 
 export const revalidate = 300
@@ -53,9 +53,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
   ]
 
-  const [blogPages] = await Promise.all([fetchBlogPages()])
+  const [blogPages, releaseNotePages] = await Promise.all([
+    fetchBlogPages(),
+    fetchReleaseNotePages(),
+  ])
 
-  return [...staticPages, ...blogPages]
+  return [...staticPages, ...blogPages, ...releaseNotePages]
 }
 
 async function fetchBlogPages() {
@@ -83,6 +86,38 @@ async function fetchBlogPages() {
     }))
   } catch (error) {
     console.error('[sitemap] ブログ記事取得失敗', {
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    })
+    return []
+  }
+}
+
+async function fetchReleaseNotePages() {
+  try {
+    if (!microCMSClient) return []
+    const data = await microCMSClient.getList<ReleaseNote>({
+      endpoint: 'motoreco-releases',
+      queries: {
+        orders: '-publishedAt',
+        limit: 100,
+        fields: 'version,updatedAt',
+        filters:
+          process.env.NODE_ENV !== 'development'
+            ? 'status[contains]published'
+            : undefined,
+      },
+    })
+    console.log(`[sitemap] リリースノート取得: ${data.contents.length}件`)
+
+    return data.contents.map((note): MetadataRoute.Sitemap[number] => ({
+      url: `${SITE_URL}/release-note/${note.version}`,
+      lastModified: new Date(note.updatedAt),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    }))
+  } catch (error) {
+    console.error('[sitemap] リリースノート取得失敗', {
       message: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
     })

--- a/apps/web/lib/microcms/blog.ts
+++ b/apps/web/lib/microcms/blog.ts
@@ -1,0 +1,33 @@
+import { safeGetList, safeGetListItem, withPublishedFilter } from './queries'
+import type { Blog } from './types'
+
+const ENDPOINT = 'motoreco-blogs'
+
+export async function getBlogs(): Promise<Blog[]> {
+  return safeGetList<Blog>(ENDPOINT, {
+    orders: '-publishedAt',
+    limit: 100,
+    filters: withPublishedFilter(),
+  })
+}
+
+export async function getBlogBySlug(slug: string): Promise<Blog | null> {
+  return safeGetListItem<Blog>(ENDPOINT, {
+    filters: withPublishedFilter(`slug[equals]${slug}`),
+  })
+}
+
+export async function getBlogSitemapEntries(): Promise<
+  Pick<Blog, 'slug' | 'updatedAt'>[]
+> {
+  return safeGetList<Pick<Blog, 'slug' | 'updatedAt'>>(
+    ENDPOINT,
+    {
+      orders: '-publishedAt',
+      limit: 100,
+      fields: 'slug,updatedAt',
+      filters: withPublishedFilter(),
+    },
+    'sitemap:blog'
+  )
+}

--- a/apps/web/lib/microcms/queries.ts
+++ b/apps/web/lib/microcms/queries.ts
@@ -1,0 +1,50 @@
+import type { MicroCMSQueries } from 'microcms-js-sdk'
+import { microCMSClient } from './config'
+
+/**
+ * 開発環境以外では status[contains]published を必ず付与した絞り込み条件を組み立てる
+ */
+export function withPublishedFilter(filter?: string): string | undefined {
+  if (process.env.NODE_ENV === 'development') return filter
+
+  return filter
+    ? `${filter}[and]status[contains]published`
+    : 'status[contains]published'
+}
+
+/**
+ * MicroCMSのリスト取得をラップし、クライアント未設定時・取得失敗時は空配列を返す
+ */
+export async function safeGetList<T>(
+  endpoint: string,
+  queries: MicroCMSQueries,
+  logContext?: string
+): Promise<T[]> {
+  try {
+    if (!microCMSClient) return []
+    const data = await microCMSClient.getList<T>({ endpoint, queries })
+    if (logContext) {
+      console.log(`[${logContext}] 取得: ${data.contents.length}件`)
+    }
+    return data.contents
+  } catch (error) {
+    if (logContext) {
+      console.error(`[${logContext}] 取得失敗`, {
+        message: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      })
+    }
+    return []
+  }
+}
+
+/**
+ * MicroCMSのリストから先頭1件を取得する。該当なし・取得失敗時は null を返す
+ */
+export async function safeGetListItem<T>(
+  endpoint: string,
+  queries: MicroCMSQueries
+): Promise<T | null> {
+  const contents = await safeGetList<T>(endpoint, { ...queries, limit: 1 })
+  return contents[0] ?? null
+}

--- a/apps/web/lib/microcms/releaseNote.ts
+++ b/apps/web/lib/microcms/releaseNote.ts
@@ -1,0 +1,57 @@
+import { safeGetList, safeGetListItem, withPublishedFilter } from './queries'
+import type { ReleaseNote } from './types'
+
+const ENDPOINT = 'motoreco-releases'
+
+type ReleaseNoteSummary = Pick<ReleaseNote, 'version' | 'title'>
+
+export async function getReleaseNotes(): Promise<ReleaseNote[]> {
+  return safeGetList<ReleaseNote>(ENDPOINT, {
+    orders: '-publishedAt',
+    limit: 100,
+    filters: withPublishedFilter(),
+  })
+}
+
+export async function getReleaseNoteByVersion(
+  version: string
+): Promise<ReleaseNote | null> {
+  return safeGetListItem<ReleaseNote>(ENDPOINT, {
+    filters: withPublishedFilter(`version[equals]${version}`),
+  })
+}
+
+export async function getAdjacentReleaseNotes(version: string): Promise<{
+  prev: ReleaseNoteSummary | null
+  next: ReleaseNoteSummary | null
+}> {
+  const notes = await safeGetList<ReleaseNoteSummary>(ENDPOINT, {
+    orders: '-publishedAt',
+    limit: 100,
+    fields: 'version,title',
+    filters: withPublishedFilter(),
+  })
+
+  const index = notes.findIndex((note) => note.version === version)
+  if (index === -1) return { prev: null, next: null }
+
+  return {
+    prev: notes[index + 1] ?? null,
+    next: index > 0 ? (notes[index - 1] ?? null) : null,
+  }
+}
+
+export async function getReleaseNoteSitemapEntries(): Promise<
+  Pick<ReleaseNote, 'version' | 'updatedAt'>[]
+> {
+  return safeGetList<Pick<ReleaseNote, 'version' | 'updatedAt'>>(
+    ENDPOINT,
+    {
+      orders: '-publishedAt',
+      limit: 100,
+      fields: 'version,updatedAt',
+      filters: withPublishedFilter(),
+    },
+    'sitemap:release-note'
+  )
+}

--- a/apps/web/lib/utils/html.ts
+++ b/apps/web/lib/utils/html.ts
@@ -1,0 +1,7 @@
+/** HTMLタグを除去しプレーンテキストに変換する */
+export function stripHtmlToText(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}


### PR DESCRIPTION
## 概要
リリースノート一覧ページのみだった構成に、バージョン単位で閲覧できる個別ページを追加しました。あわせて、各ページ・sitemapに散在していたMicroCMSへのリクエスト処理をUtilityとして整理しています。

## 変更内容

### リリースノート個別ページ
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `release-note/[version]/page.tsx` | 追加 | `version` をURL識別子とした詳細ページ。SEOメタデータ生成、本文HTMLレンダリング、前/次バージョンへのナビゲーション、未公開・存在しないバージョンは404 |
| `release-note/[version]/page.module.css` | 追加 | 詳細ページ用スタイル(ダークモード対応含む) |
| `release-note/page.tsx` | 修正 | 一覧の各項目を詳細ページへの `Link` に変更 |
| `release-note/page.module.css` | 修正 | リンク化に伴うホバースタイルを追加 |
| `app/sitemap.ts` | 修正 | リリースノート詳細ページをsitemapに登録 |

### MicroCMSリクエスト処理のUtility化
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `lib/microcms/queries.ts` | 追加 | `withPublishedFilter` / `safeGetList` / `safeGetListItem` など共通のリクエスト処理を集約 |
| `lib/microcms/blog.ts` | 追加 | ブログ取得処理(`getBlogs` / `getBlogBySlug` / `getBlogSitemapEntries`)を集約 |
| `lib/microcms/releaseNote.ts` | 追加 | リリースノート取得処理(`getReleaseNotes` / `getReleaseNoteByVersion` / `getAdjacentReleaseNotes` / `getReleaseNoteSitemapEntries`)を集約 |
| `blog/page.tsx` | 修正 | ページ内で定義していた取得関数を `lib/microcms/blog.ts` の関数呼び出しに置き換え |
| `blog/[slug]/page.tsx` | 修正 | 同上 |
| `app/sitemap.ts` | 修正 | ブログ・リリースノートの取得処理をUtility呼び出しに置き換え |

## 影響範囲
- `/release-note` 一覧ページの表示・リンク先
- `/release-note/[version]` 新規ページ
- `/blog`, `/blog/[slug]` のデータ取得処理(内部実装のみ変更、表示は変更なし)
- `/sitemap.xml` の出力内容(リリースノート詳細URLが追加)

## テストプラン
- [x] `pnpm lint` がパスすることを確認
- [x] `pnpm format` で差分が出ないことを確認
- [x] `NODE_ENV=production pnpm build` が成功することを確認
- [x] 開発サーバーで `/blog`, `/blog/[slug]`, `/release-note`, `/release-note/[version]` が正常に表示されることを確認
- [x] `/release-note/[version]` で前/次バージョンへのリンクが正しく機能することを確認(最新バージョンでは「次」が非表示)
- [x] 存在しないバージョンへのアクセスで404になることを確認
- [x] `/sitemap.xml` にリリースノート・ブログの詳細URLが含まれることを確認

Closes #436