### PR TITLE
登録データ（ツーリング・給油履歴・メンテナンス履歴）のキーワード検索機能を追加

### DIFF
--- a/apps/e2e/fixtures/authenticatedPage.ts
+++ b/apps/e2e/fixtures/authenticatedPage.ts
@@ -1,8 +1,8 @@
 import { expect, test as base, type Page } from '@playwright/test'
 import { createTestUserAndGetToken } from '../helpers/authHelper'
 import { createRandomEmail } from '../helpers/createRandomEmail'
+import { BASE_URL } from '../helpers/env'
 
-const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
 const TEST_PASSWORD = 'password123'
 
 type AuthenticatedFixtures = {

--- a/apps/e2e/helpers/apiKeyHelper.ts
+++ b/apps/e2e/helpers/apiKeyHelper.ts
@@ -1,4 +1,4 @@
-const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
+import { BASE_URL } from './env'
 
 /**
  * API 経由でテスト用 MCP APIキーを発行し、apiKeyId を返す

--- a/apps/e2e/helpers/bikeHelper.ts
+++ b/apps/e2e/helpers/bikeHelper.ts
@@ -1,4 +1,4 @@
-const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
+import { BASE_URL } from './env'
 
 /**
  * API 経由でテスト用バイクを登録し、myUserBikeId を返す

--- a/apps/e2e/helpers/env.ts
+++ b/apps/e2e/helpers/env.ts
@@ -1,0 +1,2 @@
+export const BASE_URL =
+  process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'

--- a/apps/e2e/helpers/fuelLogHelper.ts
+++ b/apps/e2e/helpers/fuelLogHelper.ts
@@ -1,4 +1,4 @@
-const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
+import { BASE_URL } from './env'
 
 /**
  * API経由で給油履歴を登録し、fuelLogId を返す

--- a/apps/e2e/helpers/maintenanceLogHelper.ts
+++ b/apps/e2e/helpers/maintenanceLogHelper.ts
@@ -1,0 +1,46 @@
+const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
+
+/**
+ * API経由でメンテナンス履歴を登録し、maintenanceLogId を返す
+ */
+export async function registerTestMaintenanceLog(
+  token: string,
+  myUserBikeId: string,
+  maintenanceLog: {
+    performedAt: string
+    mileage: number
+    memo?: string
+    maintenanceType?: string
+  }
+): Promise<string> {
+  const res = await fetch(
+    `${BASE_URL}/api/v1/user-bike/bike/${myUserBikeId}/maintenance-logs`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        performedAt: maintenanceLog.performedAt,
+        mileage: maintenanceLog.mileage,
+        memo: maintenanceLog.memo ?? null,
+        items: [
+          {
+            maintenanceType: maintenanceLog.maintenanceType ?? 'ENGINE_OIL',
+            value: 1,
+          },
+        ],
+        updateTotalMileage: false,
+      }),
+      signal: AbortSignal.timeout(30_000),
+    }
+  )
+  if (!res.ok) {
+    throw new Error(
+      `メンテナンス履歴登録失敗: ${res.status} ${await res.text()}`
+    )
+  }
+  const json = (await res.json()) as { data: { maintenanceLogId: string } }
+  return json.data.maintenanceLogId
+}

--- a/apps/e2e/helpers/maintenanceLogHelper.ts
+++ b/apps/e2e/helpers/maintenanceLogHelper.ts
@@ -1,4 +1,4 @@
-const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
+import { BASE_URL } from './env'
 
 /**
  * API経由でメンテナンス履歴を登録し、maintenanceLogId を返す

--- a/apps/e2e/helpers/spotHelper.ts
+++ b/apps/e2e/helpers/spotHelper.ts
@@ -1,4 +1,4 @@
-const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
+import { BASE_URL } from './env'
 
 /**
  * API経由でツーリングにスポット・休憩を登録し、spotId を返す

--- a/apps/e2e/helpers/touringHelper.ts
+++ b/apps/e2e/helpers/touringHelper.ts
@@ -1,4 +1,4 @@
-const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
+import { BASE_URL } from './env'
 
 /**
  * API経由でツーリングを開始し、touringId を返す

--- a/apps/e2e/helpers/touringPlanHelper.ts
+++ b/apps/e2e/helpers/touringPlanHelper.ts
@@ -1,4 +1,4 @@
-const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
+import { BASE_URL } from './env'
 
 type TouringPlanLocation = {
   latitude: number

--- a/apps/e2e/pages/fuelLogListPage.ts
+++ b/apps/e2e/pages/fuelLogListPage.ts
@@ -1,0 +1,54 @@
+import { type Locator, type Page } from '@playwright/test'
+
+/**
+ * 給油履歴一覧ページの Page Object Model
+ *
+ * @remarks
+ * /app/my-bike/{bikeId}/fuel-logs に対応。
+ */
+export class FuelLogListPage {
+  readonly page: Page
+  readonly searchSection: Locator
+  readonly searchInput: Locator
+  readonly searchButton: Locator
+  readonly clearButton: Locator
+  readonly noResultMessage: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.searchSection = page.getByTestId('fuel-log-search')
+    this.searchInput = this.searchSection.getByRole('textbox', {
+      name: 'メモ・ツーリング名で検索',
+    })
+    this.searchButton = this.searchSection.getByRole('button', {
+      name: '検索',
+    })
+    this.clearButton = this.searchSection.getByRole('button', {
+      name: 'クリア',
+    })
+    this.noResultMessage = page.getByText(
+      '該当する給油履歴が見つかりませんでした'
+    )
+  }
+
+  /** 給油履歴一覧ページへ遷移する */
+  async goto(bikeId: string): Promise<void> {
+    await this.page.goto(`/app/my-bike/${bikeId}/fuel-logs`)
+  }
+
+  /** キーワードを入力して検索を実行する */
+  async searchByKeyword(keyword: string): Promise<void> {
+    await this.searchInput.fill(keyword)
+    await this.searchButton.click()
+  }
+
+  /** 検索条件をクリアする */
+  async clearSearch(): Promise<void> {
+    await this.clearButton.click()
+  }
+
+  /** メモ・給油量等（部分一致可）で給油履歴カードを取得する */
+  fuelLogCard(pattern: string | RegExp): Locator {
+    return this.page.getByRole('button', { name: pattern })
+  }
+}

--- a/apps/e2e/pages/maintenanceLogListPage.ts
+++ b/apps/e2e/pages/maintenanceLogListPage.ts
@@ -1,0 +1,54 @@
+import { type Locator, type Page } from '@playwright/test'
+
+/**
+ * メンテナンス履歴一覧ページの Page Object Model
+ *
+ * @remarks
+ * /app/my-bike/{bikeId}/maintenance-logs に対応（日付順ビュー）。
+ */
+export class MaintenanceLogListPage {
+  readonly page: Page
+  readonly searchSection: Locator
+  readonly searchInput: Locator
+  readonly searchButton: Locator
+  readonly clearButton: Locator
+  readonly noResultMessage: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.searchSection = page.getByTestId('maintenance-log-search')
+    this.searchInput = this.searchSection.getByRole('textbox', {
+      name: 'メモで検索',
+    })
+    this.searchButton = this.searchSection.getByRole('button', {
+      name: '検索',
+    })
+    this.clearButton = this.searchSection.getByRole('button', {
+      name: 'クリア',
+    })
+    this.noResultMessage = page.getByText(
+      '該当するメンテナンス履歴が見つかりませんでした'
+    )
+  }
+
+  /** メンテナンス履歴一覧ページへ遷移する */
+  async goto(bikeId: string): Promise<void> {
+    await this.page.goto(`/app/my-bike/${bikeId}/maintenance-logs`)
+  }
+
+  /** キーワードを入力して検索を実行する */
+  async searchByKeyword(keyword: string): Promise<void> {
+    await this.searchInput.fill(keyword)
+    await this.searchButton.click()
+  }
+
+  /** 検索条件をクリアする */
+  async clearSearch(): Promise<void> {
+    await this.clearButton.click()
+  }
+
+  /** メモ等（部分一致可）でメンテナンス履歴カードを取得する */
+  maintenanceLogCard(pattern: string | RegExp): Locator {
+    return this.page.getByRole('button', { name: pattern })
+  }
+}

--- a/apps/e2e/pages/touringListPage.ts
+++ b/apps/e2e/pages/touringListPage.ts
@@ -1,0 +1,54 @@
+import { type Locator, type Page } from '@playwright/test'
+
+/**
+ * ツーリング一覧ページの Page Object Model
+ *
+ * @remarks
+ * /app/my-bike/{bikeId}/tourings に対応。
+ */
+export class TouringListPage {
+  readonly page: Page
+  readonly searchSection: Locator
+  readonly searchInput: Locator
+  readonly searchButton: Locator
+  readonly clearButton: Locator
+  readonly noResultMessage: Locator
+
+  constructor(page: Page) {
+    this.page = page
+    this.searchSection = page.getByTestId('touring-search')
+    this.searchInput = this.searchSection.getByRole('textbox', {
+      name: 'タイトルで検索',
+    })
+    this.searchButton = this.searchSection.getByRole('button', {
+      name: '検索',
+    })
+    this.clearButton = this.searchSection.getByRole('button', {
+      name: 'クリア',
+    })
+    this.noResultMessage = page.getByText(
+      '該当するツーリングが見つかりませんでした'
+    )
+  }
+
+  /** ツーリング一覧ページへ遷移する */
+  async goto(bikeId: string): Promise<void> {
+    await this.page.goto(`/app/my-bike/${bikeId}/tourings`)
+  }
+
+  /** キーワードを入力して検索を実行する */
+  async searchByKeyword(keyword: string): Promise<void> {
+    await this.searchInput.fill(keyword)
+    await this.searchButton.click()
+  }
+
+  /** 検索条件をクリアする */
+  async clearSearch(): Promise<void> {
+    await this.clearButton.click()
+  }
+
+  /** タイトル（部分一致可）でツーリングカードを取得する */
+  touringCard(titlePattern: string | RegExp): Locator {
+    return this.page.getByRole('button', { name: titlePattern })
+  }
+}

