### PR TITLE
✨ ツーリングと給油履歴の手動紐づけ機能を追加

### DIFF
--- a/apps/e2e/helpers/fuelLogHelper.ts
+++ b/apps/e2e/helpers/fuelLogHelper.ts
@@ -1,0 +1,45 @@
+const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
+
+/**
+ * API経由で給油履歴を登録し、fuelLogId を返す
+ */
+export async function registerTestFuelLog(
+  token: string,
+  myUserBikeId: string,
+  fuelLog: {
+    refueledAt: string
+    mileage: number
+    previousMileage: number
+    amount?: number
+    totalPrice?: number
+    memo?: string
+    touringId?: string | null
+  }
+): Promise<string> {
+  const res = await fetch(
+    `${BASE_URL}/api/v1/user-bike/bike/${myUserBikeId}/fuel-logs`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        refueledAt: fuelLog.refueledAt,
+        mileage: fuelLog.mileage,
+        previousMileage: fuelLog.previousMileage,
+        amount: fuelLog.amount ?? 10,
+        totalPrice: fuelLog.totalPrice ?? 1500,
+        memo: fuelLog.memo ?? null,
+        updateTotalMileage: false,
+        touringId: fuelLog.touringId ?? null,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    }
+  )
+  if (!res.ok) {
+    throw new Error(`給油履歴登録失敗: ${res.status} ${await res.text()}`)
+  }
+  const json = (await res.json()) as { data: { fuelLogId: string } }
+  return json.data.fuelLogId
+}

--- a/apps/e2e/helpers/touringHelper.ts
+++ b/apps/e2e/helpers/touringHelper.ts
@@ -59,3 +59,46 @@ export async function endTestTouring(
     throw new Error(`ツーリング終了失敗: ${res.status} ${await res.text()}`)
   }
 }
+
+/**
+ * API経由で完了済みツーリングを任意の開始/終了日時で登録し、touringId を返す
+ *
+ * @remarks
+ * 給油履歴の日付範囲フィルタなど、ツーリング期間を明示的に制御したいテストで使用する。
+ */
+export async function registerTestTouring(
+  token: string,
+  myUserBikeId: string,
+  params: {
+    title: string
+    startDate: string
+    endDate: string
+    startMileage?: number
+    endMileage?: number
+  }
+): Promise<string> {
+  const res = await fetch(
+    `${BASE_URL}/api/v1/user-bike/bike/${myUserBikeId}/tourings`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        title: params.title,
+        startDate: params.startDate,
+        endDate: params.endDate,
+        startMileage: params.startMileage,
+        endMileage: params.endMileage,
+        status: 'COMPLETED',
+      }),
+      signal: AbortSignal.timeout(30_000),
+    }
+  )
+  if (!res.ok) {
+    throw new Error(`ツーリング登録失敗: ${res.status} ${await res.text()}`)
+  }
+  const json = (await res.json()) as { data: { touringId: string } }
+  return json.data.touringId
+}

--- a/apps/e2e/pages/touringDetailPage.ts
+++ b/apps/e2e/pages/touringDetailPage.ts
@@ -1,0 +1,48 @@
+import { type Locator, type Page } from '@playwright/test'
+
+/**
+ * ツーリング詳細ページの Page Object Model
+ *
+ * @remarks
+ * /app/my-bike/{bikeId}/tourings/{touringId} に対応。
+ * 給油履歴紐づけモーダル（TouringFuelLogLinkModal）の操作もあわせて提供する。
+ */
+export class TouringDetailPage {
+  readonly page: Page
+  readonly fuelLogLinkButton: Locator
+  readonly periodOnlyToggle: Locator
+  readonly linkButton: Locator
+  readonly loadMoreButton: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.fuelLogLinkButton = page.getByRole('button', {
+      name: '給油履歴の紐づけ',
+    })
+    this.periodOnlyToggle = page.getByRole('checkbox', {
+      name: '期間内のみ表示',
+    })
+    this.linkButton = page.getByRole('button', { name: '紐づける' })
+    this.loadMoreButton = page.getByRole('button', { name: 'もっと見る' })
+  }
+
+  /** ツーリング詳細ページへ遷移する */
+  async goto(bikeId: string, touringId: string): Promise<void> {
+    await this.page.goto(`/app/my-bike/${bikeId}/tourings/${touringId}`)
+  }
+
+  /** 給油履歴の紐づけモーダルを開く */
+  async openFuelLogLinkModal(): Promise<void> {
+    await this.fuelLogLinkButton.click()
+  }
+
+  /** 給油履歴ピッカー内のチェックボックスをラベル（部分一致可）で取得する */
+  fuelLogCheckbox(labelPattern: string | RegExp): Locator {
+    return this.page.getByRole('checkbox', { name: labelPattern })
+  }
+
+  /** 給油履歴の紐づけモーダルを送信して更新する */
+  async submitFuelLogLink(): Promise<void> {
+    await this.linkButton.click()
+  }
+}

