### PR TITLE
🐛 バイク1台時のグリッド固定2カラムによる名称折り返しを修正

### DIFF
--- a/apps/web/components/MyBikeListSection.module.css
+++ b/apps/web/components/MyBikeListSection.module.css
@@ -18,7 +18,7 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(calc(50% - var(--spacing-4) / 2), 1fr));
   gap: var(--spacing-4);
   width: 100%;
 }

--- a/apps/web/components/NavigationCard.module.css
+++ b/apps/web/components/NavigationCard.module.css
@@ -54,6 +54,7 @@
   color: var(--color-ink);
   line-height: var(--line-height-tight);
   margin: 0;
+  overflow-wrap: break-word;
 }
 
 .description {

--- a/apps/web/components/QuickFuelSection.module.css
+++ b/apps/web/components/QuickFuelSection.module.css
@@ -30,7 +30,7 @@
 /* バイクカードグリッドレイアウト */
 .bikeGrid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(calc(50% - var(--spacing-3) / 2), 1fr));
   gap: var(--spacing-3);
   width: 100%;
 }

--- a/apps/web/components/TouringStartEndSection.module.css
+++ b/apps/web/components/TouringStartEndSection.module.css
@@ -105,7 +105,7 @@
 /* バイク選択グリッド（小さめ） */
 .bikeSelectionGrid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(calc(50% - var(--spacing-3) / 2), 1fr));
   gap: var(--spacing-3);
   width: 100%;
 }

--- a/packages/ui/src/BaseCard/baseCard.module.css
+++ b/packages/ui/src/BaseCard/baseCard.module.css
@@ -62,6 +62,7 @@
 }
 
 .noBorder {
+  max-width: none;
   border: none;
   box-shadow: none;
 }


### PR DESCRIPTION
## 概要
バイクを1台しか登録していないユーザーの場合、マイバイク一覧・ホーム画面のバイク選択グリッドが2カラム固定のため、カードが半分幅に圧縮されバイク名が不自然に折り返す不具合を修正した。あわせて、ホーム画面のヒストリーセクションが共有コンポーネントのmax-width制約により他セクションより幅が狭く表示される問題も修正した。

## 変更内容

### バイク選択グリッドの1件時レイアウト崩れ修正
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `apps/web/components/MyBikeListSection.module.css` | 修正 | `.grid` を `repeat(2, 1fr)` から `repeat(auto-fit, minmax(calc(50% - gap/2), 1fr))` に変更 |
| `apps/web/components/TouringStartEndSection.module.css` | 修正 | `.bikeSelectionGrid` に同様の変更を適用 |
| `apps/web/components/QuickFuelSection.module.css` | 修正 | `.bikeGrid` に同様の変更を適用 |
| `apps/web/components/NavigationCard.module.css` | 修正 | `.title` に `overflow-wrap: break-word` を防御的に追加 |

### その他の修正
| ファイル | 変更種別 | 内容 |
| --- | --- | --- |
| `packages/ui/src/BaseCard/baseCard.module.css` | 修正 | `.noBorder` に `max-width: none` を追加し、RecentHistorySectionがホーム画面の他セクションと同じ幅で表示されるよう修正(標準のBaseCard利用箇所には影響なし) |

## 影響範囲
- `/app/my-bike`(マイバイク一覧)— `MyBikeListSection`
- `/app/home`(ホーム)— `TouringStartEndSection`, `QuickFuelSection`, `RecentHistorySection`
- `packages/ui` の `BaseCard` を利用する全画面(ログイン画面等)への影響なし(`.noBorder` は `RecentHistorySection` でのみ使用)

## テストプラン
- [x] `pnpm lint`
- [x] `pnpm format`
- [x] `NODE_ENV=production pnpm build`
- [x] Playwrightによるグリッドレイアウトの実挙動検証(1件→フル幅、2件→2カラム、3件→2カラム+折返し)
- [x] 関連E2E(`myBike` / `touringMode` / `login` / `history`)13件実行、全てパス
- [x] バイク登録数が1台のユーザーで `/app/my-bike` および `/app/home` を実機表示し、カード内の名称が折り返さないことを確認

Closes #499