--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -7,6 +7,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 dotenv.config({ path: path.resolve(__dirname, '../../.env.local') })
 
+// helpers/env.ts を import すると dotenv.config() より先に評価されてしまうため、
+// ここだけは BASE_URL を独自に算出する
 const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
 const isCI = !!process.env['CI']
 

--- a/apps/e2e/tests/auth/login.spec.ts
+++ b/apps/e2e/tests/auth/login.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from '@playwright/test'
 import { createTestUserAndGetToken } from '../../helpers/authHelper'
 import { createRandomEmail } from '../../helpers/createRandomEmail'
+import { BASE_URL } from '../../helpers/env'
 import { HomePage } from '../../pages/homePage'
 import { LoginPage } from '../../pages/loginPage'
 
 const TEST_PASSWORD = 'password123'
-const BASE_URL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3000'
 
 /**
  * ログインフロー E2E テスト

--- a/apps/e2e/tests/fuel-log/fuelLogSearch.spec.ts
+++ b/apps/e2e/tests/fuel-log/fuelLogSearch.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '../../fixtures/authenticatedPage'
+import { registerTestBike } from '../../helpers/bikeHelper'
+import { registerTestFuelLog } from '../../helpers/fuelLogHelper'
+import { FuelLogListPage } from '../../pages/fuelLogListPage'
+
+test.describe('給油履歴一覧 - キーワード検索', () => {
+  test('メモの部分一致で絞り込める', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '給油検索テスト',
+    })
+    await registerTestFuelLog(authToken, myUserBikeId, {
+      refueledAt: new Date().toISOString(),
+      mileage: 10100,
+      previousMileage: 10000,
+      memo: 'E2E ENEOSで給油',
+    })
+    await registerTestFuelLog(authToken, myUserBikeId, {
+      refueledAt: new Date().toISOString(),
+      mileage: 10200,
+      previousMileage: 10100,
+      memo: 'E2E 出光で給油',
+    })
+
+    const fuelLogListPage = new FuelLogListPage(page)
+    await fuelLogListPage.goto(myUserBikeId)
+
+    await expect(fuelLogListPage.fuelLogCard(/E2E ENEOSで給油/)).toBeVisible()
+    await expect(fuelLogListPage.fuelLogCard(/E2E 出光で給油/)).toBeVisible()
+
+    await fuelLogListPage.searchByKeyword('ENEOS')
+
+    await expect(fuelLogListPage.fuelLogCard(/E2E ENEOSで給油/)).toBeVisible()
+    await expect(
+      fuelLogListPage.fuelLogCard(/E2E 出光で給油/)
+    ).not.toBeVisible()
+  })
+
+  test('該当する給油履歴がない場合は空状態メッセージが表示される', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '給油検索該当なしテスト',
+    })
+    await registerTestFuelLog(authToken, myUserBikeId, {
+      refueledAt: new Date().toISOString(),
+      mileage: 10100,
+      previousMileage: 10000,
+      memo: 'E2E検索対象外給油',
+    })
+
+    const fuelLogListPage = new FuelLogListPage(page)
+    await fuelLogListPage.goto(myUserBikeId)
+    await fuelLogListPage.searchByKeyword('存在しないキーワード')
+
+    await expect(fuelLogListPage.noResultMessage).toBeVisible()
+  })
+
+  test('クリアボタンで検索条件を解除できる', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: '給油検索クリアテスト',
+    })
+    await registerTestFuelLog(authToken, myUserBikeId, {
+      refueledAt: new Date().toISOString(),
+      mileage: 10100,
+      previousMileage: 10000,
+      memo: 'E2Eクリア確認給油',
+    })
+
+    const fuelLogListPage = new FuelLogListPage(page)
+    await fuelLogListPage.goto(myUserBikeId)
+    await fuelLogListPage.searchByKeyword('存在しないキーワード')
+    await expect(fuelLogListPage.noResultMessage).toBeVisible()
+
+    await fuelLogListPage.clearSearch()
+    await expect(fuelLogListPage.fuelLogCard(/E2Eクリア確認給油/)).toBeVisible()
+  })
+})

--- a/apps/e2e/tests/maintenance-log/maintenanceLogSearch.spec.ts
+++ b/apps/e2e/tests/maintenance-log/maintenanceLogSearch.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '../../fixtures/authenticatedPage'
+import { registerTestBike } from '../../helpers/bikeHelper'
+import { registerTestMaintenanceLog } from '../../helpers/maintenanceLogHelper'
+import { MaintenanceLogListPage } from '../../pages/maintenanceLogListPage'
+
+test.describe('メンテナンス履歴一覧 - キーワード検索', () => {
+  test('メモの部分一致で絞り込める', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: 'メンテナンス検索テスト',
+    })
+    await registerTestMaintenanceLog(authToken, myUserBikeId, {
+      performedAt: new Date().toISOString(),
+      mileage: 10100,
+      memo: 'E2Eエンジンオイル交換',
+    })
+    await registerTestMaintenanceLog(authToken, myUserBikeId, {
+      performedAt: new Date().toISOString(),
+      mileage: 10200,
+      memo: 'E2Eチェーン注油',
+    })
+
+    const maintenanceLogListPage = new MaintenanceLogListPage(page)
+    await maintenanceLogListPage.goto(myUserBikeId)
+
+    await expect(
+      maintenanceLogListPage.maintenanceLogCard(/E2Eエンジンオイル交換/)
+    ).toBeVisible()
+    await expect(
+      maintenanceLogListPage.maintenanceLogCard(/E2Eチェーン注油/)
+    ).toBeVisible()
+
+    await maintenanceLogListPage.searchByKeyword('注油')
+
+    await expect(
+      maintenanceLogListPage.maintenanceLogCard(/E2Eチェーン注油/)
+    ).toBeVisible()
+    await expect(
+      maintenanceLogListPage.maintenanceLogCard(/E2Eエンジンオイル交換/)
+    ).not.toBeVisible()
+  })
+
+  test('該当するメンテナンス履歴がない場合は空状態メッセージが表示される', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: 'メンテナンス検索該当なしテスト',
+    })
+    await registerTestMaintenanceLog(authToken, myUserBikeId, {
+      performedAt: new Date().toISOString(),
+      mileage: 10100,
+      memo: 'E2E検索対象外メンテナンス',
+    })
+
+    const maintenanceLogListPage = new MaintenanceLogListPage(page)
+    await maintenanceLogListPage.goto(myUserBikeId)
+    await maintenanceLogListPage.searchByKeyword('存在しないキーワード')
+
+    await expect(maintenanceLogListPage.noResultMessage).toBeVisible()
+  })
+
+  test('クリアボタンで検索条件を解除できる', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: 'メンテナンス検索クリアテスト',
+    })
+    await registerTestMaintenanceLog(authToken, myUserBikeId, {
+      performedAt: new Date().toISOString(),
+      mileage: 10100,
+      memo: 'E2Eクリア確認メンテナンス',
+    })
+
+    const maintenanceLogListPage = new MaintenanceLogListPage(page)
+    await maintenanceLogListPage.goto(myUserBikeId)
+    await maintenanceLogListPage.searchByKeyword('存在しないキーワード')
+    await expect(maintenanceLogListPage.noResultMessage).toBeVisible()
+
+    await maintenanceLogListPage.clearSearch()
+    await expect(
+      maintenanceLogListPage.maintenanceLogCard(/E2Eクリア確認メンテナンス/)
+    ).toBeVisible()
+  })
+})

--- a/apps/e2e/tests/touring/touringSearch.spec.ts
+++ b/apps/e2e/tests/touring/touringSearch.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '../../fixtures/authenticatedPage'
+import { registerTestBike } from '../../helpers/bikeHelper'
+import { registerTestTouring } from '../../helpers/touringHelper'
+import { TouringListPage } from '../../pages/touringListPage'
+
+test.describe('ツーリング一覧 - キーワード検索', () => {
+  test('タイトルの部分一致で絞り込める', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: 'ツーリング検索テスト',
+    })
+    await registerTestTouring(authToken, myUserBikeId, {
+      title: 'E2E房総半島ツーリング',
+      startDate: new Date().toISOString(),
+      endDate: new Date().toISOString(),
+    })
+    await registerTestTouring(authToken, myUserBikeId, {
+      title: 'E2E富士山周辺ドライブ',
+      startDate: new Date().toISOString(),
+      endDate: new Date().toISOString(),
+    })
+
+    const touringListPage = new TouringListPage(page)
+    await touringListPage.goto(myUserBikeId)
+
+    await expect(
+      touringListPage.touringCard(/E2E房総半島ツーリング/)
+    ).toBeVisible()
+    await expect(
+      touringListPage.touringCard(/E2E富士山周辺ドライブ/)
+    ).toBeVisible()
+
+    await touringListPage.searchByKeyword('房総')
+
+    await expect(
+      touringListPage.touringCard(/E2E房総半島ツーリング/)
+    ).toBeVisible()
+    await expect(
+      touringListPage.touringCard(/E2E富士山周辺ドライブ/)
+    ).not.toBeVisible()
+  })
+
+  test('該当するツーリングがない場合は空状態メッセージが表示される', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: 'ツーリング検索該当なしテスト',
+    })
+    await registerTestTouring(authToken, myUserBikeId, {
+      title: 'E2E検索対象外ツーリング',
+      startDate: new Date().toISOString(),
+      endDate: new Date().toISOString(),
+    })
+
+    const touringListPage = new TouringListPage(page)
+    await touringListPage.goto(myUserBikeId)
+    await touringListPage.searchByKeyword('存在しないキーワード')
+
+    await expect(touringListPage.noResultMessage).toBeVisible()
+  })
+
+  test('クリアボタンで検索条件を解除できる', async ({
+    authenticatedPage: page,
+    authToken,
+  }) => {
+    const myUserBikeId = await registerTestBike(authToken, {
+      nickname: 'ツーリング検索クリアテスト',
+    })
+    await registerTestTouring(authToken, myUserBikeId, {
+      title: 'E2Eクリア確認ツーリング',
+      startDate: new Date().toISOString(),
+      endDate: new Date().toISOString(),
+    })
+
+    const touringListPage = new TouringListPage(page)
+    await touringListPage.goto(myUserBikeId)
+    await touringListPage.searchByKeyword('存在しないキーワード')
+    await expect(touringListPage.noResultMessage).toBeVisible()
+
+    await touringListPage.clearSearch()
+    await expect(
+      touringListPage.touringCard(/E2Eクリア確認ツーリング/)
+    ).toBeVisible()
+  })
+})

--- a/apps/web/__tests__/api/v1/maintenanceLog.test.ts
+++ b/apps/web/__tests__/api/v1/maintenanceLog.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto'
 import { beforeEach, describe, expect, test } from 'vitest'
 import { createTestUser, testAuthRequired } from '../../helpers/authHelper'
 import { createTestUserBike } from '../../helpers/bikeHelper'
@@ -125,6 +126,170 @@ describe('Maintenance Log API Endpoints', () => {
       expect(json.message).toBe('メンテナンス履歴登録成功')
       expect(json.data.maintenanceLogId).toBeDefined()
       expect(json.data.items).toHaveLength(2)
+    })
+  })
+
+  describe('GET /api/v1/user-bike/bike/:myUserBikeId/maintenance-logs', () => {
+    beforeEach(async () => {
+      await createTestMaintenanceLog(token, myUserBikeId, {
+        performedAt: '2024-01-01T10:00:00.000Z',
+        mileage: 10500,
+        memo: 'エンジンオイル交換',
+        items: [{ maintenanceType: 'ENGINE_OIL', value: 1 }],
+      })
+      await createTestMaintenanceLog(token, myUserBikeId, {
+        performedAt: '2024-02-01T10:00:00.000Z',
+        mileage: 11000,
+        memo: 'チェーン注油',
+        items: [{ maintenanceType: 'DRIVE_CHAIN', value: 1 }],
+      })
+      await createTestMaintenanceLog(token, myUserBikeId, {
+        performedAt: '2024-03-01T10:00:00.000Z',
+        mileage: 11500,
+        items: [{ maintenanceType: 'FRONT_TIRE', value: 1 }],
+      })
+    })
+
+    test('Authorizationヘッダーが未指定の場合にエラーとなる', async () => {
+      await testAuthRequired(
+        `/api/v1/user-bike/bike/${myUserBikeId}/maintenance-logs`,
+        'GET'
+      )
+    })
+
+    test('存在しないバイクIDの場合は404となる', async () => {
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${randomUUID()}/maintenance-logs`,
+        {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(404)
+      expect404Error(json)
+    })
+
+    test('メンテナンス履歴一覧を取得できる（デフォルトパラメータ）', async () => {
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${myUserBikeId}/maintenance-logs`,
+        {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(200)
+      expect(json.status).toBe('success')
+      expect(json.message).toBe('メンテナンス履歴一覧取得成功')
+      expect(Array.isArray(json.data)).toBe(true)
+      expect(json.data.length).toBe(3)
+      expect(json.data[0].performedAt).toBe('2024-03-01T10:00:00.000Z')
+      expect(json.data[2].performedAt).toBe('2024-01-01T10:00:00.000Z')
+    })
+
+    test('メンテナンス履歴が0件の場合は空配列を返す', async () => {
+      const bike = await createTestUserBike(token, {
+        displacement: 125,
+        nickname: 'メンテナンス履歴なしバイク',
+        totalMileage: 100,
+      })
+
+      const res = await app.request(
+        `/api/v1/user-bike/bike/${bike.myUserBikeId}/maintenance-logs`,
+        {
+          method: 'GET',
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      )
+
+      const json = await res.json()
+      expect(res.status).toBe(200)
+      expect(json.data).toEqual([])
+    })
+
+    describe('キーワード検索機能', () => {
+      test('メモの部分一致でメンテナンス履歴を検索できる', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/maintenance-logs?keyword=${encodeURIComponent('オイル')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(1)
+        expect(json.data[0].memo).toBe('エンジンオイル交換')
+      })
+
+      test('大文字小文字を区別せず検索できる', async () => {
+        await createTestMaintenanceLog(token, myUserBikeId, {
+          performedAt: '2024-04-01T10:00:00.000Z',
+          mileage: 12000,
+          memo: 'REAR SHOCK点検',
+          items: [{ maintenanceType: 'LIGHT', value: null }],
+        })
+
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/maintenance-logs?keyword=${encodeURIComponent('rear shock')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(1)
+        expect(json.data[0].memo).toBe('REAR SHOCK点検')
+      })
+
+      test('前後の空白はトリムされて検索される', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/maintenance-logs?keyword=${encodeURIComponent('  オイル  ')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(1)
+      })
+
+      test('該当データがない場合は空配列を返す', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/maintenance-logs?keyword=${encodeURIComponent('存在しないキーワード')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data).toEqual([])
+      })
+
+      test('既存のページネーション・ソートと併用できる', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/maintenance-logs?keyword=${encodeURIComponent('注油')}&sort-order=asc&page=1&per-size=10`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(1)
+        expect(json.data[0].memo).toBe('チェーン注油')
+      })
     })
   })
 

--- a/apps/web/__tests__/api/v1/userBike.test.ts
+++ b/apps/web/__tests__/api/v1/userBike.test.ts
@@ -1925,6 +1925,142 @@ describe('UserBike API Endpoints', () => {
         }
       })
     })
+
+    describe('キーワード検索機能', () => {
+      let touringId: string
+
+      beforeEach(async () => {
+        touringId = await createTestTouring(token, myUserBikeId, {
+          title: '房総半島ツーリング',
+          startDate: '2024-06-05T00:00:00.000Z',
+          endDate: '2024-06-05T00:00:00.000Z',
+        })
+
+        await createTestFuelLog(token, myUserBikeId, {
+          refueledAt: '2024-06-01T10:00:00.000Z',
+          mileage: 3500,
+          amount: 10.0,
+          totalPrice: 1500,
+          memo: 'ENEOSで給油しました',
+        })
+        await createTestFuelLog(token, myUserBikeId, {
+          refueledAt: '2024-06-02T10:00:00.000Z',
+          mileage: 3600,
+          amount: 10.0,
+          totalPrice: 1500,
+          memo: '出光スタンドで給油',
+        })
+        await createTestFuelLog(token, myUserBikeId, {
+          refueledAt: '2024-06-06T10:00:00.000Z',
+          mileage: 3700,
+          amount: 10.0,
+          totalPrice: 1500,
+          touringId,
+        })
+      })
+
+      test('メモの部分一致で給油履歴を検索できる', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/fuel-logs?keyword=${encodeURIComponent('ENEOS')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(1)
+        expect(json.data[0].memo).toBe('ENEOSで給油しました')
+      })
+
+      test('大文字小文字を区別せず検索できる', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/fuel-logs?keyword=${encodeURIComponent('eneos')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(1)
+      })
+
+      test('前後の空白はトリムされて検索される', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/fuel-logs?keyword=${encodeURIComponent('  ENEOS  ')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(1)
+      })
+
+      test('紐づくツーリングタイトルの部分一致でも検索できる', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/fuel-logs?keyword=${encodeURIComponent('房総')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(1)
+        expect(json.data[0].touringId).toBe(touringId)
+      })
+
+      test('該当データがない場合は空配列を返す', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/fuel-logs?keyword=${encodeURIComponent('存在しないキーワード')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data).toEqual([])
+      })
+
+      test('既存のソート指定と併用できる', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/fuel-logs?keyword=${encodeURIComponent('給油')}&sort-order=asc`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(2)
+        expect(json.data[0].refueledAt).toBe('2024-06-01T10:00:00.000Z')
+        expect(json.data[1].refueledAt).toBe('2024-06-02T10:00:00.000Z')
+      })
+
+      test('空白のみのkeywordはバリデーションエラーとなる', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/fuel-logs?keyword=${encodeURIComponent('   ')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(400)
+        expectValidationError(json)
+      })
+    })
   })
 
   describe('GET /api/v1/user-bike/bike/:myUserBikeId/fuel-insights', () => {
@@ -3073,6 +3209,92 @@ describe('UserBike API Endpoints', () => {
           touring.startDate
         )
         expect(new Date(touring.endDate).toISOString()).toBe(touring.endDate)
+      })
+    })
+
+    describe('キーワード検索機能', () => {
+      beforeEach(async () => {
+        await createTestTouring(token, myUserBikeId, {
+          title: 'Golden Week Ride',
+          startDate: '2024-05-01T00:00:00.000Z',
+          endDate: '2024-05-03T00:00:00.000Z',
+        })
+      })
+
+      test('タイトルの部分一致でツーリングを検索できる', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings?keyword=${encodeURIComponent('春')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(2)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const titles = json.data.map((t: any) => t.title)
+        expect(titles).toEqual(
+          expect.arrayContaining(['早春ツーリング', '春ツーリング'])
+        )
+      })
+
+      test('大文字小文字を区別せず検索できる', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings?keyword=${encodeURIComponent('golden')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(1)
+        expect(json.data[0].title).toBe('Golden Week Ride')
+      })
+
+      test('前後の空白はトリムされて検索される', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings?keyword=${encodeURIComponent('  早春  ')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(1)
+      })
+
+      test('該当データがない場合は空配列を返す', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings?keyword=${encodeURIComponent('存在しないキーワード')}`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data).toEqual([])
+      })
+
+      test('既存のstatusフィルタと併用できる', async () => {
+        const res = await app.request(
+          `/api/v1/user-bike/bike/${myUserBikeId}/tourings?keyword=${encodeURIComponent('ツーリング')}&status=COMPLETED`,
+          {
+            method: 'GET',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        )
+
+        const json = await res.json()
+        expect(res.status).toBe(200)
+        expect(json.data.length).toBe(3)
       })
     })
   })

--- a/apps/web/__tests__/helpers/fuelLogHelper.ts
+++ b/apps/web/__tests__/helpers/fuelLogHelper.ts
@@ -14,6 +14,7 @@ export async function createTestFuelLog(
     totalPrice: number
     memo?: string | null
     updateTotalMileage?: boolean
+    touringId?: string | null
   }
 ): Promise<string> {
   const payload = {

--- a/apps/web/__tests__/unit/services/MaintenanceLogService.test.ts
+++ b/apps/web/__tests__/unit/services/MaintenanceLogService.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import {
+  createMaintenanceLogId,
+  createMyUserBikeId,
+  createUserId,
+} from '@repo/shared-types'
+import { MaintenanceLogEntity } from '@/lib/api/server/entities/MaintenanceLogEntity'
+import { MyUserBikeEntity } from '@/lib/api/server/entities/MyUserBikeEntity'
+import { ApiV1Error } from '@/lib/api/server/errors/ApiV1Error'
+import { IMaintenanceLogRepository } from '@/lib/api/server/interfaces/IMaintenanceLogRepository'
+import { IMyUserBikeRepository } from '@/lib/api/server/interfaces/IMyUserBikeRepository'
+import { MaintenanceLogService } from '@/lib/api/server/services/MaintenanceLogService'
+
+const myUserBikeId = createMyUserBikeId('bike-1')
+const userId = createUserId('user-1')
+
+const buildMaintenanceLog = (index: number) =>
+  new MaintenanceLogEntity({
+    maintenanceLogId: createMaintenanceLogId(`log-${index}`),
+    myUserBikeId,
+    performedAt: new Date(
+      `2020-01-${String((index % 28) + 1).padStart(2, '0')}T00:00:00.000Z`
+    ),
+    mileage: index,
+    memo: null,
+    items: [{ maintenanceType: 'ENGINE_OIL', value: null }],
+  })
+
+describe('MaintenanceLogService', () => {
+  let maintenanceLogRepository: IMaintenanceLogRepository
+  let myUserBikeRepository: IMyUserBikeRepository
+  let service: MaintenanceLogService
+
+  beforeEach(() => {
+    maintenanceLogRepository = {
+      createMaintenanceLog: vi.fn(),
+      findMaintenanceLogById: vi.fn(),
+      findMaintenanceLogs: vi.fn().mockResolvedValue([]),
+      findAllMaintenanceLogs: vi.fn().mockResolvedValue([]),
+      updateMaintenanceLog: vi.fn(),
+      countMaintenanceLogs: vi.fn(),
+    }
+
+    myUserBikeRepository = {
+      createMyUserBike: vi.fn(),
+      findMyUserBikes: vi.fn(),
+      findPublicBikesByUserId: vi.fn(),
+      findMyUserBikeById: vi
+        .fn()
+        .mockResolvedValue({} as unknown as MyUserBikeEntity),
+      updateMyUserBike: vi.fn(),
+      updateTotalMileage: vi.fn(),
+      findMyUserBikeDetail: vi.fn(),
+      countOwnedBikes: vi.fn(),
+      findMyUserBikeTotalMileage: vi.fn(),
+    } as unknown as IMyUserBikeRepository
+
+    service = new MaintenanceLogService(
+      maintenanceLogRepository,
+      myUserBikeRepository
+    )
+  })
+
+  describe('getAllMaintenanceLogs', () => {
+    test('バイクが見つからない場合はNOT_FOUNDを投げる', async () => {
+      vi.mocked(myUserBikeRepository.findMyUserBikeById).mockResolvedValue(null)
+
+      await expect(
+        service.getAllMaintenanceLogs({ myUserBikeId, userId })
+      ).rejects.toThrow(ApiV1Error)
+      expect(
+        maintenanceLogRepository.findAllMaintenanceLogs
+      ).not.toHaveBeenCalled()
+    })
+
+    test('件数によらず単一クエリで全件取得する（ページング分割しない）', async () => {
+      const logs = Array.from({ length: 230 }, (_, i) => buildMaintenanceLog(i))
+      const findAllMaintenanceLogs = vi.mocked(
+        maintenanceLogRepository.findAllMaintenanceLogs
+      )
+      findAllMaintenanceLogs.mockResolvedValue(logs)
+
+      const result = await service.getAllMaintenanceLogs({
+        myUserBikeId,
+        userId,
+      })
+
+      expect(result).toHaveLength(230)
+      expect(findAllMaintenanceLogs).toHaveBeenCalledTimes(1)
+      expect(findAllMaintenanceLogs).toHaveBeenCalledWith(myUserBikeId, 'desc')
+    })
+
+    test('sortOrderを指定した場合はそのまま渡す', async () => {
+      const findAllMaintenanceLogs = vi.mocked(
+        maintenanceLogRepository.findAllMaintenanceLogs
+      )
+
+      await service.getAllMaintenanceLogs({
+        myUserBikeId,
+        userId,
+        sortOrder: 'asc',
+      })
+
+      expect(findAllMaintenanceLogs).toHaveBeenCalledWith(myUserBikeId, 'asc')
+    })
+  })
+})

--- a/apps/web/__tests__/unit/valueObjects/MaintenanceLogSearchParams.test.ts
+++ b/apps/web/__tests__/unit/valueObjects/MaintenanceLogSearchParams.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest'
+import { MaintenanceLogSearchParams } from '@/lib/api/server/valueObjects/MaintenanceLogSearchParams'
+
+describe('MaintenanceLogSearchParams', () => {
+  describe('デフォルト値', () => {
+    test('page未指定時は1ページ目扱いになる（skipが0）', () => {
+      const params = new MaintenanceLogSearchParams({})
+      expect(params.skip).toBe(0)
+    })
+
+    test('pageSize未指定時は20件になる', () => {
+      const params = new MaintenanceLogSearchParams({})
+      expect(params.take).toBe(20)
+    })
+
+    test('sortOrder未指定時はdescになる', () => {
+      const params = new MaintenanceLogSearchParams({})
+      expect(params.sortOrder).toBe('desc')
+    })
+
+    test('keyword未指定時はundefinedになる', () => {
+      const params = new MaintenanceLogSearchParams({})
+      expect(params.keyword).toBeUndefined()
+    })
+  })
+
+  describe('ページネーション', () => {
+    test('page=3, pageSize=10のときskipは20になる', () => {
+      const params = new MaintenanceLogSearchParams({ page: 3, pageSize: 10 })
+      expect(params.skip).toBe(20)
+      expect(params.take).toBe(10)
+    })
+
+    test('page=0以下は1ページ目扱いになる', () => {
+      const params = new MaintenanceLogSearchParams({ page: 0 })
+      expect(params.skip).toBe(0)
+    })
+
+    test('pageSizeが100を超える場合は100に丸められる', () => {
+      const params = new MaintenanceLogSearchParams({ pageSize: 200 })
+      expect(params.take).toBe(100)
+    })
+
+    test('pageSizeが1未満の場合は20に丸められる', () => {
+      const params = new MaintenanceLogSearchParams({ pageSize: 0 })
+      expect(params.take).toBe(20)
+    })
+  })
+
+  describe('keyword', () => {
+    test('指定した値がそのまま保持される', () => {
+      const params = new MaintenanceLogSearchParams({ keyword: 'オイル交換' })
+      expect(params.keyword).toBe('オイル交換')
+    })
+  })
+
+  describe('sortOrder', () => {
+    test('ascを指定できる', () => {
+      const params = new MaintenanceLogSearchParams({ sortOrder: 'asc' })
+      expect(params.sortOrder).toBe('asc')
+    })
+  })
+})

--- a/apps/web/app/api/mcp/route.ts
+++ b/apps/web/app/api/mcp/route.ts
@@ -23,7 +23,6 @@ import { ApiKeyService } from '@/lib/api/server/services/ApiKeyService'
 import { MaintenanceLogService } from '@/lib/api/server/services/MaintenanceLogService'
 import { TouringPlanService } from '@/lib/api/server/services/TouringPlanService'
 import { TouringService } from '@/lib/api/server/services/TouringService'
-import { MaintenanceLogSearchParams } from '@/lib/api/server/valueObjects/MaintenanceLogSearchParams'
 import { TouringSearchParams } from '@/lib/api/server/valueObjects/TouringSearchParams'
 import { UserBikeSearchParams } from '@/lib/api/server/valueObjects/UserBikeSearchParams'
 
@@ -323,21 +322,11 @@ function buildMcpServer(rawUserId: string, scopes: ApiKeyScope[]): McpServer {
               )?.bikeMaintenanceTypes ?? [])
             : []
 
-          const logCount = await maintenanceLogRepo.countMaintenanceLogs(
-            createMyUserBikeId(myUserBikeId)
-          )
-          const logs =
-            logCount > 0
-              ? await maintenanceLogService.getMaintenanceLogs({
-                  myUserBikeId: createMyUserBikeId(myUserBikeId),
-                  userId,
-                  searchParams: new MaintenanceLogSearchParams({
-                    page: 1,
-                    pageSize: logCount,
-                    sortOrder: 'desc',
-                  }),
-                })
-              : []
+          const logs = await maintenanceLogService.getAllMaintenanceLogs({
+            myUserBikeId: createMyUserBikeId(myUserBikeId),
+            userId,
+            sortOrder: 'desc',
+          })
 
           const latestByType: Record<
             string,

--- a/apps/web/app/api/mcp/route.ts
+++ b/apps/web/app/api/mcp/route.ts
@@ -23,6 +23,7 @@ import { ApiKeyService } from '@/lib/api/server/services/ApiKeyService'
 import { MaintenanceLogService } from '@/lib/api/server/services/MaintenanceLogService'
 import { TouringPlanService } from '@/lib/api/server/services/TouringPlanService'
 import { TouringService } from '@/lib/api/server/services/TouringService'
+import { MaintenanceLogSearchParams } from '@/lib/api/server/valueObjects/MaintenanceLogSearchParams'
 import { TouringSearchParams } from '@/lib/api/server/valueObjects/TouringSearchParams'
 import { UserBikeSearchParams } from '@/lib/api/server/valueObjects/UserBikeSearchParams'
 
@@ -330,9 +331,11 @@ function buildMcpServer(rawUserId: string, scopes: ApiKeyScope[]): McpServer {
               ? await maintenanceLogService.getMaintenanceLogs({
                   myUserBikeId: createMyUserBikeId(myUserBikeId),
                   userId,
-                  page: 1,
-                  perSize: logCount,
-                  sortOrder: 'desc',
+                  searchParams: new MaintenanceLogSearchParams({
+                    page: 1,
+                    pageSize: logCount,
+                    sortOrder: 'desc',
+                  }),
                 })
               : []
 

--- a/apps/web/app/app/(protected)/my-bike/[id]/fuel-logs/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/fuel-logs/page.tsx
@@ -32,6 +32,7 @@ function FuelLogsPage() {
   const [chartPeriod, setChartPeriod] = useState<FuelLogPeriod>('latest-year')
   const [isRegisterModalOpen, setIsRegisterModalOpen] = useState(false)
   const [editingFuelLogId, setEditingFuelLogId] = useState<string | null>(null)
+  const [keyword, setKeyword] = useState('')
 
   const chartPeriodOptions: SelectOption[] = [
     { value: 'latest-year', label: '最新の履歴から1年' },
@@ -60,9 +61,10 @@ function FuelLogsPage() {
         bikeId
           ? `/api/v1/user-bike/bike/${bikeId}/fuel-logs?sort-by=refueled-at&sort-order=desc&per-size=10&page=${
               pageIndex + 1
-            }`
+            }${keyword ? `&keyword=${encodeURIComponent(keyword)}` : ''}`
           : null,
-      fetchFuelLogs
+      fetchFuelLogs,
+      { keepPreviousData: true }
     )
 
   const {
@@ -88,7 +90,12 @@ function FuelLogsPage() {
     setSize(size + 1)
   }
 
-  if (isLoading) {
+  const handleSearch = (value: string) => {
+    setKeyword(value)
+    setSize(1)
+  }
+
+  if (isLoading && !data) {
     return (
       <div className="w-full max-w-2xl">
         <div className="flex items-center justify-center min-h-100">
@@ -229,6 +236,8 @@ function FuelLogsPage() {
             onLoadMore={handleLoadMore}
             canLoadMore={canLoadMore}
             isLoadingMore={isLoadingMore}
+            onSearch={handleSearch}
+            isSearchActive={keyword.length > 0}
           />
         </div>
       </div>

--- a/apps/web/app/app/(protected)/my-bike/[id]/maintenance-logs/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/maintenance-logs/page.tsx
@@ -32,6 +32,7 @@ function MaintenanceLogsPage() {
   const [editingLog, setEditingLog] =
     useState<ApiResponseMaintenanceLogDetail | null>(null)
   const [viewMode, setViewMode] = useState<ViewMode>('date')
+  const [keyword, setKeyword] = useState('')
 
   const fetchLogs = async (url: string) => {
     const response = await authenticatedFetch(url, { method: 'GET' })
@@ -52,9 +53,12 @@ function MaintenanceLogsPage() {
     useSWRInfinite(
       (pageIndex: number) =>
         bikeId
-          ? `/api/v1/user-bike/bike/${bikeId}/maintenance-logs?sort-order=desc&per-size=${PER_SIZE}&page=${pageIndex + 1}`
+          ? `/api/v1/user-bike/bike/${bikeId}/maintenance-logs?sort-order=desc&per-size=${PER_SIZE}&page=${pageIndex + 1}${
+              keyword ? `&keyword=${encodeURIComponent(keyword)}` : ''
+            }`
           : null,
-      fetchLogs
+      fetchLogs,
+      { keepPreviousData: true }
     )
 
   // 項目別ビュー用: 全件取得（最大100件）
@@ -77,7 +81,7 @@ function MaintenanceLogsPage() {
     }
   )
 
-  if (isLoading) {
+  if (isLoading && !data) {
     return (
       <div className="w-full max-w-2xl">
         <div className="flex items-center justify-center min-h-100">
@@ -125,6 +129,11 @@ function MaintenanceLogsPage() {
   }
 
   const handleSuccess = () => {
+    setSize(1)
+  }
+
+  const handleSearch = (value: string) => {
+    setKeyword(value)
     setSize(1)
   }
 
@@ -191,6 +200,8 @@ function MaintenanceLogsPage() {
             onLoadMore={() => setSize(size + 1)}
             canLoadMore={canLoadMore}
             isLoadingMore={isLoadingMore}
+            onSearch={handleSearch}
+            isSearchActive={keyword.length > 0}
           />
         ) : isAllLoading ? (
           <div className="flex items-center justify-center p-8">

--- a/apps/web/app/app/(protected)/my-bike/[id]/tourings/page.tsx
+++ b/apps/web/app/app/(protected)/my-bike/[id]/tourings/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useParams, useRouter } from 'next/navigation'
+import { useState } from 'react'
 import useSWR from 'swr'
 import type {
   ApiResponseTouringDetail,
@@ -17,6 +18,7 @@ function TouringsPage() {
   const params = useParams()
   const router = useRouter()
   const bikeId = params.id as string
+  const [keyword, setKeyword] = useState('')
 
   const {
     data: tourings,
@@ -24,7 +26,9 @@ function TouringsPage() {
     isLoading,
   } = useSWR(
     bikeId
-      ? `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=start-date&sort-order=desc`
+      ? `/api/v1/user-bike/bike/${bikeId}/tourings?sort-by=start-date&sort-order=desc${
+          keyword ? `&keyword=${encodeURIComponent(keyword)}` : ''
+        }`
       : null,
     async (url: string) => {
       const response = await authenticatedFetch(url, { method: 'GET' })
@@ -39,7 +43,8 @@ function TouringsPage() {
         ApiResponseTouringDetail[]
       >
       return json.data
-    }
+    },
+    { keepPreviousData: true }
   )
 
   // 表示順: STARTED → COMPLETED (開始日降順)
@@ -60,7 +65,7 @@ function TouringsPage() {
     router.push(`/app/my-bike/${bikeId}/tourings/register?mode=history`)
   }
 
-  if (isLoading) {
+  if (isLoading && !tourings) {
     return (
       <div className="w-full max-w-2xl">
         <div className="flex items-center justify-center min-h-100">
@@ -125,6 +130,8 @@ function TouringsPage() {
           tourings={sortedTourings}
           onDetail={handleDetail}
           onRegister={handleRegisterHistory}
+          onSearch={setKeyword}
+          isSearchActive={keyword.length > 0}
         />
       </div>
     </>

--- a/apps/web/components/common/KeywordSearchBar.module.css
+++ b/apps/web/components/common/KeywordSearchBar.module.css
@@ -1,0 +1,10 @@
+.form {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-3);
+}
+
+.inputWrap {
+  flex: 1;
+}

--- a/apps/web/components/common/KeywordSearchBar.tsx
+++ b/apps/web/components/common/KeywordSearchBar.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { type FormEvent, useState } from 'react'
+import { Button } from '@repo/ui/button'
+import { Input } from '@repo/ui/input'
+import styles from './KeywordSearchBar.module.css'
+
+export interface KeywordSearchBarProps {
+  /**
+   * 入力欄のプレースホルダー
+   */
+  placeholder: string
+  /**
+   * 検索確定時（送信・クリア）のコールバック。
+   * 空文字の場合は検索条件なしとして扱う。
+   */
+  onSearch: (keyword: string) => void
+  /**
+   * ルートフォームに付与するdata-testid
+   */
+  testId?: string
+}
+
+/**
+ * 一覧画面共通のキーワード検索フォーム
+ *
+ * @remarks
+ * 入力中は検索を発火せず、送信（ボタンクリック・Enter）で確定する。
+ * 確定済みキーワードがある場合はクリアボタンを表示する。
+ */
+export const KeywordSearchBar = ({
+  placeholder,
+  onSearch,
+  testId,
+}: KeywordSearchBarProps) => {
+  const [inputValue, setInputValue] = useState('')
+  const [appliedKeyword, setAppliedKeyword] = useState('')
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault()
+    const trimmed = inputValue.trim()
+    setAppliedKeyword(trimmed)
+    onSearch(trimmed)
+  }
+
+  const handleClear = () => {
+    setInputValue('')
+    setAppliedKeyword('')
+    onSearch('')
+  }
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit} data-testid={testId}>
+      <div className={styles.inputWrap}>
+        <Input
+          type="text"
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+          placeholder={placeholder}
+        />
+      </div>
+      <Button type="submit" variant="cloud">
+        検索
+      </Button>
+      {appliedKeyword && (
+        <Button type="button" variant="cloud" onClick={handleClear}>
+          クリア
+        </Button>
+      )}
+    </form>
+  )
+}