--- a/apps/e2e/tests/touring/touringFuelLogLink.spec.ts
+++ b/apps/e2e/tests/touring/touringFuelLogLink.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test } from '../../fixtures/authenticatedPage'
+import { registerTestBike } from '../../helpers/bikeHelper'
+import { registerTestFuelLog } from '../../helpers/fuelLogHelper'
+import {
+  endTestTouring,
+  registerTestTouring,
+  startTestTouring,
+} from '../../helpers/touringHelper'
+import { TouringDetailPage } from '../../pages/touringDetailPage'
+
+test.describe('ツーリング詳細 - 給油履歴の手動紐づけ', () => {
+  test('ツーリング終了後に追加した給油履歴を紐づけモーダルから検索して手動で紐づけられる', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '給油紐づけ登録テスト',
+    })
+    const touringId = await startTestTouring(
+      authToken,
+      myUserBikeId,
+      '給油紐づけ登録テストツーリング'
+    )
+    await endTestTouring(authToken, myUserBikeId, touringId)
+
+    // ツーリング終了後に追加した未紐づけの給油履歴（ツーリング期間内の日時）
+    const refueledAt = new Date().toISOString()
+    await registerTestFuelLog(authToken, myUserBikeId, {
+      refueledAt,
+      mileage: 10100,
+      previousMileage: 10000,
+      memo: 'E2E未紐づけ給油',
+    })
+
+    const touringDetailPage = new TouringDetailPage(page)
+    await touringDetailPage.goto(myUserBikeId, touringId)
+    await touringDetailPage.openFuelLogLinkModal()
+
+    const fuelLogCheckbox = touringDetailPage.fuelLogCheckbox(/E2E未紐づけ給油/)
+    await expect(fuelLogCheckbox).toBeVisible({ timeout: 10_000 })
+    await expect(fuelLogCheckbox).not.toBeChecked()
+
+    await fuelLogCheckbox.check()
+    await touringDetailPage.submitFuelLogLink()
+    await touringDetailPage.linkButton.waitFor({
+      state: 'hidden',
+      timeout: 15_000,
+    })
+
+    // 再度紐づけモーダルを開き、紐づけが保存されていることを確認する
+    await touringDetailPage.openFuelLogLinkModal()
+    const reopenedCheckbox =
+      touringDetailPage.fuelLogCheckbox(/E2E未紐づけ給油/)
+    await expect(reopenedCheckbox).toBeVisible({ timeout: 10_000 })
+    await expect(reopenedCheckbox).toBeChecked()
+  })
+
+  test('紐づけ済みの給油履歴を紐づけモーダルからチェックを外して解除できる', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '給油紐づけ解除テスト',
+    })
+    const touringId = await startTestTouring(
+      authToken,
+      myUserBikeId,
+      '給油紐づけ解除テストツーリング'
+    )
+    await endTestTouring(authToken, myUserBikeId, touringId)
+
+    // 既にこのツーリングに紐づいた状態で給油履歴を登録する
+    const refueledAt = new Date().toISOString()
+    await registerTestFuelLog(authToken, myUserBikeId, {
+      refueledAt,
+      mileage: 10100,
+      previousMileage: 10000,
+      memo: 'E2E解除対象給油',
+      touringId,
+    })
+
+    const touringDetailPage = new TouringDetailPage(page)
+    await touringDetailPage.goto(myUserBikeId, touringId)
+    await touringDetailPage.openFuelLogLinkModal()
+
+    const fuelLogCheckbox = touringDetailPage.fuelLogCheckbox(/E2E解除対象給油/)
+    await expect(fuelLogCheckbox).toBeVisible({ timeout: 10_000 })
+    await expect(fuelLogCheckbox).toBeChecked()
+
+    await fuelLogCheckbox.uncheck()
+    await touringDetailPage.submitFuelLogLink()
+    await touringDetailPage.linkButton.waitFor({
+      state: 'hidden',
+      timeout: 15_000,
+    })
+
+    // 再度紐づけモーダルを開き、紐づけが解除されていることを確認する
+    await touringDetailPage.openFuelLogLinkModal()
+    const reopenedCheckbox =
+      touringDetailPage.fuelLogCheckbox(/E2E解除対象給油/)
+    await expect(reopenedCheckbox).toBeVisible({ timeout: 10_000 })
+    await expect(reopenedCheckbox).not.toBeChecked()
+  })
+
+  test('「期間内のみ表示」を解除すると期間外の給油履歴を検索して紐づけられる', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '給油紐づけ全件表示テスト',
+    })
+
+    // 10日前に完了した過去のツーリング（デフォルトの期間フィルタの範囲外）
+    const tenDaysAgo = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000)
+    const touringStart = new Date(tenDaysAgo.getTime())
+    const touringEnd = new Date(tenDaysAgo.getTime() + 60 * 60 * 1000)
+    const touringId = await registerTestTouring(authToken, myUserBikeId, {
+      title: '給油紐づけ全件表示テストツーリング',
+      startDate: touringStart.toISOString(),
+      endDate: touringEnd.toISOString(),
+    })
+
+    // 現在日時（ツーリング期間から大きく外れた）給油履歴を未紐づけで登録する
+    const refueledAt = new Date().toISOString()
+    await registerTestFuelLog(authToken, myUserBikeId, {
+      refueledAt,
+      mileage: 10100,
+      previousMileage: 10000,
+      memo: 'E2E期間外給油',
+    })
+
+    const touringDetailPage = new TouringDetailPage(page)
+    await touringDetailPage.goto(myUserBikeId, touringId)
+    await touringDetailPage.openFuelLogLinkModal()
+
+    // デフォルト（期間内のみ表示=ON）では期間外の給油履歴は表示されない
+    const fuelLogCheckbox = touringDetailPage.fuelLogCheckbox(/E2E期間外給油/)
+    await expect(touringDetailPage.periodOnlyToggle).toBeChecked()
+    await expect(fuelLogCheckbox).not.toBeVisible()
+
+    // 「期間内のみ表示」を解除すると全件検索され、期間外の給油履歴も表示される
+    await touringDetailPage.periodOnlyToggle.uncheck()
+    await expect(fuelLogCheckbox).toBeVisible({ timeout: 10_000 })
+
+    await fuelLogCheckbox.check()
+    await touringDetailPage.submitFuelLogLink()
+    await touringDetailPage.linkButton.waitFor({
+      state: 'hidden',
+      timeout: 15_000,
+    })
+
+    // 再度紐づけモーダルを開き、「期間内のみ表示」を解除した状態で紐づけが保存されていることを確認する
+    await touringDetailPage.openFuelLogLinkModal()
+    await touringDetailPage.periodOnlyToggle.uncheck()
+    const reopenedCheckbox = touringDetailPage.fuelLogCheckbox(/E2E期間外給油/)
+    await expect(reopenedCheckbox).toBeVisible({ timeout: 10_000 })
+    await expect(reopenedCheckbox).toBeChecked()
+  })
+})

