### PR TITLE
[Bug] search・notifications・ユーザー公開ページのパンくずラベルを修正

### DIFF
--- a/apps/web/components/Navigation/BreadcrumbNav.tsx
+++ b/apps/web/components/Navigation/BreadcrumbNav.tsx
@@ -116,6 +116,21 @@ function buildBreadcrumbs(pathname: string): BreadcrumbItem[] {
     return items
   }
 
+  if (segments[1] === 'search') {
+    items.push({ label: 'ユーザーを探す' })
+    return items
+  }
+
+  if (segments[1] === 'notifications') {
+    items.push({ label: '通知' })
+    return items
+  }
+
+  if (segments[1] === 'users') {
+    items.push({ label: 'ユーザープロフィール' })
+    return items
+  }
+
   return [{ label: 'ページ' }]
 }
 


### PR DESCRIPTION
## 概要
`/app/search`、`/app/notifications`、`/app/users/[userId]` の3画面でパンくずナビゲーションが各画面固有のラベルではなく汎用フォールバックの「ページ」と表示される不具合を修正した。

## 変更内容

### パンくずナビゲーション
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `apps/web/components/Navigation/BreadcrumbNav.tsx` | 修正 | `buildBreadcrumbs()` に `search`(「ユーザーを探す」)・`notifications`(「通知」)・`users/[userId]`(「ユーザープロフィール」)のパス分岐を追加 |

## 影響範囲
- `apps/web/components/Navigation/BreadcrumbNav.tsx`
- `/app/search`、`/app/notifications`、`/app/users/[userId]` のパンくず表示

## テストプラン
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `NODE_ENV=production pnpm build`
- [x] Playwrightで実機を操作し、3画面すべてでパンくずが正しいラベルで表示されることを確認

Closes #500