--- a/apps/web/components/fuel-log/FuelLogListSection.tsx
+++ b/apps/web/components/fuel-log/FuelLogListSection.tsx
@@ -5,6 +5,7 @@ import { BaseCard } from '@repo/ui/baseCard'
 import { Button } from '@repo/ui/button'
 import { FuelLogItem } from './FuelLogItem'
 import styles from './FuelLogListSection.module.css'
+import { KeywordSearchBar } from '@/components/common/KeywordSearchBar'
 
 export interface FuelLogListSectionProps {
   /**
@@ -36,6 +37,16 @@ export interface FuelLogListSectionProps {
    * 追加読み込み中かどうか
    */
   isLoadingMore?: boolean
+
+  /**
+   * キーワード検索確定時のコールバック
+   */
+  onSearch: (keyword: string) => void
+
+  /**
+   * キーワード検索が適用中かどうか
+   */
+  isSearchActive: boolean
 }
 
 export const FuelLogListSection = ({
@@ -45,15 +56,28 @@ export const FuelLogListSection = ({
   onLoadMore,
   canLoadMore = false,
   isLoadingMore = false,
+  onSearch,
+  isSearchActive,
 }: FuelLogListSectionProps) => {
   return (
     <BaseCard title="給油履歴">
+      <KeywordSearchBar
+        placeholder="メモ・ツーリング名で検索"
+        onSearch={onSearch}
+        testId="fuel-log-search"
+      />
       {fuelLogs.length === 0 ? (
         <div className={styles.emptyState}>
-          <p>給油履歴がまだありません</p>
-          <Button onClick={onRegister} variant="primary">
-            最初の給油履歴を登録
-          </Button>
+          {isSearchActive ? (
+            <p>該当する給油履歴が見つかりませんでした</p>
+          ) : (
+            <>
+              <p>給油履歴がまだありません</p>
+              <Button onClick={onRegister} variant="primary">
+                最初の給油履歴を登録
+              </Button>
+            </>
+          )}
         </div>
       ) : (
         <div className={styles.listContainer}>

--- a/apps/web/components/maintenance-log/MaintenanceLogListSection.tsx
+++ b/apps/web/components/maintenance-log/MaintenanceLogListSection.tsx
@@ -5,6 +5,7 @@ import { BaseCard } from '@repo/ui/baseCard'
 import { Button } from '@repo/ui/button'
 import { MaintenanceLogItem } from './MaintenanceLogItem'
 import styles from './MaintenanceLogListSection.module.css'
+import { KeywordSearchBar } from '@/components/common/KeywordSearchBar'
 
 type MaintenanceLogListSectionProps = {
   logs: ApiResponseMaintenanceLogDetail[]
@@ -13,6 +14,8 @@ type MaintenanceLogListSectionProps = {
   onLoadMore?: () => void
   canLoadMore?: boolean
   isLoadingMore?: boolean
+  onSearch: (keyword: string) => void
+  isSearchActive: boolean
 }
 
 export const MaintenanceLogListSection = ({
@@ -22,15 +25,28 @@ export const MaintenanceLogListSection = ({
   onLoadMore,
   canLoadMore = false,
   isLoadingMore = false,
+  onSearch,
+  isSearchActive,
 }: MaintenanceLogListSectionProps) => {
   return (
     <BaseCard title="メンテナンス履歴">
+      <KeywordSearchBar
+        placeholder="メモで検索"
+        onSearch={onSearch}
+        testId="maintenance-log-search"
+      />
       {logs.length === 0 ? (
         <div className={styles.emptyState}>
-          <p>メンテナンス履歴がまだありません</p>
-          <Button onClick={onRegister} variant="primary">
-            最初のメンテナンスを登録
-          </Button>
+          {isSearchActive ? (
+            <p>該当するメンテナンス履歴が見つかりませんでした</p>
+          ) : (
+            <>
+              <p>メンテナンス履歴がまだありません</p>
+              <Button onClick={onRegister} variant="primary">
+                最初のメンテナンスを登録
+              </Button>
+            </>
+          )}
         </div>
       ) : (
         <div className={styles.listContainer}>

--- a/apps/web/components/touring/TouringListSection.tsx
+++ b/apps/web/components/touring/TouringListSection.tsx
@@ -5,26 +5,42 @@ import { BaseCard } from '@repo/ui/baseCard'
 import { Button } from '@repo/ui/button'
 import { TouringListItem } from './TouringListItem'
 import styles from './TouringListSection.module.css'
+import { KeywordSearchBar } from '@/components/common/KeywordSearchBar'
 
 export interface TouringListSectionProps {
   tourings: ApiResponseTouringDetail[]
   onDetail?: (touringId: string) => void
   onRegister: () => void
+  onSearch: (keyword: string) => void
+  isSearchActive: boolean
 }
 
 export const TouringListSection = ({
   tourings,
   onDetail,
   onRegister,
+  onSearch,
+  isSearchActive,
 }: TouringListSectionProps) => {
   return (
     <BaseCard title="ツーリング">
+      <KeywordSearchBar
+        placeholder="タイトルで検索"
+        onSearch={onSearch}
+        testId="touring-search"
+      />
       {tourings.length === 0 ? (
         <div className={styles.emptyState}>
-          <p>ツーリングの記録がまだありません</p>
-          <Button onClick={onRegister} variant="primary">
-            最初のツーリングを登録
-          </Button>
+          {isSearchActive ? (
+            <p>該当するツーリングが見つかりませんでした</p>
+          ) : (
+            <>
+              <p>ツーリングの記録がまだありません</p>
+              <Button onClick={onRegister} variant="primary">
+                最初のツーリングを登録
+              </Button>
+            </>
+          )}
         </div>
       ) : (
         <div className={styles.listContainer}>

--- a/apps/web/lib/api/server/interfaces/IMaintenanceLogRepository.ts
+++ b/apps/web/lib/api/server/interfaces/IMaintenanceLogRepository.ts
@@ -1,12 +1,6 @@
 import { MaintenanceLogId, MyUserBikeId } from '@repo/shared-types'
 import { MaintenanceLogEntity } from '../entities/MaintenanceLogEntity'
-
-export type MaintenanceLogListParams = {
-  myUserBikeId: MyUserBikeId
-  page: number
-  perSize: number
-  sortOrder: 'asc' | 'desc'
-}
+import { MaintenanceLogSearchParams } from '../valueObjects/MaintenanceLogSearchParams'
 
 export interface IMaintenanceLogRepository {
   createMaintenanceLog(
@@ -17,7 +11,8 @@ export interface IMaintenanceLogRepository {
     myUserBikeId: MyUserBikeId
   ): Promise<MaintenanceLogEntity | null>
   findMaintenanceLogs(
-    params: MaintenanceLogListParams
+    myUserBikeId: MyUserBikeId,
+    searchParams: MaintenanceLogSearchParams
   ): Promise<MaintenanceLogEntity[]>
   updateMaintenanceLog(
     maintenanceLog: MaintenanceLogEntity

--- a/apps/web/lib/api/server/interfaces/IMaintenanceLogRepository.ts
+++ b/apps/web/lib/api/server/interfaces/IMaintenanceLogRepository.ts
@@ -14,6 +14,10 @@ export interface IMaintenanceLogRepository {
     myUserBikeId: MyUserBikeId,
     searchParams: MaintenanceLogSearchParams
   ): Promise<MaintenanceLogEntity[]>
+  findAllMaintenanceLogs(
+    myUserBikeId: MyUserBikeId,
+    sortOrder: 'asc' | 'desc'
+  ): Promise<MaintenanceLogEntity[]>
   updateMaintenanceLog(
     maintenanceLog: MaintenanceLogEntity
   ): Promise<MaintenanceLogEntity>

--- a/apps/web/lib/api/server/repositories/PrismaFuelLogRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaFuelLogRepository.ts
@@ -167,6 +167,23 @@ export class PrismaFuelLogRepository
               refueledAt: dateRangeCondition,
             }
           : {}),
+        ...(searchParams.keyword
+          ? {
+              OR: [
+                {
+                  memo: { contains: searchParams.keyword, mode: 'insensitive' },
+                },
+                {
+                  touring: {
+                    title: {
+                      contains: searchParams.keyword,
+                      mode: 'insensitive',
+                    },
+                  },
+                },
+              ],
+            }
+          : {}),
       },
       select: {
         id: true,

--- a/apps/web/lib/api/server/repositories/PrismaMaintenanceLogRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaMaintenanceLogRepository.ts
@@ -142,6 +142,31 @@ export class PrismaMaintenanceLogRepository
     return logs.map(mapToEntity)
   }
 
+  async findAllMaintenanceLogs(
+    myUserBikeId: MyUserBikeId,
+    sortOrder: 'asc' | 'desc'
+  ): Promise<MaintenanceLogEntity[]> {
+    const logs = await this.connection.tUserMyBikeMaintenance.findMany({
+      where: { userMyBikeId: myUserBikeId },
+      orderBy: { performedAt: sortOrder },
+      select: {
+        id: true,
+        userMyBikeId: true,
+        performedAt: true,
+        mileage: true,
+        memo: true,
+        maintenanceItems: {
+          select: {
+            type: true,
+            value: true,
+          },
+        },
+      },
+    })
+
+    return logs.map(mapToEntity)
+  }
+
   async countMaintenanceLogs(myUserBikeId: MyUserBikeId): Promise<number> {
     return this.connection.tUserMyBikeMaintenance.count({
       where: { userMyBikeId: myUserBikeId },

--- a/apps/web/lib/api/server/repositories/PrismaMaintenanceLogRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaMaintenanceLogRepository.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@repo/database'
 import {
   createMaintenanceLogId,
   createMyUserBikeId,
@@ -6,10 +7,8 @@ import {
   MyUserBikeId,
 } from '@repo/shared-types'
 import { MaintenanceLogEntity } from '../entities/MaintenanceLogEntity'
-import {
-  IMaintenanceLogRepository,
-  MaintenanceLogListParams,
-} from '../interfaces/IMaintenanceLogRepository'
+import { IMaintenanceLogRepository } from '../interfaces/IMaintenanceLogRepository'
+import { MaintenanceLogSearchParams } from '../valueObjects/MaintenanceLogSearchParams'
 import { PrismaRepositoryBase } from './PrismaRepositoryBase'
 
 type MaintenanceLogRow = {
@@ -109,14 +108,22 @@ export class PrismaMaintenanceLogRepository
   }
 
   async findMaintenanceLogs(
-    params: MaintenanceLogListParams
+    myUserBikeId: MyUserBikeId,
+    searchParams: MaintenanceLogSearchParams
   ): Promise<MaintenanceLogEntity[]> {
-    const { myUserBikeId, page, perSize, sortOrder } = params
+    const where: Prisma.TUserMyBikeMaintenanceWhereInput = {
+      userMyBikeId: myUserBikeId,
+    }
+
+    if (searchParams.keyword) {
+      where.memo = { contains: searchParams.keyword, mode: 'insensitive' }
+    }
+
     const logs = await this.connection.tUserMyBikeMaintenance.findMany({
-      where: { userMyBikeId: myUserBikeId },
-      orderBy: { performedAt: sortOrder },
-      skip: (page - 1) * perSize,
-      take: perSize,
+      where,
+      orderBy: { performedAt: searchParams.sortOrder },
+      skip: searchParams.skip,
+      take: searchParams.take,
       select: {
         id: true,
         userMyBikeId: true,

--- a/apps/web/lib/api/server/repositories/PrismaTouringRepository.ts
+++ b/apps/web/lib/api/server/repositories/PrismaTouringRepository.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@repo/database'
 import {
   createMyUserBikeId,
   createTouringId,
@@ -126,13 +127,20 @@ export class PrismaTouringRepository
             { startDate: searchParams.sortOrder },
           ]
 
+    const where: Prisma.TUserMyBikeTouringWhereInput = {
+      userMyBikeId: myUserBikeId,
+    }
+
+    if (searchParams.status !== undefined) {
+      where.status = searchParams.status
+    }
+
+    if (searchParams.keyword) {
+      where.title = { contains: searchParams.keyword, mode: 'insensitive' }
+    }
+
     const tourings = await this.connection.tUserMyBikeTouring.findMany({
-      where: {
-        userMyBikeId: myUserBikeId,
-        ...(searchParams.status !== undefined
-          ? { status: searchParams.status }
-          : {}),
-      },
+      where,
       select: touringSelect,
       orderBy,
     })

--- a/apps/web/lib/api/server/services/MaintenanceLogService.ts
+++ b/apps/web/lib/api/server/services/MaintenanceLogService.ts
@@ -18,6 +18,12 @@ type GetMaintenanceLogsParams = {
   searchParams: MaintenanceLogSearchParams
 }
 
+type GetAllMaintenanceLogsParams = {
+  myUserBikeId: MyUserBikeId
+  userId: UserId
+  sortOrder?: 'asc' | 'desc'
+}
+
 type RegisterMaintenanceLogParams = {
   myUserBikeId: MyUserBikeId
   user: UserEntity
@@ -60,6 +66,31 @@ export class MaintenanceLogService {
     return this.maintenanceLogRepository.findMaintenanceLogs(
       params.myUserBikeId,
       params.searchParams
+    )
+  }
+
+  /**
+   * ページングで打ち切らず全件のメンテナンス履歴を取得する。
+   * @remarks
+   * MaintenanceLogSearchParams経由のfindMaintenanceLogsはpageSizeが
+   * 一覧APIの負荷対策として100件に丸められるため、全履歴を必要とする
+   * 集計処理では専用のfindAllMaintenanceLogs（単一クエリ）を使う。
+   */
+  public async getAllMaintenanceLogs(
+    params: GetAllMaintenanceLogsParams
+  ): Promise<MaintenanceLogEntity[]> {
+    const myUserBike = await this.myUserBikeRepository.findMyUserBikeById(
+      params.myUserBikeId,
+      params.userId
+    )
+
+    if (!myUserBike) {
+      throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
+    }
+
+    return this.maintenanceLogRepository.findAllMaintenanceLogs(
+      params.myUserBikeId,
+      params.sortOrder ?? 'desc'
     )
   }
 

--- a/apps/web/lib/api/server/services/MaintenanceLogService.ts
+++ b/apps/web/lib/api/server/services/MaintenanceLogService.ts
@@ -10,13 +10,12 @@ import { UserEntity } from '../entities/UserEntity'
 import { ApiV1Error } from '../errors/ApiV1Error'
 import { IMaintenanceLogRepository } from '../interfaces/IMaintenanceLogRepository'
 import { IMyUserBikeRepository } from '../interfaces/IMyUserBikeRepository'
+import { MaintenanceLogSearchParams } from '../valueObjects/MaintenanceLogSearchParams'
 
 type GetMaintenanceLogsParams = {
   myUserBikeId: MyUserBikeId
   userId: UserId
-  page: number
-  perSize: number
-  sortOrder: 'asc' | 'desc'
+  searchParams: MaintenanceLogSearchParams
 }
 
 type RegisterMaintenanceLogParams = {
@@ -58,12 +57,10 @@ export class MaintenanceLogService {
       throw new ApiV1Error('NOT_FOUND', '指定されたバイクが見つかりません')
     }
 
-    return this.maintenanceLogRepository.findMaintenanceLogs({
-      myUserBikeId: params.myUserBikeId,
-      page: params.page,
-      perSize: params.perSize,
-      sortOrder: params.sortOrder,
-    })
+    return this.maintenanceLogRepository.findMaintenanceLogs(
+      params.myUserBikeId,
+      params.searchParams
+    )
   }
 
   public async registerMaintenanceLog(

--- a/apps/web/lib/api/server/v1/userBike/fuelLogs.ts
+++ b/apps/web/lib/api/server/v1/userBike/fuelLogs.ts
@@ -45,6 +45,7 @@ userBikeFuelLogs.get(
       period: query.period,
       startDate: query.startDate,
       endDate: query.endDate,
+      keyword: query.keyword,
     })
 
     const fuelLogRepo = new PrismaFuelLogRepository(prisma)

--- a/apps/web/lib/api/server/v1/userBike/maintenanceLogs.ts
+++ b/apps/web/lib/api/server/v1/userBike/maintenanceLogs.ts
@@ -18,6 +18,7 @@ import {
 import { PrismaMaintenanceLogRepository } from '../../repositories/PrismaMaintenanceLogRepository'
 import { PrismaMyUserBikeRepository } from '../../repositories/PrismaMyUserBikeRepository'
 import { MaintenanceLogService } from '../../services/MaintenanceLogService'
+import { MaintenanceLogSearchParams } from '../../valueObjects/MaintenanceLogSearchParams'
 
 const userBikeMaintenanceLogs = new Hono().basePath(
   '/bike/:myUserBikeId/maintenance-logs'
@@ -39,12 +40,17 @@ userBikeMaintenanceLogs.get(
       myUserBikeRepo
     )
 
+    const searchParams = new MaintenanceLogSearchParams({
+      page: query.page,
+      pageSize: query['per-size'],
+      sortOrder: query['sort-order'],
+      keyword: query.keyword,
+    })
+
     const logs = await service.getMaintenanceLogs({
       myUserBikeId: createMyUserBikeId(myUserBikeId),
       userId: userEntity.id,
-      page: query.page ?? 1,
-      perSize: query['per-size'] ?? 20,
-      sortOrder: query['sort-order'] ?? 'desc',
+      searchParams,
     })
 
     return c.json<SuccessResponse<ApiResponseMaintenanceLogList>>(

--- a/apps/web/lib/api/server/v1/userBike/tourings.ts
+++ b/apps/web/lib/api/server/v1/userBike/tourings.ts
@@ -50,6 +50,7 @@ userBikeTourings.get(
       sortBy: query['sort-by'] === 'end-date' ? 'endDate' : 'startDate',
       sortOrder: query['sort-order'],
       status: query['status'],
+      keyword: query['keyword'],
     })
 
     const touringRepo = new PrismaTouringRepository(prisma)

--- a/apps/web/lib/api/server/valueObjects/FuelLogSearchParams.ts
+++ b/apps/web/lib/api/server/valueObjects/FuelLogSearchParams.ts
@@ -11,6 +11,7 @@ export class FuelLogSearchParams {
   private readonly _period?: FuelLogPeriod
   private readonly _startDate?: Date
   private readonly _endDate?: Date
+  private readonly _keyword?: string
 
   constructor(params: {
     page?: number
@@ -20,6 +21,7 @@ export class FuelLogSearchParams {
     period?: FuelLogPeriod
     startDate?: Date
     endDate?: Date
+    keyword?: string
   }) {
     this._page = params.page && params.page > 0 ? params.page : 1
     this._pageSize = this.validatePageSize(params.pageSize)
@@ -28,6 +30,7 @@ export class FuelLogSearchParams {
     this._period = params.period
     this._startDate = params.startDate
     this._endDate = params.endDate
+    this._keyword = params.keyword
   }
 
   private validatePageSize(size?: number): number {
@@ -70,6 +73,10 @@ export class FuelLogSearchParams {
 
   get endDate(): Date | undefined {
     return this._endDate
+  }
+
+  get keyword(): string | undefined {
+    return this._keyword
   }
 
   get isDateRangeMode(): boolean {

--- a/apps/web/lib/api/server/valueObjects/MaintenanceLogSearchParams.ts
+++ b/apps/web/lib/api/server/valueObjects/MaintenanceLogSearchParams.ts
@@ -1,0 +1,43 @@
+/**
+ * メンテナンス履歴検索パラメータを表すバリューオブジェクト
+ */
+export class MaintenanceLogSearchParams {
+  private readonly _page: number
+  private readonly _pageSize: number
+  private readonly _sortOrder: 'asc' | 'desc'
+  private readonly _keyword?: string
+
+  constructor(params: {
+    page?: number
+    pageSize?: number
+    sortOrder?: 'asc' | 'desc'
+    keyword?: string
+  }) {
+    this._page = params.page && params.page > 0 ? params.page : 1
+    this._pageSize = this.validatePageSize(params.pageSize)
+    this._sortOrder = params.sortOrder || 'desc'
+    this._keyword = params.keyword
+  }
+
+  private validatePageSize(size?: number): number {
+    if (!size || size < 1) return 20
+    if (size > 100) return 100
+    return size
+  }
+
+  get sortOrder(): 'asc' | 'desc' {
+    return this._sortOrder
+  }
+
+  get keyword(): string | undefined {
+    return this._keyword
+  }
+
+  get skip(): number {
+    return (this._page - 1) * this._pageSize
+  }
+
+  get take(): number {
+    return this._pageSize
+  }
+}

--- a/apps/web/lib/api/server/valueObjects/TouringSearchParams.ts
+++ b/apps/web/lib/api/server/valueObjects/TouringSearchParams.ts
@@ -7,15 +7,18 @@ export class TouringSearchParams {
   private readonly _sortBy: 'startDate' | 'endDate'
   private readonly _sortOrder: 'asc' | 'desc'
   private readonly _status: TouringStatus | undefined
+  private readonly _keyword: string | undefined
 
   constructor(params: {
     sortBy?: 'startDate' | 'endDate'
     sortOrder?: 'asc' | 'desc'
     status?: TouringStatus
+    keyword?: string
   }) {
     this._sortBy = params.sortBy || 'startDate'
     this._sortOrder = params.sortOrder || 'desc'
     this._status = params.status
+    this._keyword = params.keyword
   }
 
   get sortBy(): 'startDate' | 'endDate' {
@@ -28,5 +31,9 @@ export class TouringSearchParams {
 
   get status(): TouringStatus | undefined {
     return this._status
+  }
+
+  get keyword(): string | undefined {
+    return this._keyword
   }
 }

--- a/packages/shared-types/src/schemas/fuelLogSchema.ts
+++ b/packages/shared-types/src/schemas/fuelLogSchema.ts
@@ -91,6 +91,13 @@ export const FuelLogListQuerySchema = z
         invalid_type_error: '終了日は日付形式で指定してください',
       })
       .optional(),
+    keyword: z
+      .string({
+        invalid_type_error: 'キーワードは文字列で指定してください',
+      })
+      .trim()
+      .min(1, 'キーワードは1文字以上で指定してください')
+      .optional(),
   })
   // 排他制御: period と startDate/endDate の両方指定を禁止
   .refine(

--- a/packages/shared-types/src/schemas/maintenanceLogSchema.ts
+++ b/packages/shared-types/src/schemas/maintenanceLogSchema.ts
@@ -103,6 +103,13 @@ export const MaintenanceLogListQuerySchema = z.object({
   page: z.coerce.number().int().min(1).default(1).optional(),
   'per-size': z.coerce.number().int().min(1).max(100).default(20).optional(),
   'sort-order': z.enum(['asc', 'desc']).default('desc').optional(),
+  keyword: z
+    .string({
+      invalid_type_error: 'キーワードは文字列で指定してください',
+    })
+    .trim()
+    .min(1, 'キーワードは1文字以上で指定してください')
+    .optional(),
 })
 
 export type MaintenanceLogListQuery = z.infer<

--- a/packages/shared-types/src/schemas/touringSchema.ts
+++ b/packages/shared-types/src/schemas/touringSchema.ts
@@ -290,6 +290,13 @@ export const TouringListQuerySchema = z.object({
   'sort-by': z.enum(['start-date', 'end-date']).optional(),
   'sort-order': z.enum(['asc', 'desc']).default('desc').optional(),
   status: z.enum(['STARTED', 'COMPLETED']).optional(),
+  keyword: z
+    .string({
+      invalid_type_error: 'キーワードは文字列で指定してください',
+    })
+    .trim()
+    .min(1, 'キーワードは1文字以上で指定してください')
+    .optional(),
 })
 
 export type TouringListQuery = z.infer<typeof TouringListQuerySchema>


### PR DESCRIPTION
## 概要
API層に既存一覧取得エンドポイントへのoptionalなkeywordクエリパラメータ追加と、対応するUIの検索フォームを実装しました。既存クライアントへの破壊的変更はありません。

## 変更内容

### API - キーワード検索パラメータの追加
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `packages/shared-types/.../touringSchema.ts` | 修正 | `TouringListQuerySchema`にkeyword追加 |
| `packages/shared-types/.../fuelLogSchema.ts` | 修正 | `FuelLogListQuerySchema`にkeyword追加 |
| `packages/shared-types/.../maintenanceLogSchema.ts` | 修正 | `MaintenanceLogListQuerySchema`にkeyword追加 |
| `apps/web/.../valueObjects/TouringSearchParams.ts` | 修正 | keywordフィールド追加 |
| `apps/web/.../valueObjects/FuelLogSearchParams.ts` | 修正 | keywordフィールド追加 |
| `apps/web/.../valueObjects/MaintenanceLogSearchParams.ts` | 追加 | 新規VO作成（他2リソースとパターン統一） |
| `apps/web/.../interfaces/IMaintenanceLogRepository.ts` | 修正 | `findMaintenanceLogs`のシグネチャをSearchParamsベースに変更 |
| `apps/web/.../repositories/PrismaTouringRepository.ts` | 修正 | `title`へのcontains検索（大文字小文字区別なし） |
| `apps/web/.../repositories/PrismaFuelLogRepository.ts` | 修正 | `memo` OR 紐づく`touring.title`へのcontains検索 |
| `apps/web/.../repositories/PrismaMaintenanceLogRepository.ts` | 修正 | `memo`へのcontains検索 |
| `apps/web/.../services/MaintenanceLogService.ts` | 修正 | SearchParams対応に追随 |
| `apps/web/.../v1/userBike/tourings.ts` | 修正 | keywordクエリマッピング |
| `apps/web/.../v1/userBike/fuelLogs.ts` | 修正 | keywordクエリマッピング |
| `apps/web/.../v1/userBike/maintenanceLogs.ts` | 修正 | keywordクエリマッピング・SearchParams化 |
| `apps/web/app/api/mcp/route.ts` | 修正 | MaintenanceLogService呼び出し変更に追随修正 |

### UI - 検索フォームの追加
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `apps/web/components/common/KeywordSearchBar.tsx` | 追加 | 一覧画面共通のキーワード検索フォームコンポーネント |
| `apps/web/components/common/KeywordSearchBar.module.css` | 追加 | スタイル |
| `apps/web/components/touring/TouringListSection.tsx` | 修正 | 検索欄・該当なし空状態の出し分けを追加 |
| `apps/web/components/fuel-log/FuelLogListSection.tsx` | 修正 | 同上 |
| `apps/web/components/maintenance-log/MaintenanceLogListSection.tsx` | 修正 | 同上（日付順ビューのみ、項目別ビューは対象外） |
| `apps/web/app/.../tourings/page.tsx` | 修正 | SWRキーにkeyword組み込み。`keepPreviousData`で検索時の全画面ローディング化を防止 |
| `apps/web/app/.../fuel-logs/page.tsx` | 修正 | 同上（useSWRInfinite、検索時はpage 1にリセット） |
| `apps/web/app/.../maintenance-logs/page.tsx` | 修正 | 同上（useSWRInfinite、検索時はpage 1にリセット） |

### テスト
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `apps/web/__tests__/api/v1/userBike.test.ts` | 修正 | ツーリング/給油履歴のキーワード検索テスト追加 |
| `apps/web/__tests__/api/v1/maintenanceLog.test.ts` | 修正 | GET一覧の基本テスト（未実装だった）とキーワード検索テストを追加 |
| `apps/web/__tests__/unit/valueObjects/MaintenanceLogSearchParams.test.ts` | 追加 | VO単体テスト |
| `apps/web/__tests__/helpers/fuelLogHelper.ts` | 修正 | テストヘルパーにtouringId対応追加 |
| `apps/e2e/pages/touringListPage.ts` | 追加 | ツーリング一覧POM |
| `apps/e2e/pages/fuelLogListPage.ts` | 追加 | 給油履歴一覧POM |
| `apps/e2e/pages/maintenanceLogListPage.ts` | 追加 | メンテナンス履歴一覧POM |
| `apps/e2e/helpers/maintenanceLogHelper.ts` | 追加 | メンテナンス履歴API登録ヘルパー |
| `apps/e2e/tests/touring/touringSearch.spec.ts` | 追加 | キーワード検索E2Eテスト |
| `apps/e2e/tests/fuel-log/fuelLogSearch.spec.ts` | 追加 | 同上 |
| `apps/e2e/tests/maintenance-log/maintenanceLogSearch.spec.ts` | 追加 | 同上 |

## 影響範囲
- ツーリング一覧・給油履歴一覧・メンテナンス履歴一覧の各API・各一覧画面
- `apps/mobile`等の既存クライアント: keywordはoptionalのため後方互換（影響なし）
- 対象3画面は元々E2E POM/テストが存在しなかったため、新規追加のみで既存E2Eテストへの影響はなし

## テストプラン
- [x] `pnpm lint` / `pnpm format` / `NODE_ENV=production pnpm build` がパスすること
- [x] `apps/web` の単体・統合テストが全てパスすること（540件）
- [x] `apps/e2e` の全テストがパスすること（新規9件含む、既存の無関係な1件を除き67件成功）
- [x] ブラウザ実機で3画面それぞれキーワード検索・該当なし表示・クリアボタンの動作を確認

Closes #493