--- a/apps/web/__tests__/unit/services/TouringService.test.ts
+++ b/apps/web/__tests__/unit/services/TouringService.test.ts
@@ -143,6 +143,7 @@ describe('TouringService', () => {
     fuelLogRepository = {
       createFuelLog: vi.fn(),
       findFuelLogs: vi.fn().mockResolvedValue([]),
+      findFuelLogsByTouringId: vi.fn().mockResolvedValue([]),
       findFuelLogById: vi.fn(),
       updateFuelLog: vi.fn(),
       deleteFuelLog: vi.fn(),
@@ -617,8 +618,10 @@ describe('TouringService', () => {
       test('ツーリング期間外の給油履歴IDを指定しても紐づけできる', async () => {
         const existing = buildTouring({ status: 'COMPLETED' })
         vi.mocked(touringRepository.findTouringById).mockResolvedValue(existing)
-        // 期間外のためfindFuelLogsには含まれない（解除対象なし）
-        vi.mocked(fuelLogRepository.findFuelLogs).mockResolvedValue([])
+        // 解除対象は現在このツーリングに紐づいているものだけなので空
+        vi.mocked(fuelLogRepository.findFuelLogsByTouringId).mockResolvedValue(
+          []
+        )
 
         const outOfRangeFuelLogId = createFuelLogId('fuel-log-out-of-range')
 
@@ -637,7 +640,9 @@ describe('TouringService', () => {
       test('既に他のツーリングに紐づいている給油履歴を指定すると、新しいツーリングへ付け替えられる', async () => {
         const existing = buildTouring({ status: 'COMPLETED' })
         vi.mocked(touringRepository.findTouringById).mockResolvedValue(existing)
-        vi.mocked(fuelLogRepository.findFuelLogs).mockResolvedValue([])
+        vi.mocked(fuelLogRepository.findFuelLogsByTouringId).mockResolvedValue(
+          []
+        )
 
         const fuelLogLinkedToOtherTouring = createFuelLogId('fuel-log-other')
 
@@ -670,10 +675,9 @@ describe('TouringService', () => {
           fuelLogId: createFuelLogId('fuel-log-linked-2'),
           touringId: existing.id,
         })
-        vi.mocked(fuelLogRepository.findFuelLogs).mockResolvedValue([
-          linkedFuelLog1,
-          linkedFuelLog2,
-        ])
+        vi.mocked(fuelLogRepository.findFuelLogsByTouringId).mockResolvedValue(
+          [linkedFuelLog1, linkedFuelLog2]
+        )
 
         await service.updateTouring({
           touringId: existing.id,
@@ -682,6 +686,10 @@ describe('TouringService', () => {
           fuelLogIds: [],
         })
 
+        expect(fuelLogRepository.findFuelLogsByTouringId).toHaveBeenCalledWith(
+          existing.id,
+          myUserBikeId
+        )
         expect(
           fuelLogRepository.updateMultipleFuelLogsTouringId
         ).toHaveBeenCalledTimes(1)
@@ -692,6 +700,37 @@ describe('TouringService', () => {
           myUserBikeId,
           null
         )
+      })
+
+      test('ツーリング期間外の給油日時で紐づいている給油履歴も、選択解除すると解除される', async () => {
+        // レビュー指摘: 解除対象の探索を期間内(startDate〜endDate)のfindFuelLogsに限定すると、
+        // 「全件表示」で紐づけた期間外の給油履歴が解除候補から漏れてしまう不具合の回帰テスト
+        const existing = buildTouring({
+          status: 'COMPLETED',
+          startDate: new Date('2020-07-01T09:00:00.000Z'),
+          endDate: new Date('2020-07-01T11:00:00.000Z'),
+        })
+        vi.mocked(touringRepository.findTouringById).mockResolvedValue(existing)
+
+        const outOfRangeLinkedFuelLog = buildFuelLog({
+          fuelLogId: createFuelLogId('fuel-log-out-of-range-linked'),
+          refueledAt: new Date('2020-06-20T09:00:00.000Z'),
+          touringId: existing.id,
+        })
+        vi.mocked(fuelLogRepository.findFuelLogsByTouringId).mockResolvedValue(
+          [outOfRangeLinkedFuelLog]
+        )
+
+        await service.updateTouring({
+          touringId: existing.id,
+          myUserBikeId,
+          userId,
+          fuelLogIds: [],
+        })
+
+        expect(
+          fuelLogRepository.updateMultipleFuelLogsTouringId
+        ).toHaveBeenCalledWith([outOfRangeLinkedFuelLog.id], myUserBikeId, null)
       })
 
       test('fuelLogIdsが未指定の場合は紐づけ状態を変更しない', async () => {
@@ -705,7 +744,9 @@ describe('TouringService', () => {
           title: '更新後タイトル',
         })
 
-        expect(fuelLogRepository.findFuelLogs).not.toHaveBeenCalled()
+        expect(
+          fuelLogRepository.findFuelLogsByTouringId
+        ).not.toHaveBeenCalled()
         expect(
           fuelLogRepository.updateMultipleFuelLogsTouringId
         ).not.toHaveBeenCalled()

--- a/apps/web/__tests__/unit/services/TouringService.test.ts
+++ b/apps/web/__tests__/unit/services/TouringService.test.ts
@@ -1,12 +1,15 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import {
+  createFuelLogId,
   createMyUserBikeId,
   createTouringId,
   createTouringPlanId,
   createTouringPlanSpotId,
   createUserId,
+  FuelLog,
   Touring,
 } from '@repo/shared-types'
+import { FuelLogEntity } from '@/lib/api/server/entities/FuelLogEntity'
 import { MyUserBikeEntity } from '@/lib/api/server/entities/MyUserBikeEntity'
 import { SpotEntity } from '@/lib/api/server/entities/SpotEntity'
 import { TouringEntity } from '@/lib/api/server/entities/TouringEntity'
@@ -53,6 +56,22 @@ const buildTouring = (overrides: Partial<Touring> = {}) => {
     endLatitude: null,
     endLongitude: null,
     status: 'STARTED',
+    ...overrides,
+  })
+}
+
+const buildFuelLog = (overrides: Partial<FuelLog> = {}) => {
+  return new FuelLogEntity({
+    fuelLogId: createFuelLogId('fuel-log-1'),
+    myUserBikeId,
+    refueledAt: new Date('2020-07-01T09:00:00.000Z'),
+    mileage: 1050,
+    previousMileage: 1000,
+    amount: 10,
+    totalPrice: 1500,
+    memo: null,
+    touringId: null,
+    touringTitle: null,
     ...overrides,
   })
 }
@@ -592,6 +611,105 @@ describe('TouringService', () => {
       })
 
       expect(result.touringPlanId).toBe('plan-1')
+    })
+
+    describe('fuelLogIdsによる給油履歴の紐づけ更新', () => {
+      test('ツーリング期間外の給油履歴IDを指定しても紐づけできる', async () => {
+        const existing = buildTouring({ status: 'COMPLETED' })
+        vi.mocked(touringRepository.findTouringById).mockResolvedValue(existing)
+        // 期間外のためfindFuelLogsには含まれない（解除対象なし）
+        vi.mocked(fuelLogRepository.findFuelLogs).mockResolvedValue([])
+
+        const outOfRangeFuelLogId = createFuelLogId('fuel-log-out-of-range')
+
+        await service.updateTouring({
+          touringId: existing.id,
+          myUserBikeId,
+          userId,
+          fuelLogIds: [outOfRangeFuelLogId],
+        })
+
+        expect(
+          fuelLogRepository.updateMultipleFuelLogsTouringId
+        ).toHaveBeenCalledWith([outOfRangeFuelLogId], myUserBikeId, existing.id)
+      })
+
+      test('既に他のツーリングに紐づいている給油履歴を指定すると、新しいツーリングへ付け替えられる', async () => {
+        const existing = buildTouring({ status: 'COMPLETED' })
+        vi.mocked(touringRepository.findTouringById).mockResolvedValue(existing)
+        vi.mocked(fuelLogRepository.findFuelLogs).mockResolvedValue([])
+
+        const fuelLogLinkedToOtherTouring = createFuelLogId('fuel-log-other')
+
+        await service.updateTouring({
+          touringId: existing.id,
+          myUserBikeId,
+          userId,
+          fuelLogIds: [fuelLogLinkedToOtherTouring],
+        })
+
+        // 新しいツーリングIDで一括更新される（FKは単一のためこの呼び出しにより旧ツーリングとの紐づけは自動的に解除される）
+        expect(
+          fuelLogRepository.updateMultipleFuelLogsTouringId
+        ).toHaveBeenCalledWith(
+          [fuelLogLinkedToOtherTouring],
+          myUserBikeId,
+          existing.id
+        )
+      })
+
+      test('空配列を渡すと既存の紐づけが全解除される', async () => {
+        const existing = buildTouring({ status: 'COMPLETED' })
+        vi.mocked(touringRepository.findTouringById).mockResolvedValue(existing)
+
+        const linkedFuelLog1 = buildFuelLog({
+          fuelLogId: createFuelLogId('fuel-log-linked-1'),
+          touringId: existing.id,
+        })
+        const linkedFuelLog2 = buildFuelLog({
+          fuelLogId: createFuelLogId('fuel-log-linked-2'),
+          touringId: existing.id,
+        })
+        vi.mocked(fuelLogRepository.findFuelLogs).mockResolvedValue([
+          linkedFuelLog1,
+          linkedFuelLog2,
+        ])
+
+        await service.updateTouring({
+          touringId: existing.id,
+          myUserBikeId,
+          userId,
+          fuelLogIds: [],
+        })
+
+        expect(
+          fuelLogRepository.updateMultipleFuelLogsTouringId
+        ).toHaveBeenCalledTimes(1)
+        expect(
+          fuelLogRepository.updateMultipleFuelLogsTouringId
+        ).toHaveBeenCalledWith(
+          [linkedFuelLog1.id, linkedFuelLog2.id],
+          myUserBikeId,
+          null
+        )
+      })
+
+      test('fuelLogIdsが未指定の場合は紐づけ状態を変更しない', async () => {
+        const existing = buildTouring({ status: 'COMPLETED' })
+        vi.mocked(touringRepository.findTouringById).mockResolvedValue(existing)
+
+        await service.updateTouring({
+          touringId: existing.id,
+          myUserBikeId,
+          userId,
+          title: '更新後タイトル',
+        })
+
+        expect(fuelLogRepository.findFuelLogs).not.toHaveBeenCalled()
+        expect(
+          fuelLogRepository.updateMultipleFuelLogsTouringId
+        ).not.toHaveBeenCalled()
+      })
     })
   })
 

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx
@@ -10,11 +10,13 @@ import { Button } from '@repo/ui/button'
 import { toast } from '@repo/ui/sonner'
 import styles from './page.module.css'
 import { EditIcon } from '@/components/icons/EditIcon'
+import { FuelIcon } from '@/components/icons/FuelIcon'
 import { SpotAddModal } from '@/components/spot/SpotAddModal'
 import { SpotEditModal } from '@/components/spot/SpotEditModal'
 import { RouteTimeline } from '@/components/touring/RouteTimeline'
 import type { RouteTimelineItem } from '@/components/touring/RouteTimeline'
 import { TouringEditModal } from '@/components/touring/TouringEditModal'
+import { TouringFuelLogLinkModal } from '@/components/touring/TouringFuelLogLinkModal'
 import { TouringLocationEditModal } from '@/components/touring/TouringLocationEditModal'
 import TouringRouteMap from '@/components/touring/TouringRouteMap'
 import type { MapPoint } from '@/components/touring/TouringRouteMap'
@@ -33,6 +35,7 @@ function TouringDetailPage() {
   const bikeId = params.id as string
   const touringId = params.touringId as string
   const [isEditModalOpen, setIsEditModalOpen] = useState(false)
+  const [isFuelLogLinkModalOpen, setIsFuelLogLinkModalOpen] = useState(false)
   const [editingLocationTarget, setEditingLocationTarget] = useState<
     'start' | 'end' | null
   >(null)
@@ -501,6 +504,14 @@ function TouringDetailPage() {
               >
                 <EditIcon />
               </button>
+              <button
+                onClick={() => setIsFuelLogLinkModalOpen(true)}
+                className={styles.editButton}
+                aria-label="給油履歴の紐づけ"
+                title="給油履歴の紐づけ"
+              >
+                <FuelIcon />
+              </button>
             </div>
             <p className={`text-xs mt-1 ${styles.mutedText}`}>
               {formatDate(touring.startDate)} → {formatDate(touring.endDate)}
@@ -554,6 +565,15 @@ function TouringDetailPage() {
           touringId={touringId}
           onClose={() => setIsEditModalOpen(false)}
           onSuccess={handleEditSuccess}
+        />
+      )}
+
+      {isFuelLogLinkModalOpen && (
+        <TouringFuelLogLinkModal
+          bikeId={bikeId}
+          touringId={touringId}
+          onClose={() => setIsFuelLogLinkModalOpen(false)}
+          onSuccess={() => setIsFuelLogLinkModalOpen(false)}
         />
       )}
 

--- a/apps/web/components/touring/FuelLogLinkPicker.module.css
+++ b/apps/web/components/touring/FuelLogLinkPicker.module.css
@@ -1,0 +1,70 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-2);
+}
+
+.title {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-ink);
+  margin: 0;
+}
+
+.note {
+  font-size: var(--font-size-xs);
+  color: var(--color-ink);
+  opacity: 0.6;
+  margin: 0;
+}
+
+.loading,
+.empty {
+  font-size: var(--font-size-sm);
+  color: var(--color-ink);
+  opacity: 0.6;
+  margin: 0;
+  padding: var(--spacing-2) 0;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  max-height: 320px;
+  overflow-y: auto;
+  padding-right: var(--spacing-1);
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  padding: var(--spacing-2);
+  border: 1px solid var(--color-cloud);
+  border-radius: var(--radius-sm);
+}
+
+.badge {
+  font-size: var(--font-size-xs);
+  color: var(--color-ink);
+  background-color: var(--color-cloud);
+  border-radius: var(--radius-sm);
+  padding: 2px var(--spacing-2);
+  white-space: nowrap;
+}
+
+.loadMore {
+  display: flex;
+  justify-content: center;
+  padding-top: var(--spacing-2);
+}

--- a/apps/web/components/touring/FuelLogLinkPicker.tsx
+++ b/apps/web/components/touring/FuelLogLinkPicker.tsx
@@ -1,0 +1,190 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import useSWRInfinite from 'swr/infinite'
+import type {
+  ApiResponseFuelLogList,
+  SuccessResponse,
+} from '@repo/shared-types'
+import { formatDateTime } from '@repo/shared-utils'
+import { Button } from '@repo/ui/button'
+import { Checkbox } from '@repo/ui/checkbox'
+import styles from './FuelLogLinkPicker.module.css'
+import { authenticatedFetch } from '@/lib/api/client'
+import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
+
+const PAGE_SIZE = 10
+
+export interface FuelLogLinkPickerProps {
+  /**
+   * 対象バイクのID
+   */
+  bikeId: string
+  /**
+   * 編集中のツーリングID（付け替え判定に使用）
+   */
+  currentTouringId: string
+  /**
+   * 初期選択済みの給油履歴ID一覧
+   */
+  initialSelectedIds: string[]
+  /**
+   * 「期間内のみ表示」時の検索開始日時（ISO文字列）
+   */
+  defaultStartDate: string
+  /**
+   * 「期間内のみ表示」時の検索終了日時（ISO文字列）
+   */
+  defaultEndDate: string
+  /**
+   * 選択状態が変化した際のコールバック
+   */
+  onChange: (selectedIds: string[]) => void
+}
+
+/**
+ * ツーリングに紐づける給油履歴を検索・選択するピッカー
+ *
+ * @remarks
+ * `GET /api/v1/user-bike/bike/:myUserBikeId/fuel-logs` を「もっと見る」形式でページングしながら取得し、
+ * チェックボックスで複数選択できるようにする。
+ * 「期間内のみ表示」トグルがONの場合はツーリング期間（前後2時間）で絞り込み、
+ * OFFの場合は全期間から検索できる。
+ */
+export const FuelLogLinkPicker = ({
+  bikeId,
+  currentTouringId,
+  initialSelectedIds,
+  defaultStartDate,
+  defaultEndDate,
+  onChange,
+}: FuelLogLinkPickerProps) => {
+  const [periodOnly, setPeriodOnly] = useState(true)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(
+    () => new Set(initialSelectedIds)
+  )
+
+  const fetchFuelLogs = async (url: string) => {
+    const response = await authenticatedFetch(url, { method: 'GET' })
+    if (!response.ok) {
+      const errorData = await response.json()
+      throw new ApiV1Error(
+        errorData.errorCode || 'SERVER_ERROR',
+        errorData.message || 'エラーが発生しました'
+      )
+    }
+    const json =
+      (await response.json()) as SuccessResponse<ApiResponseFuelLogList>
+    return json.data
+  }
+
+  const getKey = (pageIndex: number): string => {
+    const params = new URLSearchParams({
+      'sort-by': 'refueled-at',
+      'sort-order': 'desc',
+      'per-size': String(PAGE_SIZE),
+      page: String(pageIndex + 1),
+    })
+    if (periodOnly) {
+      params.set('startDate', defaultStartDate)
+      params.set('endDate', defaultEndDate)
+    }
+    return `/api/v1/user-bike/bike/${bikeId}/fuel-logs?${params.toString()}`
+  }
+
+  const { data, size, setSize, isLoading, isValidating } = useSWRInfinite(
+    getKey,
+    fetchFuelLogs
+  )
+
+  const fuelLogs = useMemo(
+    () => (data ? data.filter(Boolean).flat() : []),
+    [data]
+  )
+  const lastPageCount = data?.[data.length - 1]?.length ?? 0
+  const canLoadMore = lastPageCount === PAGE_SIZE
+  const isLoadingMore = isValidating && !isLoading && size > 0
+
+  const handleToggle = (fuelLogId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(fuelLogId)) {
+        next.delete(fuelLogId)
+      } else {
+        next.add(fuelLogId)
+      }
+      return next
+    })
+  }
+
+  useEffect(() => {
+    onChange(Array.from(selectedIds))
+  }, [selectedIds, onChange])
+
+  const handleTogglePeriodOnly = () => {
+    setPeriodOnly((prev) => !prev)
+    setSize(1)
+  }
+
+  return (
+    <div className={styles.container} data-testid="fuel-log-link-picker">
+      <div className={styles.header}>
+        <p className={styles.title}>紐づける給油履歴</p>
+        <Checkbox
+          id="fuel-log-picker-period-only"
+          label="期間内のみ表示"
+          checked={periodOnly}
+          onChange={handleTogglePeriodOnly}
+        />
+      </div>
+      <p className={styles.note}>
+        給油履歴を選択するとこのツーリングに紐づきます。既に別のツーリングに紐づいている給油履歴を選択すると、元のツーリングから自動的に解除されます。
+      </p>
+
+      {isLoading ? (
+        <p className={styles.loading}>読み込み中...</p>
+      ) : fuelLogs.length === 0 ? (
+        <p className={styles.empty}>
+          {periodOnly
+            ? '期間内に給油履歴が見つかりません。「期間内のみ表示」を解除すると全件から検索できます。'
+            : '給油履歴が見つかりません'}
+        </p>
+      ) : (
+        <div className={styles.list}>
+          {fuelLogs.map((fuelLog) => {
+            const linkedToOtherTouring =
+              fuelLog.touringId !== null &&
+              fuelLog.touringId !== currentTouringId
+
+            return (
+              <div key={fuelLog.fuelLogId} className={styles.item}>
+                <Checkbox
+                  id={`fuel-log-picker-item-${fuelLog.fuelLogId}`}
+                  label={`${formatDateTime(fuelLog.refueledAt)} ${fuelLog.mileage.toLocaleString()}km ${fuelLog.amount.toFixed(1)}L${fuelLog.memo ? ` ${fuelLog.memo}` : ''}`}
+                  checked={selectedIds.has(fuelLog.fuelLogId)}
+                  onChange={() => handleToggle(fuelLog.fuelLogId)}
+                />
+                {linkedToOtherTouring && (
+                  <span className={styles.badge}>
+                    {fuelLog.touringTitle ?? '他のツーリング'}に紐づけ済み
+                  </span>
+                )}
+              </div>
+            )
+          })}
+          {canLoadMore && (
+            <div className={styles.loadMore}>
+              <Button
+                onClick={() => setSize(size + 1)}
+                variant="cloud"
+                loading={isLoadingMore}
+              >
+                もっと見る
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/components/touring/TouringEditForm.tsx
+++ b/apps/web/components/touring/TouringEditForm.tsx
@@ -122,7 +122,7 @@ export function TouringEditForm({
     )
   }
 
-  if (!initialData) return null
+  if (!initialData || !data) return null
 
   return (
     <div

--- a/apps/web/components/touring/TouringFuelLogLinkModal.tsx
+++ b/apps/web/components/touring/TouringFuelLogLinkModal.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import useSWR, { mutate } from 'swr'
+import type {
+  ApiResponseTouringDetail,
+  SuccessResponse,
+} from '@repo/shared-types'
+import { Button } from '@repo/ui/button'
+import { ErrorMessage } from '@repo/ui/errorMessage'
+import { toast } from '@repo/ui/sonner'
+import { FuelLogLinkPicker } from './FuelLogLinkPicker'
+import { ModalBase } from '@/components/common/ModalBase'
+import { authenticatedFetch, apiPatch } from '@/lib/api/client'
+import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
+
+/**
+ * 給油履歴ピッカーの検索範囲をツーリング期間の前後に広げる幅（時間）
+ */
+const FUEL_LOG_PICKER_MARGIN_HOURS = 2
+
+interface TouringFuelLogLinkModalProps {
+  bikeId: string
+  touringId: string
+  onClose: () => void
+  onSuccess: () => void
+}
+
+/**
+ * ツーリングと給油履歴の紐づけを管理するモーダル
+ *
+ * @remarks
+ * ツーリング編集モーダルとは独立して開く。給油履歴の選択のみを行い、
+ * `PATCH /bike/:myUserBikeId/tourings/:touringId` に `fuelLogIds` のみを送信する
+ * （タイトル・日時・走行距離は更新しない）。
+ */
+export function TouringFuelLogLinkModal({
+  bikeId,
+  touringId,
+  onClose,
+  onSuccess,
+}: TouringFuelLogLinkModalProps) {
+  const [selectedFuelLogIds, setSelectedFuelLogIds] = useState<string[]>([])
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  const detailUrl = `/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}`
+
+  const { data, isLoading } = useSWR(detailUrl, async (url) => {
+    const response = await authenticatedFetch(url, { method: 'GET' })
+    if (!response.ok) {
+      const errorData = await response.json()
+      throw new ApiV1Error(
+        errorData.errorCode || 'SERVER_ERROR',
+        errorData.message || 'エラーが発生しました'
+      )
+    }
+    const json =
+      (await response.json()) as SuccessResponse<ApiResponseTouringDetail>
+    return json.data
+  })
+
+  useEffect(() => {
+    if (data) {
+      setSelectedFuelLogIds(data.fuelLogIds)
+    }
+  }, [data])
+
+  const handleSubmit = async () => {
+    setError('')
+    setIsSubmitting(true)
+
+    try {
+      await apiPatch(`/api/v1/user-bike/bike/${bikeId}/tourings/${touringId}`, {
+        fuelLogIds: selectedFuelLogIds,
+      })
+
+      await mutate(detailUrl)
+      await mutate(
+        `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=start-date&sort-order=desc`
+      )
+      toast.success('給油履歴の紐づけを更新しました')
+      onSuccess()
+    } catch (err) {
+      setError(err instanceof ApiV1Error ? err.message : 'エラーが発生しました')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <ModalBase title="給油履歴の紐づけ" onClose={onClose}>
+      {isLoading || !data ? (
+        <p>読み込み中...</p>
+      ) : (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--spacing-4)',
+          }}
+        >
+          <FuelLogLinkPicker
+            bikeId={bikeId}
+            currentTouringId={touringId}
+            initialSelectedIds={data.fuelLogIds}
+            defaultStartDate={shiftIsoDate(
+              data.startDate,
+              -FUEL_LOG_PICKER_MARGIN_HOURS
+            )}
+            defaultEndDate={shiftIsoDate(
+              data.endDate,
+              FUEL_LOG_PICKER_MARGIN_HOURS
+            )}
+            onChange={setSelectedFuelLogIds}
+          />
+
+          {error && <ErrorMessage>{error}</ErrorMessage>}
+
+          <div style={{ display: 'flex', gap: 'var(--spacing-2)' }}>
+            <Button
+              type="button"
+              onClick={onClose}
+              variant="cloud"
+              disabled={isSubmitting}
+              fullWidth
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              loading={isSubmitting}
+              fullWidth
+            >
+              紐づける
+            </Button>
+          </div>
+        </div>
+      )}
+    </ModalBase>
+  )
+}
+
+/**
+ * ISO日時文字列を指定時間だけシフトする
+ */
+function shiftIsoDate(isoDate: string, hours: number): string {
+  return new Date(
+    new Date(isoDate).getTime() + hours * 60 * 60 * 1000
+  ).toISOString()
+}

--- a/apps/web/lib/api/server/interfaces/IFuelLogRepository.ts
+++ b/apps/web/lib/api/server/interfaces/IFuelLogRepository.ts
@@ -12,6 +12,13 @@ export interface IFuelLogRepository {
     fuelLogId: FuelLogId,
     myUserBikeId: MyUserBikeId
   ): Promise<FuelLogEntity | null>
+  /**
+   * 指定したツーリングに紐づく給油履歴を、給油日時の範囲によらず全件取得する
+   */
+  findFuelLogsByTouringId(
+    touringId: TouringId,
+    myUserBikeId: MyUserBikeId
+  ): Promise<FuelLogEntity[]>
   updateFuelLog(fuelLog: FuelLogEntity): Promise<FuelLogEntity>
   deleteFuelLog(fuelLogId: FuelLogId, myUserBikeId: MyUserBikeId): Promise<void>
   updateFuelLogTouringId(

--- a/apps/web/lib/api/server/repositories/PrismaFuelLogRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaFuelLogRepository.ts
@@ -206,6 +206,50 @@ export class PrismaFuelLogRepository
     )
   }
 
+  async findFuelLogsByTouringId(
+    touringId: TouringId,
+    myUserBikeId: MyUserBikeId
+  ): Promise<FuelLogEntity[]> {
+    const fuelLogs = await this.connection.tUserMyBikeFuelLog.findMany({
+      where: {
+        touringId: touringId,
+        userMyBikeId: myUserBikeId,
+      },
+      select: {
+        id: true,
+        userMyBikeId: true,
+        amount: true,
+        price: true,
+        mileage: true,
+        previousMileage: true,
+        refueledAt: true,
+        memo: true,
+        touringId: true,
+        touring: {
+          select: {
+            title: true,
+          },
+        },
+      },
+    })
+
+    return fuelLogs.map(
+      (log) =>
+        new FuelLogEntity({
+          fuelLogId: createFuelLogId(log.id),
+          myUserBikeId: createMyUserBikeId(log.userMyBikeId),
+          amount: log.amount,
+          totalPrice: log.price,
+          mileage: log.mileage,
+          previousMileage: log.previousMileage,
+          refueledAt: log.refueledAt,
+          memo: log.memo,
+          touringId: log.touringId ? createTouringId(log.touringId) : null,
+          touringTitle: log.touring?.title ?? null,
+        })
+    )
+  }
+
   async findFuelLogById(
     fuelLogId: FuelLogId,
     myUserBikeId: MyUserBikeId

--- a/apps/web/lib/api/server/services/TouringService.ts
+++ b/apps/web/lib/api/server/services/TouringService.ts
@@ -19,7 +19,6 @@ import { ISpotRepository } from '../interfaces/ISpotRepository'
 import { ITouringPlanRepository } from '../interfaces/ITouringPlanRepository'
 import { ITouringPlanSpotRepository } from '../interfaces/ITouringPlanSpotRepository'
 import { ITouringRepository } from '../interfaces/ITouringRepository'
-import { FuelLogSearchParams } from '../valueObjects/FuelLogSearchParams'
 import { TouringSearchParams } from '../valueObjects/TouringSearchParams'
 import { computeTouringPlanSpotTimes } from './computeTouringPlanSpotTimes'
 
@@ -484,22 +483,16 @@ export class TouringService {
 
       // 給油履歴の紐づけ更新
       if (params.fuelLogIds !== undefined) {
-        // 既存の紐づけを解除
-        const searchParams = new FuelLogSearchParams({
-          startDate: updatedTouring.startDate,
-          endDate: updatedTouring.endDate,
-        })
-        const existingFuelLogs = await this.fuelLogRepository.findFuelLogs(
-          params.myUserBikeId,
-          searchParams
-        )
+        // 既存の紐づけを解除（給油日時がツーリング期間外でも解除対象に含めるため、
+        // 期間で絞り込まずtouringIdで直接紐づいている給油履歴を全件取得する）
+        const existingFuelLogs =
+          await this.fuelLogRepository.findFuelLogsByTouringId(
+            params.touringId,
+            params.myUserBikeId
+          )
 
         const existingFuelLogIdsToUnlink = existingFuelLogs
-          .filter(
-            (log) =>
-              log.touringId === params.touringId &&
-              !params.fuelLogIds!.includes(log.id)
-          )
+          .filter((log) => !params.fuelLogIds!.includes(log.id))
           .map((log) => log.id)
 
         if (existingFuelLogIdsToUnlink.length > 0) {


### PR DESCRIPTION
## 概要
ツーリング中のクイックアクセス給油記録は自動でツーリングに紐づく一方、ツーリング終了後に別途追加した給油記録は紐づけられない問題を解消する。ツーリング詳細ページに「給油履歴の紐づけ」専用モーダルを新設し、期間検索（前後2時間/全件表示切替）で給油履歴を検索・複数選択して手動で紐づけ・解除できるようにした。

## 変更内容

### 給油履歴紐づけ機能
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `apps/web/components/touring/TouringFuelLogLinkModal.tsx` | 追加 | 給油履歴の紐づけ専用モーダル。`fuelLogIds`のみをPATCHし、タイトル・日時・走行距離は変更しない |
| `apps/web/components/touring/FuelLogLinkPicker.tsx` / `.module.css` | 追加 | 給油履歴の検索・複数選択ピッカー。期間フィルタ（デフォルト: ツーリング期間の前後2時間）・「期間内のみ表示/全件表示」トグル・ページング（もっと見る）・他ツーリング紐づけ済みバッジ表示に対応 |
| `apps/web/app/app/(protected)/my-bike/[id]/tourings/[touringId]/page.tsx` | 修正 | ツーリング詳細ページに「給油履歴の紐づけ」ボタンとモーダル起動を追加 |
| `apps/web/components/touring/TouringEditForm.tsx` | 修正 | 紐づけUIをツーリング編集モーダルとは独立させたため、元のタイトル・日時・走行距離編集のみの構成に戻した |

バックエンド（`TouringUpdateRequestSchema.fuelLogIds` / `TouringService.updateTouring()` の一括紐づけ・解除ロジック）は既に実装済みのため変更なし。

### テスト
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `apps/web/__tests__/unit/services/TouringService.test.ts` | 修正 | `fuelLogIds`更新ロジックのユニットテストを4件追加（期間外紐づけ・付け替え・全解除・未指定時の非変更） |
| `apps/e2e/helpers/fuelLogHelper.ts` | 追加 | 給油履歴登録用E2Eヘルパー |
| `apps/e2e/helpers/touringHelper.ts` | 修正 | 任意の開始/終了日時で完了済みツーリングを登録する`registerTestTouring`を追加 |
| `apps/e2e/pages/touringDetailPage.ts` | 追加 | ツーリング詳細ページのPage Object Model |
| `apps/e2e/tests/touring/touringFuelLogLink.spec.ts` | 追加 | 紐づけ・解除・「全件表示」での期間外検索のE2Eテスト（3ケース） |

## 影響範囲
- ツーリング詳細ページ（ボタン追加・新規モーダル）
- ツーリング編集モーダル（紐づけUIを分離し元の構成に戻したのみで機能変更なし）
- 給油履歴一覧・詳細表示、クイックアクセスからの自動紐づけへの影響なし

## テストプラン
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `NODE_ENV=production pnpm build`
- [x] `TouringService`のユニットテスト（26件）
- [x] Playwright MCPによる実機検証（開発サーバー・Firebase Emulator・DB使用、紐づけ・再確認・期間トグル・解除操作でコンソールエラー0件を確認）
- [ ] `apps/e2e`の自動E2Eテスト実行（Firebase Emulator/DB起動環境での`pnpm exec playwright test tests/touring/touringFuelLogLink.spec.ts`は未実施のため、レビュー時に実行を推奨）

Closes #461